### PR TITLE
Remove unneeded middleware from server

### DIFF
--- a/lib/plugins/console/server/index.js
+++ b/lib/plugins/console/server/index.js
@@ -67,12 +67,6 @@ module.exports = function(args, callback){
   app.use(express.cookieParser('x2gt3QrS50t0LOR'));
   app.use(express.cookieSession());
 
-  // Enable body parsing
-  app.use(express.bodyParser());
-
-  // Enable method override
-  app.use(express.methodOverride());
-
   // Routes
   require('./routes')(new Controller(app, base));
 


### PR DESCRIPTION
`express.bodyParser()` is deprecated in the upcoming Connect version 3.0:

```
connect.multipart() will be removed in connect 3.0
visit https://github.com/senchalabs/connect/wiki/Connect-3.0 for alternatives
```

As hexo should only generate static files (and the server module isn't considered to run in a production environment), it should be safe to remove it completely along with `express.methodOverride()`.
