### PR TITLE
Adding ignore option to ignore a list of elements during the sync

### DIFF
--- a/lib/plugins/deployer/rsync.js
+++ b/lib/plugins/deployer/rsync.js
@@ -1,7 +1,7 @@
 var extend = require('../../extend'),
   term = require('term'),
   util = require('../../util'),
-  spawn = util.spawn,
+  exec = util.exec,
   config = hexo.config.deploy;
 
 extend.deployer.register('rsync', function(args, callback){
@@ -14,6 +14,7 @@ extend.deployer.register('rsync', function(args, callback){
       '    host: <host>',
       '    user: <user>',
       '    root: <root>',
+      '    ignore: [port] # An array of files/patterns to ignore',
       '    port: [port] # Default is 22',
       '    delete: [delete] # Default is true',
       '',
@@ -24,9 +25,15 @@ extend.deployer.register('rsync', function(args, callback){
   if (!config.hasOwnProperty('delete')) config.delete = true;
   if (!config.port) config.port = 22;
 
-  spawn({
-    command: 'rsync',
-    args: ['-avze', 'ssh -p ' + config.port, 'public/', config.user + '@' + config.host + ':' + config.root],
+  var args = [
+    Array.isArray(config.exclude) ? "--exclude='" + config.exclude.join("' --exclude='") + "'" : '',
+    '-avz',
+    '-e "ssh -p ' + config.port + '"',
+    'public/', config.user + '@' + config.host + ':' + config.root
+  ].filter(function(arg){ return arg });
+
+  exec({
+    command: ['rsync'].concat(args).join(' '),
     exit: function(code){
       if (code === 0){
         console.log('Deploy completely.');


### PR DESCRIPTION
I switched over `exec` to avoid the escaping of the arguments.
Also, it forced to make the `--rsh|-e` flag more explicit.

This is an example or `_config.yml` I have for my own website:
```yml
deploy:
  type: rsync
  host: oncletom
  user: oncletom
  root: ~/
  delete: true
  exclude: [.ssh, .bash*, .htaccess, images, talks]
```