### PR TITLE
Added feature to customize server address in console

### DIFF
--- a/assets/init/_config.yml
+++ b/assets/init/_config.yml
@@ -58,6 +58,7 @@ tag: 2
 ## You can customize the logger format as defined in
 ## http://www.senchalabs.org/connect/logger.html
 port: 4000
+server_address: localhost
 logger: false
 logger_format:
 

--- a/lib/plugins/console/index.js
+++ b/lib/plugins/console/index.js
@@ -87,6 +87,7 @@ var serverOptions = {
   alias: 's',
   desc: 'Start the server and watch for file changes.',
   options: [
+    {name: '-a, --address', desc: 'Override the default server address. Default is localhost'},
     {name: '-p, --port', desc: 'Override the default port'},
     {name: '-s, --static', desc: 'Only serve static files'},
     {name: '-l, --log [format]', desc: 'Enable logger. Override the logger format.'},

--- a/lib/plugins/console/server.js
+++ b/lib/plugins/console/server.js
@@ -9,6 +9,7 @@ module.exports = function(args, callback){
     processor = hexo.extend.processor;
 
   var app = express(),
+    serverAddress = args.a || args.address || config.server_address || 'localhost',
     port = parseInt(args.p || args.port || config.port, 10) || 4000,
     useDrafts = args.d || args.drafts || config.render_drafts || false,
     loggerFormat = args.l || args.log,
@@ -87,7 +88,7 @@ module.exports = function(args, callback){
       if (useDrafts)
         log.i('Using drafts.');
 
-      log.i('Hexo is running at ' + 'localhost:%d%s'.underline + '. Press Ctrl+C to stop.', port, root);
+      log.i('Hexo is running at ' + '%s:%d%s'.underline + '. Press Ctrl+C to stop.', serverAddress, port, root);
 
       /**
       * Fired after server started.


### PR DESCRIPTION
Fix for issue [#466](https://github.com/tommy351/hexo/issues/466). 

Able to override the default server address in console when you run `hexo server`.

Server address can be set either in `_config.yaml` or run with `-a` or `--address` options. Default is localhost. Note that the server is still running in localhost/127.0.0.1 obviously.
