### PR TITLE
prevent console.log( http://0.0.0.0:4000 )

### DIFF
--- a/lib/plugins/console/server.js
+++ b/lib/plugins/console/server.js
@@ -13,6 +13,10 @@ module.exports = function(args, callback){
     useDrafts = args.d || args.drafts || config.render_drafts || false,
     root = config.root;
 
+  if(serverIp === '0.0.0.0'){
+    serverIp = 'localhost';
+  }
+
   // If the port setting is invalid, set to the default port 4000
   if (port > 65535 || port < 1){
     port = 4000;


### PR DESCRIPTION
I update hexo from v2.5.7 to v2.8.3

my _config.yml file was create by `hexo init .` hexo@2.5.7

``` yaml
port: 4000
server_ip: 0.0.0.0
```

then I run `hexo serve` , message shows like
`[info] Hexo is running at http://0.0.0.0:4000/. Press Ctrl+C to stop.`

in assets/_config.yml

``` yaml
server_ip: 0.0.0.0  #before v2.8.2
server_ip: localhost #v2.8.2 & after
```

And this url (http://0.0.0.0) is not accessable ...
