### PR TITLE
Add a configuration option reverse_order for pagination

### DIFF
--- a/lib/plugins/generator/paginator.js
+++ b/lib/plugins/generator/paginator.js
@@ -12,7 +12,14 @@ var Paginator = function(base, posts, num, total){
   this.total = total;
   this.current = num;
   this.current_url = format(base, num);
+
+  this.reverse_order = config.reverse_order;
+  if (this.reverse_order) {
+    posts = posts.reverse();
+  }
+
   this.posts = posts.slice(perPage * (num - 1), perPage * num);
+
 
   if (num == 1){
     this.prev = 0;


### PR DESCRIPTION
Being able to control the order of the pagination is extremely helpful for me as I'm using hexo to create a site for a novel that I'm writing and would like to enable people to be able to read the book online in chapter order, but the default would be in reverse chapter order, so a small change to the pagination plugin would allow you to specify that you would like to reverse the order of the posts.