### PR TITLE
Fixed openshift deployment issues

### DIFF
--- a/lib/plugins/deployer/openshift.js
+++ b/lib/plugins/deployer/openshift.js
@@ -4,8 +4,10 @@ var colors = require('colors'),
   spawn = require('child_process').spawn,
   util = require('../../util'),
   file = util.file2,
-  commitMessage = require('./util').commitMessage;
-  async = require('async');
+  commitMessage = require('./util').commitMessage,
+  async = require('async'),
+  fs = require('graceful-fs'); //required for chmod on testrubyserver.rb;
+
 
 var run = function(command, args, callback){
   var cp = spawn(command, args);
@@ -48,10 +50,14 @@ module.exports = function(args, callback){
 
   async.series([
     function(next){
+      file.copyFile(blogDir+'/testrubyserver.rb', publicDir);
       file.rmdir(blogDir, next);
     },
     function(next){
       file.copyDir(publicDir, blogDir, next);
+    },
+    function(next){
+      fs.chmod(blogDir+'/testrubyserver.rb',0777,next);
     },
     function(next){
       var commands = [


### PR DESCRIPTION
Fixed the following issues:
- missing async variable making the async function not working
- root directory should be declared
- diy directory pointed at wrong location
- openshift uses a testrubyserver.rb file to deploy, original function removed this file. The testrubyserver.rb file should be executable for openshift to function
