### PR TITLE
Fix a typo in the hello-world example post

### DIFF
--- a/lib/cli/init.js
+++ b/lib/cli/init.js
@@ -121,7 +121,7 @@ extend.console.register('init', 'Initialize', function(args){
         'tags: ',
         '---',
         '',
-        'Welcome to [Hexo](http://zespia.tw/hexo)! This is your very first post. Check [documentaion](http://zespia.tw/hexo/docs) to learn how to use.'
+        'Welcome to [Hexo](http://zespia.tw/hexo)! This is your very first post. Check [documentation](http://zespia.tw/hexo/docs) to learn how to use.'
       ];
 
       file.write(target + '/source/_posts/hello-world.md', content.join('\n'), next);


### PR DESCRIPTION
Changed "documentaion" to "documentation"
