### PR TITLE
case sensitive on github page deployment

### DIFF
--- a/lib/plugins/deployer/github.js
+++ b/lib/plugins/deployer/github.js
@@ -57,10 +57,11 @@ module.exports = function(args, callback){
 
   var match = url.match(rRepo),
     username = match[2],
-    repo = match[3];
+    repo = match[3],
+    rGh = new RegExp('^' + username + '\.github\.[io|com]', 'i');
 
   // https://help.github.com/articles/user-organization-and-project-pages
-  if (repo === username + '.github.io' || repo === username + '.github.com'){
+  if (repo.match(rGh)){
     var branch = 'master';
   } else {
     var branch = 'gh-pages'


### PR DESCRIPTION
hexo will deploy to wrong branch when username and gh-pages are different case, 
something like this: `Ferrari/ferrari.github.com`, will deploy to gh-pages not master branch.
Special case but lucky to me have this issue. xD  
