### PR TITLE
make --safe flag work (fix misspelling)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -54,7 +54,7 @@ var Hexo = module.exports = function(baseDir, args){
   });
 
   this.debug = !!args.debug;
-  this.safe = !!args.save;
+  this.safe = !!args.safe;
   this.route = new Router();
 
   // Extend

--- a/lib/init.js
+++ b/lib/init.js
@@ -170,7 +170,7 @@ module.exports = function(cwd, args, callback){
       });
     }],
     load_plugins: ['config', function(next, results){
-      if (hexo.save || !results.config) return next();
+      if (hexo.safe || !results.config) return next();
 
       var pluginDir = hexo.plugin_dir;
 
@@ -196,7 +196,7 @@ module.exports = function(cwd, args, callback){
       });
     }],
     load_scripts: ['config', function(next, results){
-      if (hexo.save || !results.config) return next();
+      if (hexo.safe || !results.config) return next();
 
       // TODO
       var scriptDir = hexo.script_dir;


### PR DESCRIPTION
The `--safe` flag wasn't working due to misspellings, this makes it work.
