### PR TITLE
Fix loading deployer of Heroku and OpenShift.

### DIFF
--- a/lib/plugins/deployer/heroku/index.js
+++ b/lib/plugins/deployer/heroku/index.js
@@ -5,7 +5,7 @@ var async = require('async'),
   spawn = require('child_process').spawn,
   util = require('../../../util'),
   file = util.file2,
-  commitMessage = require('../../util').commitMessage;
+  commitMessage = require('../util').commitMessage;
 
 module.exports = function(args, callback){
   if (!args.repo && !args.repository){

--- a/lib/plugins/deployer/openshift.js
+++ b/lib/plugins/deployer/openshift.js
@@ -4,7 +4,7 @@ var colors = require('colors'),
   spawn = require('child_process').spawn,
   util = require('../../util'),
   file = util.file2,
-  commitMessage = require('../util').commitMessage;
+  commitMessage = require('./util').commitMessage;
 
 var run = function(command, args, callback){
   var cp = spawn(command, args);


### PR DESCRIPTION
I wrote a blog about how I [Fixed Hexo's Deployer.](http://nicktd.com/2014/04/25/fixing-hexos-deployer/)
#### Before this fix:

When trying to deploy blog to Heroku error happens, because the deployer for Heroku isn't loaded.
Same for OpenShift's deployer.
#### Suggestion:

In `hexo/lib/loaders/entend.js`, a logging could be added for errors at 31th line in the catch statement. Because if not the error is hidden by that catch statement.
Here's what I added when I was debugging:

``` javascript
try {
   require('../plugins/' + item);
} catch (e){
  hexo.log.e("Failed loading: " + item + " for: " + e);
}
```

<br>
If you need anything, just leave me a comment. :smile:
#### PS.

Hexo is AWESOME!  Great work!
Thanks.
