### PR TITLE
using theme config in source_dir #440

### DIFF
--- a/lib/core/theme.js
+++ b/lib/core/theme.js
@@ -40,9 +40,13 @@ var _loadConfig = function(callback){
   if (typeof callback !== 'function') callback = function(){};
 
   var configPath = pathFn.join(hexo.theme_dir, '_config.yml');
+  var configPath_user = pathFn.join(hexo.source_dir, '_' + hexo.config.theme + '.yml');
 
-  fs.exists(configPath, function(exist){
-    if (!exist) return callback();
+  async.detect([configPath_user,configPath],fs.exists,function(configPath){
+    if (!configPath) return callback();
+
+    themeConfigPath = configPath;
+    hexo.log.d('Theme config file: ' + configPath.green);
 
     hexo.render.render({path: configPath}, function(err, result){
       if (err) return callback(HexoError.wrap(err, 'Theme configuration load failed'));


### PR DESCRIPTION
具体情况在 #440,

为了方便根踪,使用新的分支,重新发送Pull request

唯一的缺点就是如果配置文件在source目录下不能自动刷新配置,(chenall的主题已经实现此功能,并且会自动刷新配置)
