### PR TITLE
change moment.lang() to moment.locale()

### DIFF
--- a/lib/model/types/moment.js
+++ b/lib/model/types/moment.js
@@ -17,7 +17,7 @@ var cast = SchemaMoment.prototype.cast = function(value){
   if (moment.isMoment(value)) return value;
 
   if (hexo.config.language){
-    return moment(value).lang(hexo.config.language.toLowerCase());
+    return moment(value).locale(hexo.config.language.toLowerCase());
   } else {
     return moment(value);
   }


### PR DESCRIPTION
As for moment ^2.8.0, the `moment.lang()` method is deprecated, so we use `locale()` method instead, note that the `localeData()` method refered in the deprecation message is not chainable, please see https://github.com/icambron/moment/commit/a45c1290b57eb9d7953f8bd71ab98736b943b9bc and https://github.com/moment/moment/pull/1819
