### PR TITLE
fix travis-ci badge on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hexo
 
-[![Build Status](https://travis-ci.org/tommy351/hexo.svg?branch=master)](https://travis-ci.org/tommy351/hexo)  [![NPM version](https://badge.fury.io/js/hexo.svg)](http://badge.fury.io/js/hexo)
+[![Build Status](https://travis-ci.org/hexojs/hexo.svg?branch=master)](https://travis-ci.org/hexojs/hexo)  [![NPM version](https://badge.fury.io/js/hexo.svg)](http://badge.fury.io/js/hexo)
 
 [![Clone in Koding](http://learn.koding.com/btn/clone_d.png)][koding]
 [koding]: https://koding.com/Teamwork?import=https://github.com/tommy351/hexo/archive/master.zip&c=git3


### PR DESCRIPTION
This is a minor fix. On README.md, the Travis-CI badge shows a broken image. It was pointing to the old repo URL. I've updated it.
