### PR TITLE
Added `amount` option to list_tags.

### DIFF
--- a/lib/plugins/helper/list.js
+++ b/lib/plugins/helper/list.js
@@ -108,6 +108,7 @@ exports.list_tags = function(tags, options){
   if (!tags.length) return '';
 
   options = _.extend({
+    limit: 0, // 0 = unlimited
     orderby: 'name',
     order: 1,
     show_count: true,
@@ -129,7 +130,11 @@ exports.list_tags = function(tags, options){
     result = '';
   }
 
-  tags.sort(options.orderby, options.order).each(function(tag){
+  tags = tags.sort(options.orderby, options.order);
+  
+  if (options.amount) tags = tags.limit(options.amount);
+  
+  tags.each(function(tag){
     if (!tag.length) return;
 
     if (style === 'list'){


### PR DESCRIPTION
Allows the list_tags helper to limit the amount of tags listed.  Related to my feature request #723.
