### PR TITLE
fix mistake in tagcloud.js

### DIFF
--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -1,4 +1,6 @@
-var _ = require('lodash');
+var _ = require('lodash'),
+  config = hexo.config,
+  root = config.root;
 
 module.exports = function(tags, options){
   if (!options){


### PR DESCRIPTION
the `result` returned include a variale root, which is not refered in
`tagcloud.js`.
so the after require(`lodash`), config and root should be set.
