### PR TITLE
Filtering node_modules

### DIFF
--- a/lib/init.js
+++ b/lib/init.js
@@ -166,15 +166,14 @@ module.exports = function(args){
         fs.readdir(dir, function(err, files){
           if (err) throw new Error('Plugins loaded error');
 
-          files.forEach(function(item){
-            if (item.substring(0, 1) !== '.'){
+          // loading only node_modules identified as hexo plugins
+          files.filter(function(file){ return file.match(/^hexo-/); }).forEach(function(item){
               try {
                 require(dir + item);
               } catch (err){
                 console.log('Plugin loaded error: %s'.red, item.bold);
                 if (debug) throw err;
               }
-            }
           });
 
           next();
@@ -192,14 +191,12 @@ module.exports = function(args){
         fs.readdir(dir, function(err, files){
           if (err) throw new Error('Scripts loaded error');
 
-          files.forEach(function(item){
-            if (item.substring(0, 1) !== '.'){
-              try {
-                require(dir + item);
-              } catch (err){
-                console.log('Script loaded error: %s'.red, item.bold);
-                if (debug) throw err;
-              }
+          files.filter(function(file){ return file[0] !== "." }).forEach(function(item){
+            try {
+              require(dir + item);
+            } catch (err){
+              console.log('Script loaded error: %s'.red, item.bold);
+              if (debug) throw err;
             }
           });
 


### PR DESCRIPTION
And improving the filtering of scripts.

Basically it will try to load only explicit hexo plugins.
It will enable projects to have other node modules (grunt tasks for example) not to generate an error (because their otherwise it makes the `--debug` flag totally unusable).
