### PR TITLE
Fix default value of `og:description` in `open_graph`

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -17,8 +17,11 @@ module.exports = function(options){
   var description = page.description || '';
 
   if (!description){
-    if (page.excerpt) description = format.strip_html(page.excerpt);
-    if (page.content) description = format.strip_html(content);
+    if (page.excerpt){
+      description = format.strip_html(page.excerpt);
+    } else if (page.content){
+      description = format.strip_html(content);
+    }
   }
 
   description = description.substring(0, 200).replace(/^\s+|\s+$/g, '');


### PR DESCRIPTION
By default, `og:description` should be `page.excerpt` or first 200 characters of `page.content`.

However, in the current implementation, `page.excerpt` will always be overwritten by `page.content`.
