### PR TITLE
Fixed #105.

### DIFF
--- a/lib/plugins/deployer/github.js
+++ b/lib/plugins/deployer/github.js
@@ -47,7 +47,7 @@ extend.deployer.register('github', function(args, callback){
           ['init'],
           ['add', '-A'],
           ['commit', '-m', 'First commit'],
-          ['branch', '-m', config.branch],
+          ['branch', '-M', config.branch],
           ['remote', 'add', 'github', config.repository]
         ];
 


### PR DESCRIPTION
Use '-M' to force rename branch when setup git in deploying process, otherwise, git will throw error: 'fatal: A branch named 'master' already exists.' if 'config.branch' is 'master' and therefore later process will fail.
