### PR TITLE
Fragment cache

### DIFF
--- a/lib/plugins/helper/fragment_cache.js
+++ b/lib/plugins/helper/fragment_cache.js
@@ -1,0 +1,8 @@
+var cache = {};
+
+module.exports = function(id, fn){
+  if (this.cache && cache[id] != null) return cache[id];
+
+  var result = cache[id] = fn();
+  return result;
+};

--- a/lib/plugins/helper/index.js
+++ b/lib/plugins/helper/index.js
@@ -25,6 +25,8 @@ helper.register('word_wrap', format.word_wrap);
 helper.register('truncate', format.truncate);
 helper.register('render', format.render);
 
+helper.register('fragment_cache', require('./fragment_cache'));
+
 helper.register('gravatar', require('./gravatar'));
 
 var is = require('./is');

--- a/lib/plugins/helper/partial.js
+++ b/lib/plugins/helper/partial.js
@@ -1,24 +1,39 @@
 var pathFn = require('path'),
   _ = require('lodash');
 
-module.exports = function(name, options, only){
+module.exports = function(name, locals, options){
+  options = _.extend({
+    cache: false,
+    only: false
+  }, options);
+
   var viewDir = this.view_dir || this.settings.views,
-    path = pathFn.join(pathFn.dirname(this.filename.substring(viewDir.length)), name);
+    path = pathFn.join(pathFn.dirname(this.filename.substring(viewDir.length)), name),
+    view = hexo.theme.getView(path) || hexo.theme.getView(name),
+    self = this;
 
-  var view = hexo.theme.getView(path) || hexo.theme.getView(name);
-
-  if (view){
-    var locals = {};
-
-    if (only){
-      _.extend(locals, options);
-    } else {
-      _.extend(locals, _.omit(this, 'layout'), options);
-    }
-
-    return view.renderSync(locals);
-  } else {
+  if (!view){
     hexo.log.w('Partial %s does not exist', name);
     return '';
+  }
+
+  var partial = function(){
+    var viewLocals = {};
+
+    if (options.only){
+      _.extend(viewLocals, locals);
+    } else {
+      _.extend(viewLocals, _.omit(self, 'layout'), locals);
+    }
+
+    return view.renderSync(viewLocals);
+  };
+
+  if (options.cache){
+    var cacheId = typeof options.cache === 'string' ? options.cache : view.path;
+
+    return this.fragment_cache(cacheId, partial);
+  } else {
+    return partial();
   }
 };


### PR DESCRIPTION
Add fragment cache to improve the performance of file generating. This concept is stolen from [Ruby on Rails](http://guides.rubyonrails.org/caching_with_rails.html#fragment-caching). The cache will be only enabled in generating mode.

**New helper**: `fragment_cache(id, fn)`

``` js
<%- fragment_cache('footer', function(){
  return '<footer></footer>';
}); %>
```

**Partial cache**

A new option `cache` will be added to `partial` helper. This is a shortcut to `fragment_cache` helper. For example:

``` js
<%- partial('footer', {}, {cache: true}) %>
```

yields:

``` js
<%- fragment_cache('footer', function(){
  return partial('footer', {});
}) %>
```

The effect of fragment cache is remarkable. I used `fragment_cache` helper in sidebar to reduce database queries. It only took less than 10 seconds to generate 1000+ static files. The original elapsed time is 10 minutes, which means is at least 60x faster.
