### PR TITLE
Fix issue #807, add tail `/` to archive links

### DIFF
--- a/lib/plugins/helper/list.js
+++ b/lib/plugins/helper/list.js
@@ -230,7 +230,7 @@ exports.list_archives = function(options){
 
       if (!monthly.length) continue;
 
-      item(i + '/' + (j < 10 ? '0' + j : j), moment({year: i, month: j - 1}).format(format), monthly.length);
+      item(i + '/' + (j < 10 ? '0' + j : j) + '/', moment({year: i, month: j - 1}).format(format), monthly.length);
     }
   }
 


### PR DESCRIPTION
Add `/` to the archive links, enforce `POW` to serve corresponding `index.html` instead of `404`.
