### PR TITLE
修复紧跟backtick codeblock后的markdown标记失效的问题

### DIFF
--- a/lib/plugins/filter/backtick_code_block.js
+++ b/lib/plugins/filter/backtick_code_block.js
@@ -41,7 +41,7 @@ extend.filter.register('pre', function(data){
       }
     }
 
-    return '<escape>' + highlight(str, options).replace(/&amp;/g, '&') + '</escape>';
+    return '<escape>' + highlight(str, options).replace(/&amp;/g, '&') + '</escape>\n';
   });
 
   return data;


### PR DESCRIPTION
比如这样的源码

``````
``` shell
#awesome codes
```

### 说些别的
``````

会变成

```
<escape>(略)</escape>### 说些别的
```

导致后面那个h3的markdown失效，所以应该加上一个`\n`
