### PR TITLE
Fix: TOC helper would raise an exception if it was called with content that doesn’t contain any headings.

### DIFF
--- a/lib/plugins/helper/toc.js
+++ b/lib/plugins/helper/toc.js
@@ -17,12 +17,11 @@ module.exports = function(str, options){
     firstLevel = 0,
     lastLevel = 0;
 
-  if (!headings.length) return '';
+  if (!headings || !headings.length) return '';
 
   for (var i = 1; i <= 6; i++){
     lastNumber[i] = 0;
   }
-
   headings.forEach(function(heading, i){
     if (!rHeading.test(heading)) return;
 


### PR DESCRIPTION
That's all :)
