### PR TITLE
Generate absolute link for include_code

### DIFF
--- a/lib/plugins/tag/include_code.js
+++ b/lib/plugins/tag/include_code.js
@@ -52,7 +52,7 @@ module.exports = function(args, callback){
   // If the language is not defined, use file extension instead
   lang = lang || pathFn.extname(path).substring(1);
 
-  caption = '<span>' + title + '</span><a href="' + codeDir + path + '">download</a>';
+  caption = '<span>' + title + '</span><a href="/' + codeDir + path + '">download</a>';
 
   return highlight(code, {
     lang: lang,


### PR DESCRIPTION
Here are the relevant lines of my config:

```
permalink: :year/:month/:title/
code_dir: projects/
source_dir: source
```

An URL for a post is for instance `/2014/03/monthofcode-day-8-mathematics/`

If I use the include_code tag : 

```
{% include_code monthofcode/8/8.js %}
```

the generated download link is `projects/monthofcode/8/8.js` which is resolved to `/2014/03/monthofcode-day-8-mathematics/projects/monthofcode/8/8.js` instead of the desired `/projects/monthofcode/8/8.js`.

Since the `code_dir` option is relative the the `source_dir`, I don't see why we shouldn't use an absolute link (starting with a slash).

What do you think?
