### PR TITLE
use UTC date in permalink to prevent url change

### DIFF
--- a/lib/plugins/filter/new_post_path.js
+++ b/lib/plugins/filter/new_post_path.js
@@ -14,7 +14,7 @@ module.exports = function(data, replace, callback){
     config = hexo.config,
     newPostName = config.new_post_name,
     layout = data.layout,
-    date = data.date,
+    date = moment.utc(data.date),
     slug = data.slug,
     target = '';
 


### PR DESCRIPTION
When I generating posts on my new computer, some posts permalink changed.

![permalink change](http://i1263.photobucket.com/albums/ii623/phoenixlzx/github/001_zpsc275848a.jpg)

Using UTC date time may fix this issue.