### PR TITLE
關於 source_dir and public_dir 自動配置

### DIFF
--- a/lib/loaders/config.js
+++ b/lib/loaders/config.js
@@ -20,9 +20,6 @@ var defaults = {
   archive_dir: 'archives',
   category_dir: 'categories',
   code_dir: 'downloads/code',
-  // Directory
-  source_dir: 'source',
-  public_dir: 'public',
   // Writing
   new_post_name: ':title.md',
   default_layout: 'post',
@@ -125,7 +122,7 @@ module.exports = function(callback){
         * @for Hexo
         */
 
-        hexo.constant('public_dir', joinPath(baseDir, config.public_dir));
+        hexo.constant('public_dir', (config.public_dir ? joinPath(baseDir, config.public_dir) : joinPath(path.dirname(configPath), 'public')));
 
         /**
         * The path of source directory.
@@ -135,7 +132,7 @@ module.exports = function(callback){
         * @for Hexo
         */
 
-        hexo.constant('source_dir', joinPath(baseDir, config.source_dir))
+        hexo.constant('source_dir', (config.source_dir ? joinPath(baseDir, config.source_dir) : joinPath(path.dirname(configPath), 'source')))
 
         /**
         * The path of plugin directory.


### PR DESCRIPTION
為了更方便的支持多站點，當`source_dir`和`public_dir` 留空時自動根據配置文件的位置設置這兩個路徑。

比如demo站點的配置文件在demo目錄下並且source_dir和public_dir.的配置為空
這時對應的
source_dir ＝ demo/source 
public_dir = demo/public

這樣子比較靈活，另外保持了兼容性，只有當配置值為空時才會自動配置。
