### PR TITLE
fix blank lines for #792 #774

### DIFF
--- a/lib/util/highlight.js
+++ b/lib/util/highlight.js
@@ -88,8 +88,8 @@ module.exports = function(str, options){
     firstLine = options.first_line;
 
   lines.forEach(function(item, i){
-    numbers += '<div class="line">' + (i + firstLine) + '</div>';
-    content += '<div class="line">' + item + '</div>';
+    numbers += '<span class="line">' + (i + firstLine) + '</span>\n';
+    content += '<span class="line">' + item + '</span>\n';
   });
 
   var result = '<figure class="highlight' + (options.lang ? ' ' + options.lang : '') + '">' +


### PR DESCRIPTION
@tommy351 wrapped each line with `<div class="line">` to fix #687, however, there was a problem with codes with blank lines just like #792 and #774.

Adding css style for `.line` may be a solution,  but it's hard to let all the themes change their css files, I think using `span` instead of `div` and adding `\n` for each line can fix this issue without changing the css files, but I am not sure whether it will cause the same problem in #687. (I don't have the same problem in that issue before wrapping the line with `div`).
