### PR TITLE
Use ul tag to avoid duplicated prefixing indexes.

### DIFF
--- a/lib/plugins/helper/toc.js
+++ b/lib/plugins/helper/toc.js
@@ -12,7 +12,7 @@ module.exports = function(str, options){
 
   var headings = str.match(rHeadingAll),
     data = [],
-    result = '<ol class="' + options.class + '">',
+    result = '<ul class="' + options.class + '">',
     lastNumber = {},
     firstLevel = 0,
     lastLevel = 0,
@@ -51,10 +51,10 @@ module.exports = function(str, options){
     }
 
     for (i = level; i < lastLevel; i++){
-      result += '</ol>';
+      result += '</ul>';
     }
 
-    if (level > lastLevel) result += '<ol class="' + options.class + '-child">';
+    if (level > lastLevel) result += '<ul class="' + options.class + '-child">';
 
     if (options.list_number){
       number += '<span class="' + options.class + '-number">';
@@ -75,7 +75,7 @@ module.exports = function(str, options){
     lastLevel = level;
   });
 
-  result += '</ol>';
+  result += '</ul>';
 
   return result;
 };


### PR DESCRIPTION
When I tried to use `toc` helper, there are indexes generated by it and also the indexes generated by `ol` tag, resulting something like this:

<ol>
  <li> 1. Level 1 Heading </li>
  <li> 2. Level 1 Heading </li>
  <ol>
    <li> 2.1 Level 2 Heading </li>
  </ol>
</ol>


P.S.
I am trying to add a argument in `toc` helper to limit the levels of headings that it generate. I tried to abort the generation process using `if (level > 2) return;` in several different places inside `toc.js`. But nothing stops it. HELP 😄 
