### PR TITLE
Refs #64

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "files/themes/light"]
 	path = files/themes/light
-	url = git://github.com/tommy351/hexo-theme-light.git
+	url = https://github.com/tommy351/hexo-theme-light


### PR DESCRIPTION
- add the light theme submodule

i just turn out that, the reason for build failure, is that, there is no theme for the `tmp` 
