### PR TITLE
Fix issue #797, don't render draft assets

### DIFF
--- a/lib/plugins/console/server.js
+++ b/lib/plugins/console/server.js
@@ -20,7 +20,19 @@ module.exports = function(args, callback){
 
   // Drafts
   if (useDrafts) {
-    hexo.extend.processor.register('_drafts/*path', require('../processor/post'));
+    var draftDir = '_drafts/';
+    var draftDirLength = draftDir.length;
+    var regex = require('../processor/index.js').regex;
+    hexo.extend.processor.register(function(path){
+      if (!hexo.render.isRenderable(path)) return false;
+      if (regex.tmpFile.test(path)) return false;
+      if (path.substring(0, draftDirLength) !== draftDir) return false;
+
+      var str = path.substring(draftDirLength);
+      if (!regex.hiddenFile.test(str)) return false;
+
+      return {path: str};
+    }, require('../processor/post'));
   }
 
   hexo.extend.filter.apply('server_middleware', app);


### PR DESCRIPTION
Hexo crashes when draft asset directories have images in them (see #797 ).
This happens because hexo attempts to process images as posts.