### PR TITLE
W3C Validator says `a[name]` is not compliant.

### DIFF
--- a/lib/plugins/filter/excerpt.js
+++ b/lib/plugins/filter/excerpt.js
@@ -7,7 +7,7 @@ extend.filter.register('post', function(data){
   if (regex.test(content)){
     data.content = content.replace(regex, function(match, index){
       data.excerpt = index;
-      return '<a name="more"></a>';
+      return '<a id="more"></a>';
     });
   } else {
     data.excerpt = 0;


### PR DESCRIPTION
> The name attribute is obsolete. Consider putting an id attribute on the nearest container instead.
