### PR TITLE
Makes swig rendering synced

### DIFF
--- a/lib/plugins/renderer/index.js
+++ b/lib/plugins/renderer/index.js
@@ -22,7 +22,7 @@ var styl = require('./stylus');
 renderer.register('styl', 'css', styl);
 renderer.register('stylus', 'css', styl);
 
-renderer.register('swig', 'html', require('./swig'));
+renderer.register('swig', 'html', require('./swig'), true);
 
 var yml = require('./yaml');
 


### PR DESCRIPTION
Trying to make my Swig theme working I've found a bug: server or generation process freezes on first page with content.

```
$ hexo generate --debug
[debug] 04:12:49.907 Configuration file load successfully
[debug] 04:12:49.915 Version info checked successfully
[debug] 04:12:49.916 Loading the database...
[debug] 04:12:50.190 Theme layout loaded
[debug] 04:12:50.220 Theme source loaded
[debug] 04:12:50.240 Theme configuration loaded
[debug] 04:12:50.264 Theme i18n loaded
[debug] 04:12:50.372 Processed: _posts/do-work-that-matters.md
[debug] 04:12:50.501 Cache saved
[info] 04:12:50.502 Files loaded in 0.346s
[debug] 04:12:50.507 Public folder cleared: css/style.css,archives/index.html,archives/2013/index.html,archives/2013/12/index.html,index.html,blog/do-work-that-matters/index.html
[debug] 04:12:50.507 Render archive: archives/
[debug] 04:12:50.508 Render archive: archives/2013/
[debug] 04:12:50.509 Render archive: archives/2013/12/
[debug] 04:12:50.509 Render index: 
[debug] 04:12:50.510 Render post: blog/do-work-that-matters/
```

I crawled a little around the source and found that **swig renderer is registered as async.**
Don't know if this is correct, but changing mode to sync fixes the issue and my site works finally!

```
[debug] 04:15:23.340 Render post: blog/do-work-that-matters/
[create] 04:15:23.420 Public: archives/2013/12/index.html
[create] 04:15:23.423 Public: blog/do-work-that-matters/index.html
[create] 04:15:23.493 Public: index.html
[create] 04:15:23.497 Public: archives/2013/index.html
[create] 04:15:23.512 Public: archives/index.html
[info] 04:15:23.513 5 files generated in 0.196s
```
