### PR TITLE
Fixed #902: a bug of code block caused by span tags that cross multiple lines.

### DIFF
--- a/lib/util/highlight.js
+++ b/lib/util/highlight.js
@@ -10,13 +10,13 @@ hljs.highlightByLine = function(name, value, ignore_illegals) {
   var lines = value.split('\n');
   var state = null;
   lines.forEach(function(line, index) {
-    if (index != 0) result.value += '\n';
+    if (index !== 0) result.value += '\n';
     var tmpRst = hljs.highlight(name, line, ignore_illegals, state);
     state = tmpRst.top;
     result.value += tmpRst.value;
   });
   return result;
-}
+};
 
 var alias = {
   js: 'javascript',

--- a/lib/util/highlight.js
+++ b/lib/util/highlight.js
@@ -5,6 +5,18 @@ hljs.configure({
   classPrefix: ''
 });
 
+hljs.highlightByLine = function(name, value, ignore_illegals) {
+  var result = {value: ''};
+  var lines = value.split('\n');
+  var state = null;
+  lines.forEach(function(line) {
+    var tmpRst = hljs.highlight(name, line, ignore_illegals, state);
+    state = tmpRst.top;
+    result.value += tmpRst.value + '\n';
+  });
+  return result;
+}
+
 var alias = {
   js: 'javascript',
   jscript: 'javascript',
@@ -74,7 +86,7 @@ module.exports = function(str, options){
     if (keys.indexOf(lang) !== -1) lang = alias[lang];
 
     try {
-      compiled = hljs.highlight(lang, str).value;
+      compiled = hljs.highlightByLine(lang, str).value;
     } catch (e){
       compiled = hljs.highlightAuto(str).value;
     }

--- a/lib/util/highlight.js
+++ b/lib/util/highlight.js
@@ -7,7 +7,7 @@ hljs.configure({
 
 hljs.highlightByLine = function(name, value, ignore_illegals) {
   var result = {value: ''};
-  var lines  = value.split('\n');
+  var lines = value.split('\n');
   var state = null;
   lines.forEach(function(line, index) {
     if (index !== 0) result.value += '\n';

--- a/lib/util/highlight.js
+++ b/lib/util/highlight.js
@@ -9,10 +9,11 @@ hljs.highlightByLine = function(name, value, ignore_illegals) {
   var result = {value: ''};
   var lines = value.split('\n');
   var state = null;
-  lines.forEach(function(line) {
+  lines.forEach(function(line, index) {
+    if (index != 0) result.value += '\n';
     var tmpRst = hljs.highlight(name, line, ignore_illegals, state);
     state = tmpRst.top;
-    result.value += tmpRst.value + '\n';
+    result.value += tmpRst.value;
   });
   return result;
 }

--- a/lib/util/highlight.js
+++ b/lib/util/highlight.js
@@ -7,7 +7,7 @@ hljs.configure({
 
 hljs.highlightByLine = function(name, value, ignore_illegals) {
   var result = {value: ''};
-  var lines = value.split('\n');
+  var lines  = value.split('\n');
   var state = null;
   lines.forEach(function(line, index) {
     if (index !== 0) result.value += '\n';


### PR DESCRIPTION
This patch makes sure all tags are enclosed in every line with the
correct syntax class.

Input:
``` java
/**
 * Establishes a contract for reading events stored in arbitrary formats from
 * reliable, resettable streams.
 */
```
Original output:
``` html
<div class="line"><span class="javadoc">/**</div>
<div class="line"> * Establishes a contract for reading events stored in arbitrary formats from</div>
<div class="line"> * reliable, resettable streams.</div>
<div class="line"> */</span></div>
```
With this patch:
``` html
<div class="line"><span class="javadoc">/**</span></div>
<div class="line"><span class="javadoc"> * Establishes a contract for reading events stored in arbitrary formats from</span></div>
<div class="line"><span class="javadoc"> * reliable, resettable streams.</span></div>
<div class="line"><span class="javadoc"> */</span></div>
```