### PR TITLE
Should listen to localhost only by default

### DIFF
--- a/lib/plugins/console/server.js
+++ b/lib/plugins/console/server.js
@@ -8,7 +8,7 @@ module.exports = function(args, callback){
     log = hexo.log;
 
   var app = connect(),
-    serverIp = args.i || args.ip || config.server_ip || '0.0.0.0',
+    serverIp = args.i || args.ip || config.server_ip || 'localhost',
     port = parseInt(args.p || args.port || config.port, 10) || 4000,
     useDrafts = args.d || args.drafts || config.render_drafts || false,
     root = config.root;


### PR DESCRIPTION
Can listen to all IP addresses by setting config or passing argument, thus we should give the minimal authority by default.
