### PR TITLE
bug fixed in page.js

### DIFF
--- a/lib/plugins/processor/page.js
+++ b/lib/plugins/processor/page.js
@@ -95,7 +95,7 @@ module.exports = function(data, callback){
       });
     });
   } else {
-    var src = pathFn.join('source', path),
+    var src = pathFn.join(hexo.config.source_dir, path),
       doc = Asset.findOne({source: src});
 
     if (data.type === 'delete' && doc){


### PR DESCRIPTION
when modify source_dir,the static file(e.g. imgs/sss.jpg) will generate error

当修改了_config.yml的source_dir目录之后,如果新的source目录里面有一些静态文件像图片之类的文件,就会出错.
因为这里使用了硬编码'source',

改成hexo.config.source_dir 解决这个问题 .
