### PR TITLE
Rendering Problems of Code Blocks Contain {{ }}

### DIFF
--- a/lib/post/render.js
+++ b/lib/post/render.js
@@ -59,6 +59,7 @@ module.exports = function(source, data, callback){
     function(next){
       try {
         data.content = swig.render(data.content, {
+          varControls: ['{%=', '%}'],
           locals: data,
           filename: source
         });


### PR DESCRIPTION
Fix the bug of rendering post content with Swig, which is a template engine that reads all '{{}}' as a variable.

A solution to  https://github.com/hexojs/hexo/issues/925 https://github.com/hexojs/hexo/issues/924 https://github.com/hexojs/hexo/issues/921 https://github.com/hexojs/hexo/issues/916 https://github.com/hexojs/hexo/issues/910

I didn't test very carefully, please check if it works.