### PR TITLE
Suffix the archiveDir only if non-empty

### DIFF
--- a/lib/plugins/helper/list.js
+++ b/lib/plugins/helper/list.js
@@ -65,10 +65,12 @@ extend.helper.register('list_archives', function(options){
   for (var i = oldest.year(); i <= newest.year(); i++){
     var yearly = posts.find({date: {$lt: new Date(i + 1, 0, 1), $gte: new Date(i, 0, 1)}});
     if (!yearly.length) continue;
+    
+    var yearly_url = root + (archiveDir && archiveDir + '/') + i + '/';
 
     if (type === 'yearly'){
       arr.push('<li class="archive-item">' +
-        '<a href="' + root + archiveDir + '/' + i + '/" class="archive-link">' + moment([i]).format(format) + '</a>' +
+        '<a href="' + yearly_url + '" class="archive-link">' + moment([i]).format(format) + '</a>' +
         (showCount ? '<span class="archive-count">' + yearly.length + '</span>' : '') +
         '</li>');
       continue;
@@ -79,7 +81,7 @@ extend.helper.register('list_archives', function(options){
       if (!monthly.length) continue;
 
       arr.push('<li class="archive-item">' +
-        '<a href="' + root + archiveDir + '/' + i + '/' + j + '/" class="archive-link">' + moment([i, j - 1]).format(format) + '</a>' +
+        '<a href="' + yearly_url + j + '/" class="archive-link">' + moment([i, j - 1]).format(format) + '</a>' +
         (showCount ? '<span class="archive-count">' + monthly.length + '</span>' : '') +
         '</li>');
     }


### PR DESCRIPTION
If `archive_dir` equals "archives" in _config.yml, the output will be: `/archives/2013/`

If `archive_dir` equals "" in _config.yml, the output will be: `//2013/` (which leads to bad interpretation by the browser; expecting `/2013/`)

Also avoids computing the base URL for each link (either it is yearly or monthly).
