### PR TITLE
Escape file name

### DIFF
--- a/lib/util/escape.js
+++ b/lib/util/escape.js
@@ -21,11 +21,13 @@
 
 var FILE_NAME_ESCAPE_REGEX = /[\s~`!@#\$%\^&\*\(\)\-_\+=\[\]\{\}\|\\;:"'<>,\.\?\/]/g;
 var CONTINUES_DASH_REGEX = /-{1,}/g;
+var TAIL_DASH_REGEX = /-+$/;
 
 exports.filename = function(str, transform){
   var result = exports.diacritic(str.toString())
     .replace(FILE_NAME_ESCAPE_REGEX, '-')
-    .replace(CONTINUES_DASH_REGEX, '-');
+    .replace(CONTINUES_DASH_REGEX, '-')
+    .replace(TAIL_DASH_REGEX, '');
 
   transform = parseInt(transform, 10);
 


### PR DESCRIPTION
Recreate pull request #804

Fix issue #802. Escape all special characters in file name and path. And remove redundant `-` sign as `Octopress`.

Due to issue #803, I cannot run the unit test, so I'm not sure whether this breaks any unit test.
