### PR TITLE
Correct the IP address displayed by server

### DIFF
--- a/lib/plugins/console/server.js
+++ b/lib/plugins/console/server.js
@@ -35,10 +35,7 @@ module.exports = function(args, callback){
         log.i('Using drafts.');
       }
 
-      // for display purpose only
-      var ip = serverIp === '0.0.0.0' ? 'localhost' : serverIp;
-
-      log.i('Hexo is running at ' + 'http://%s:%d%s'.underline + '. Press Ctrl+C to stop.', ip, port, root);
+      log.i('Hexo is running at ' + 'http://%s:%d%s'.underline + '. Press Ctrl+C to stop.', serverIp, port, root);
 
       /**
       * Fired after server started.


### PR DESCRIPTION
Server shows wrong IP address it listens to before. It shows 0.0.0.0 while it is listening to localhost and vice versa. Also, we don't need another var only for displaying, just getting the var what server really got is enough.
