### PR TITLE
Fix typo in this.options for chokidar.

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -21,7 +21,7 @@ var fs = require('graceful-fs'),
 * @constructor
 * @param {String} base
 * @param {Object} [options] See [chokidar](https://github.com/paulmillr/chokidar)
-*   @param {Boolean} [options.presistent=true]
+*   @param {Boolean} [options.persistent=true]
 *   @param {RegExp} [options.ignored=/[\/\\]\./]
 *   @param {Boolean} [options.ignoreInitial=true]
 * @extends EventEmitter
@@ -75,7 +75,7 @@ var Box = module.exports = function Box(base, options){
   * @type Object
   */
   this.options = _.extend({
-    presistent: true,
+    persistent: true,
     ignored: /[\/\\]\./,
     ignoreInitial: true
   }, options);


### PR DESCRIPTION
It’s a pretty simple fix, but `hexo generate --watch` wasn’t working for me without this change.