### PR TITLE
fix `generate --watch` for win32 platform

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -204,7 +204,7 @@ module.exports = function(options, callback){
           path: sourceDir,
           ignoreHiddenFiles: true,
           listener: function(type, source){
-            var path = source.substring(sourceDir.length);
+            var path = source.substring(sourceDir.length).replace(pathFn.sep || (process.platform === "win32" ? '\\' : '/'), '/');
 
             clearTimeout(timer);
 


### PR DESCRIPTION
windows上的watchr会返回带`\`的路径，导致正则匹配失败

嗯，同时也治好了`server`命令
#188   #185
