### PR TITLE
Replace Express with Connect

### DIFF
--- a/lib/plugins/console/server.js
+++ b/lib/plugins/console/server.js
@@ -1,6 +1,11 @@
-var express = require('express'),
+var connect = require('connect'),
+  http = require('http'),
   path = require('path'),
-  colors = require('colors');
+  colors = require('colors'),
+  logger = require('morgan'),
+  serveStatic = require('serve-static'),
+  compress = require('compression'),
+  mime = require('mime');
 
 module.exports = function(args, callback){
   var config = hexo.config,
@@ -8,12 +13,22 @@ module.exports = function(args, callback){
     route = hexo.route,
     processor = hexo.extend.processor;
 
-  var app = express(),
+  var app = connect(),
     serverIp = args.i || args.ip || config.server_ip || '0.0.0.0',
     port = parseInt(args.p || args.port || config.port, 10) || 4000,
     useDrafts = args.d || args.drafts || config.render_drafts || false,
     loggerFormat = args.l || args.log,
     root = config.root;
+
+  var redirect = function(res, dest){
+    res.statusCode = 302;
+    res.setHeader('Location', dest);
+    res.end('Redirecting to ' + dest);
+  };
+
+  var contentType = function(res, type){
+    res.setHeader('Content-Type', ~type.indexOf('/') ? type : mime.lookup(type));
+  };
 
   // If the port setting is invalid, set to the default port 4000
   if (port > 65535 || port < 1){
@@ -27,28 +42,30 @@ module.exports = function(args, callback){
 
   // Logger
   if (loggerFormat){
-    app.use(express.logger(typeof loggerFormat === 'string' ? loggerFormat : config.logger_format));
+    app.use(logger(typeof loggerFormat === 'string' ? loggerFormat : config.logger_format));
   } else if (config.logger || hexo.debug){
-    app.use(express.logger(config.logger_format));
+    app.use(logger(config.logger_format));
   }
 
   // Change response header
   app.use(function(req, res, next){
-    res.header('X-Powered-By', 'Hexo');
+    res.setHeader('X-Powered-By', 'Hexo');
     next();
   });
 
   // Dynamic files
   if (!args.s && !args.static){
-    app.get(root + '*', function(req, res, next){
-      var url = route.format(req.params[0]),
+    app.use(root, function(req, res, next){
+      if (req.method !== 'GET') return next();
+
+      var url = route.format(req.url),
         target = route.get(url);
 
       // When the URL is `foo/index.html` but users access `foo`, redirect to `foo/`.
       if (!target){
         if (path.extname(url)) return next();
 
-        res.redirect(root + url + '/');
+        redirect(res, root + url + '/');
         return;
       }
 
@@ -56,7 +73,7 @@ module.exports = function(args, callback){
         if (err) return next(err);
         if (typeof result === 'undefined') return next();
 
-        res.type(path.extname(url));
+        contentType(res, path.extname(url));
 
         if (result.readable){
           result.pipe(res).on('error', next);
@@ -68,26 +85,29 @@ module.exports = function(args, callback){
   }
 
   // Static files
-  app.use(root, express.static(hexo.public_dir));
+  app.use(root, serveStatic(hexo.public_dir));
 
   // If root url is not `/`, redirect to the correct root url
   if (root !== '/'){
-    app.get('/', function(req, res){
-      res.redirect(root);
+    app.use(function(req, res, next){
+      if (req.method !== 'GET' || req.url !== '/') return next();
+
+      redirect(res, root);
     });
   }
 
   // gzip
-  app.use(express.compress());
+  app.use(compress());
 
   // Load source files
   hexo.post.load({watch: true}, function(err){
     if (err) return callback(err);
 
     // Start listening!
-    app.listen(port, serverIp, function(){
-      if (useDrafts)
+    http.createServer(app).listen(port, serverIp, function(){
+      if (useDrafts){
         log.i('Using drafts.');
+      }
 
       // for display purpose only
       var ip = serverIp === '0.0.0.0' ? 'localhost' : serverIp;

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "connect": "3.x",
     "serve-static": "1.0.2",
     "morgan": "1.0.0",
-    "compression": "1.0.1"
+    "compression": "1.0.1",
+    "mime": "1.2.11"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
[Express](https://github.com/visionmedia/express) is about to be updated to 4.0 and most middlewares are removed. I decided to move to [Connect](https://github.com/senchalabs/connect) because it's lighter and I don't need so much features.

This pull request will be merged when Connect 3.0 is released.
