### PR TITLE
Tab completion

### DIFF
--- a/lib/plugins/console/completion/bash
+++ b/lib/plugins/console/completion/bash
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Borrowed from grunt-cli
+# http://gruntjs.com/
+#
+# Copyright (c) 2012 Tyler Kellen, contributors
+# Licensed under the MIT license.
+# https://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+
+# Usage:
+#
+# To enable bash <tab> completion for hexo, add the following line (minus the
+# leading #, which is the bash comment character) to your ~/.bashrc file:
+#
+# eval "$(hexo _completion bash)"
+
+# Enable bash autocompletion.
+function _hexo_completions() {
+  # The currently-being-completed word.
+  local cur="${COMP_WORDS[COMP_CWORD]}"
+  # Grab tasks
+  local compls=$(hexo --console-list)
+  # Tell complete what stuff to show.
+  COMPREPLY=($(compgen -W "$compls" -- "$cur"))
+}
+
+complete -o default -F _hexo_completions hexo

--- a/lib/plugins/console/completion/index.js
+++ b/lib/plugins/console/completion/index.js
@@ -1,0 +1,13 @@
+var fs = require('graceful-fs'),
+  path = require('path');
+
+module.exports = function(args, callback){
+  var shell = args._[0];
+  if (!shell) return callback();
+
+  var stream = fs.createReadStream(path.join(__dirname, shell));
+
+  stream.pipe(process.stdout)
+    .on('error', callback)
+    .on('end', callback);
+};

--- a/lib/plugins/console/completion/zsh
+++ b/lib/plugins/console/completion/zsh
@@ -1,0 +1,25 @@
+#!/bin/zsh
+
+# Borrowed from grunt-cli
+# http://gruntjs.com/
+#
+# Copyright (c) 2012 Tyler Kellen, contributors
+# Licensed under the MIT license.
+# https://github.com/gruntjs/grunt/blob/master/LICENSE-MIT
+
+# Usage:
+#
+# To enable zsh <tab> completion for gulp, add the following line (minus the
+# leading #, which is the zsh comment character) to your ~/.zshrc file:
+#
+# eval "$(hexo _completion zsh)"
+
+# Enable zsh autocompletion.
+function _hexo_completions() {
+  # Grab tasks
+  compls=$(hexo --console-list)
+  completions=(${=compls})
+  compadd -- $completions
+}
+
+compdef _hexo_completions hexo

--- a/lib/plugins/console/completion/zsh
+++ b/lib/plugins/console/completion/zsh
@@ -9,7 +9,7 @@
 
 # Usage:
 #
-# To enable zsh <tab> completion for gulp, add the following line (minus the
+# To enable zsh <tab> completion for hexo, add the following line (minus the
 # leading #, which is the zsh comment character) to your ~/.zshrc file:
 #
 # eval "$(hexo _completion zsh)"

--- a/lib/plugins/console/help.js
+++ b/lib/plugins/console/help.js
@@ -1,3 +1,5 @@
+var _ = require('lodash');
+
 var commandList = function(title, list){
   if (!list.length) return '';
 
@@ -69,6 +71,11 @@ module.exports = function(args, callback){
         name: key,
         desc: (item.description || item.desc)
       });
+    }
+
+    if (args['console-list']){
+      console.log(_.pluck(commands, 'name').join('\n'));
+      return callback();
     }
 
     str += commandList('Commands:', commands);

--- a/lib/plugins/console/index.js
+++ b/lib/plugins/console/index.js
@@ -108,3 +108,5 @@ var publishOptions = {
 };
 
 console.register('publish', 'Publish a draft', publishOptions, require('./publish'));
+
+console.register('_completion', 'Shell completion', {debug: true}, require('./completion'));


### PR DESCRIPTION
Add completion for bash, zsh.

## Usage

**Bash:**

Add this to your `~/.bashrc` file:

``` bash
eval "$(hexo _completion bash)"
```

**Zsh:**

Add this to your `~/.zshrc` file:

``` bash
eval "$(hexo _completion zsh)"
```

## Todo

- [ ] hexo new
- [ ] hexo publish