### PR TITLE
修改了zh-CN/docs/deploy.md关于CNAME文件内容如何填写

### DIFF
--- a/source/zh-CN/docs/deploy.md
+++ b/source/zh-CN/docs/deploy.md
@@ -42,21 +42,17 @@ rm -rf .deploy
 
 ### 自定域名
 
-在`source`文件夹内建立名为`CNAME`的文件，其内容为：
-
-```
-example.com
-```
+在`source`文件夹内建立名为`CNAME`的文件。
 
 请根据你的域名类型设定DNS。
 
 #### 顶级域名 (Top-level domain)
 
-若域名类似`example.com`，则加入 **A 记录 (A record)** `204.232.175.78`。
+若域名类似`example.com`，则加入 **A 记录 (A record)** `204.232.175.78`。`CNAME`文件内容为`example.com`。
 
 #### 子域名 (Subdomain)
 
-若域名类似`username.example.com`，则加入 **CNAME 记录 (CNAME record)** `username.github.com`。
+若域名类似`username.example.com`，则加入 **CNAME 记录 (CNAME record)** `username.github.com`。`CNAME`文件内容为`username.example.com`。
 
 请参考 [GitHub Pages][1] 以取得更多资讯。
 


### PR DESCRIPTION
当前文档中关于deploy到github同时绑定独立域名的说明稍有欠缺，顶级域名example.com在CNAME文件内容为example.com。但是子域名username.example.com相对应应该在CNAME文件中填写username.example.com
