### PR TITLE
scripts directory in theme directory for theme specific scripts, e.g tags

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -49,6 +49,10 @@ var Hexo = module.exports = function(baseDir, args){
     return path.join(baseDir, 'themes', this.config.theme);
   });
 
+  this.__defineGetter__('theme_script_dir', function(){
+    return path.join(baseDir, 'themes', this.config.theme, 'scripts');
+  });
+
   this.debug = !!args.debug;
   this.safe = !!args.save;
   this.route = new Router();

--- a/lib/init.js
+++ b/lib/init.js
@@ -72,6 +72,27 @@ module.exports = function(cwd, args, callback){
     }
   }
 
+  var loadScript = function(scriptDir, next) {
+    fs.exists(scriptDir, function(exist){
+      if (!exist) return next();
+
+      file.list(scriptDir, function(err, files){
+        if (err) return log.e(HexoError.wrap(err, 'Script load failed'));
+
+        files.forEach(function(item){
+          try {
+            require(path.join(scriptDir, item));
+            log.d('Script loaded successfully: ' + item);
+          } catch (err){
+            log.e('Script load failed: ' + item);
+          }
+        });
+
+        next();
+      });
+    });
+  }
+
   async.auto({
     // Load config
     config: function(next){
@@ -179,25 +200,16 @@ module.exports = function(cwd, args, callback){
 
       // TODO
       var scriptDir = hexo.script_dir;
+      loadScript(scriptDir, next);
 
-      fs.exists(scriptDir, function(exist){
-        if (!exist) return next();
+    }],
+    load_theme_scripts: ['config', function(next, results){
+      if (hexo.save || !results.config) return next();
 
-        file.list(scriptDir, function(err, files){
-          if (err) return log.e(HexoError.wrap(err, 'Script load failed'));
+      // TODO
+      var scriptDir = hexo.theme_script_dir;
+      loadScript(scriptDir, next);
 
-          files.forEach(function(item){
-            try {
-              require(path.join(scriptDir, item));
-              log.d('Script loaded successfully: ' + item);
-            } catch (err){
-              log.e('Script load failed: ' + item);
-            }
-          });
-
-          next();
-        });
-      });
     }],
     load_database: ['update', function(next, results){
       var db = new Database(),


### PR DESCRIPTION
We use theme specific tags. For this to work we have scripts that register some tags. This pull request adds "scripts" directory support in the active theme. The same as the "scripts" directory in the root dir, but now you can have scripts (like plugins) in the theme directory to keep them in the same repo.
