### PR TITLE
`delete` property of rsync was not effective.

### DIFF
--- a/lib/plugins/deployer/rsync.js
+++ b/lib/plugins/deployer/rsync.js
@@ -15,7 +15,7 @@ extend.deployer.register('rsync', function(args, callback){
       '    user: <user>',
       '    root: <root>',
       '    port: [port] # Default is 22',
-      '    delete: [delete] # Default is true',
+      '    delete: [true|false] # Default is true',
       '',
       'More info: http://zespia.tw/hexo/docs/deploy.html'
     ].join('\n') + '\n');
@@ -24,9 +24,15 @@ extend.deployer.register('rsync', function(args, callback){
   if (!config.hasOwnProperty('delete')) config.delete = true;
   if (!config.port) config.port = 22;
 
+  var args = [
+    config.delete === true ? '--delete' : '',
+    '-avze',
+    'ssh -p ' + config.port, 'public/', config.user + '@' + config.host + ':' + config.root]
+  ].filter(function(arg){ return arg });
+
   spawn({
     command: 'rsync',
-    args: ['-avze', 'ssh -p ' + config.port, 'public/', config.user + '@' + config.host + ':' + config.root],
+    args: args,
     exit: function(code){
       if (code === 0){
         console.log('Deploy completely.');


### PR DESCRIPTION
The `filter` trick enables the fact we don't have to care about empty fields in the array.
