### PR TITLE
Fixed tagcloud plugin `result` variable is not defined error

### DIFF
--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -35,7 +35,8 @@ module.exports = function(tags, options){
     tags = tags.sort(orderby, order);
   }
 
-  var length = tags.length;
+  var length = tags.length,
+    result = '';
 
   for (var i = 0; i < length; i++){
     var item = tags.eq(i),


### PR DESCRIPTION
Fixed tagcloud plugin `result` variable is not defined error.
