### PR TITLE
Open graph fully absolute urls support

### DIFF
--- a/assets/_config.yml
+++ b/assets/_config.yml
@@ -11,7 +11,7 @@ email:
 language:
 
 # URL
-## If your site is put in a subdirectory, set url as 'http://yoursite.com/child' and root as '/child/'
+## If your site is put in a 'child' subdirectory, set url as 'http://yoursite.com' and root as '/child/'
 url: http://yoursite.com
 root: /
 permalink: :year/:month/:day/:title/

--- a/lib/loaders/config.js
+++ b/lib/loaders/config.js
@@ -107,6 +107,10 @@ module.exports = function(callback){
         var config = hexo.config = _.extend(defaults, result);
         hexo.env.init = true;
 
+        if (config.root.charAt(0) !== '/'){
+          config.root = '/' + config.root;
+        }
+
         if (_.last(config.root) !== '/'){
           config.root += '/';
         }

--- a/lib/model/schema.js
+++ b/lib/model/schema.js
@@ -12,9 +12,9 @@ var isEndWith = function(str, last){
 };
 
 var permalinkGetter = function(){
-  var link = url.resolve(hexo.config.url, hexo.config.root);
+  var url = hexo.config.url + hexo.config.root;
 
-  return link + (isEndWith(link, '/') ? '' : '/') + this.path;
+  return url + (isEndWith(url, '/') ? '' : '/') + this.path;
 };
 
 var Post = exports.Post = new Schema({

--- a/lib/model/schema.js
+++ b/lib/model/schema.js
@@ -12,9 +12,9 @@ var isEndWith = function(str, last){
 };
 
 var permalinkGetter = function(){
-  var url = hexo.config.url + hexo.config.root;
+  var link = url.resolve(hexo.config.url, hexo.config.root);
 
-  return url + (isEndWith(url, '/') ? '' : '/') + this.path;
+  return link + (isEndWith(link, '/') ? '' : '/') + this.path;
 };
 
 var Post = exports.Post = new Schema({

--- a/lib/model/schema.js
+++ b/lib/model/schema.js
@@ -12,7 +12,7 @@ var isEndWith = function(str, last){
 };
 
 var permalinkGetter = function(){
-  var url = hexo.config.url;
+  var url = hexo.config.url + hexo.config.root;
 
   return url + (isEndWith(url, '/') ? '' : '/') + this.path;
 };

--- a/lib/plugins/filter/external_link.js
+++ b/lib/plugins/filter/external_link.js
@@ -21,8 +21,8 @@ module.exports = function(data, callback){
     // Exit if the link doesn't have protocol, which means it's a internal link
     if (!data.protocol) return;
 
-    // Exit if the url is started with site url
-    if (data.hostname === config.url) return match;
+    // Exit if the url is on the site fomain
+    if (data.hostname === url.parse(config.url).hostname) return match;
 
     $(this)
       .attr('target', '_blank')

--- a/lib/plugins/helper/form.js
+++ b/lib/plugins/helper/form.js
@@ -12,6 +12,6 @@ exports.search_form = function(opts){
   return '<form action="//google.com/search" method="get" accept-charset="UTF-8" class="' + options.class + '">' +
     '<input type="search" name="q" results="0" class="' + options.class + '-input"' + (options.text ? ' placeholder="' + options.text + '"' : '') + '>' +
     (options.button ? '<input type="submit" value="' + (typeof options.button === 'string' ? options.button : options.text) + '" class="' + options.class + '-submit">' : '') +
-    '<input type="hidden" name="q" value="site:' + config.url + '">' +
+    '<input type="hidden" name="q" value="site:' + config.url + config.root + '">' +
     '</form>';
 };

--- a/lib/plugins/helper/form.js
+++ b/lib/plugins/helper/form.js
@@ -1,4 +1,5 @@
-var _ = require('lodash');
+var _ = require('lodash'),
+  url = require('url');
 
 exports.search_form = function(opts){
   var options = _.extend({
@@ -12,6 +13,6 @@ exports.search_form = function(opts){
   return '<form action="//google.com/search" method="get" accept-charset="UTF-8" class="' + options.class + '">' +
     '<input type="search" name="q" results="0" class="' + options.class + '-input"' + (options.text ? ' placeholder="' + options.text + '"' : '') + '>' +
     (options.button ? '<input type="submit" value="' + (typeof options.button === 'string' ? options.button : options.text) + '" class="' + options.class + '-submit">' : '') +
-    '<input type="hidden" name="q" value="site:' + config.url + config.root + '">' +
+    '<input type="hidden" name="q" value="site:' + url.resolve(config.url, config.root) + '">' +
     '</form>';
 };

--- a/lib/plugins/helper/form.js
+++ b/lib/plugins/helper/form.js
@@ -1,5 +1,4 @@
-var _ = require('lodash'),
-  url = require('url');
+var _ = require('lodash');
 
 exports.search_form = function(opts){
   var options = _.extend({
@@ -13,6 +12,6 @@ exports.search_form = function(opts){
   return '<form action="//google.com/search" method="get" accept-charset="UTF-8" class="' + options.class + '">' +
     '<input type="search" name="q" results="0" class="' + options.class + '-input"' + (options.text ? ' placeholder="' + options.text + '"' : '') + '>' +
     (options.button ? '<input type="submit" value="' + (typeof options.button === 'string' ? options.button : options.text) + '" class="' + options.class + '-submit">' : '') +
-    '<input type="hidden" name="q" value="site:' + url.resolve(config.url, config.root) + '">' +
+    '<input type="hidden" name="q" value="site:' + config.url + config.root + '">' +
     '</form>';
 };

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -26,7 +26,6 @@ module.exports = function(options){
   var page = this.page,
     config = this.config || hexo.config,
     content = page.content,
-    images = page.photos || [],
     self = this;
 
   var description = page.description || '';
@@ -45,15 +44,6 @@ module.exports = function(options){
     .replace(/\"/g, '\'')
     .replace(/\>/g, "&amp;");
 
-  if (!images.length && content){
-    var $ = cheerio.load(content);
-
-    $('img').each(function(){
-      var src = $(this).attr('src');
-      if (src) images.push(src);
-    });
-  }
-
   var data = _.extend({
     title: page.title || config.title,
     type: this.is_post() ? 'article' : 'website',
@@ -71,16 +61,33 @@ module.exports = function(options){
 
   var str = '';
 
+  if (!data.image){
+    var images = page.photos || [];
+    if (!images.length && content){
+      var $ = cheerio.load(content);
+
+      $('img').each(function(){
+        var src = $(this).attr('src');
+        if (src) images.push(src);
+      });
+    }
+    data.image = images;
+  }
+
+  if (!_.isArray(data.image)){
+    data.image = [data.image];
+  }
+
+  data.image.forEach(function(image){
+    str += metaTag('og:image', self.url_for(image, {absolute: true}));
+  });
+
   str += metaTag('description', data.description);
   str += metaTag('og:type', data.type);
   str += metaTag('og:title', data.title);
   str += metaTag('og:url', data.url);
   str += metaTag('og:site_name', data.site_name);
   str += metaTag('og:description', data.description);
-
-  images.forEach(function(image){
-    str += metaTag('og:image', self.url_for(image, {absolute: true}));
-  });
 
   str += metaTag('twitter:card', data.twitter_card);
   str += metaTag('twitter:title', data.title);

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -26,7 +26,8 @@ module.exports = function(options){
   var page = this.page,
     config = this.config || hexo.config,
     content = page.content,
-    images = page.photos || [];
+    images = page.photos || [],
+    self = this;
 
   var description = page.description || '';
 
@@ -78,7 +79,7 @@ module.exports = function(options){
   str += metaTag('og:description', data.description);
 
   images.forEach(function(image){
-    str += metaTag('og:image', image);
+    str += metaTag('og:image', self.url_for(image, {absolute: true}));
   });
 
   str += metaTag('twitter:card', data.twitter_card);

--- a/lib/plugins/helper/url.js
+++ b/lib/plugins/helper/url.js
@@ -39,15 +39,16 @@ exports.relative_url = function(from, to){
   return out.join('/');
 };
 
-exports.url_for = function(path){
+exports.url_for = function(path, options){
   path = path || '/';
+  absolute = options && 'absolute' in options ? options.absolute : false;
 
   var config = this.config || hexo.config,
     root = config.root,
     data = url.parse(path);
 
   if (!data.protocol && path.substring(0, 2) !== '//'){
-    if (config.relative_link){
+    if (!absolute && config.relative_link){
       path = this.relative_url(this.path, path);
     } else {
       if (path.substring(0, root.length) !== root){
@@ -56,6 +57,9 @@ exports.url_for = function(path){
         } else {
           path = root + path;
         }
+      }
+      if (absolute) {
+        path = config.url + path;
       }
     }
   }

--- a/test/scripts/helper/url.js
+++ b/test/scripts/helper/url.js
@@ -46,6 +46,30 @@ describe('url_for', function(){
     }, 'index.html').should.eql('../../index.html');
   });
 
+  it('internal url (absolute)', function(){
+    url_for.call({
+      config: {url: 'http://hexo.io', root: '/'},
+      relative_url: relative_url
+    }, 'index.html', {absolute:true}).should.eql('http://hexo.io/index.html');
+
+    url_for.call({
+      config: {url: 'http://hexo.io', root: '/blog/'},
+      relative_url: relative_url
+    }, 'index.html', {absolute:true}).should.eql('http://hexo.io/blog/index.html');
+
+    url_for.call({
+      config: {url: 'http://hexo.io', root: '/', relative_link: true},
+      path: '',
+      relative_url: relative_url
+    }, 'index.html', {absolute:true}).should.eql('http://hexo.io/index.html');
+
+    url_for.call({
+      config: {url: 'http://hexo.io', root: '/', relative_link: true},
+      path: 'foo/bar/',
+      relative_url: relative_url
+    }, 'index.html', {absolute:true}).should.eql('http://hexo.io/index.html');
+  });
+
   it('external url', function(){
     [
       'http://zespia.tw/',


### PR DESCRIPTION
- Fixes the issue https://github.com/hexojs/hexo/issues/942
- Allows using fully absolute urls for og image tags (which is mandatory for Facebook).
- Fixes [poor external link detection](https://github.com/guiohm/hexo/commit/b424e11bfd3fd13f5978439eca545f45dbf547af#diff-62e9cf90d8889a8a3819d3cd1341272dL25)

I don't quite understand why the optional subdirectory had to be added on both `config.url`and `config.root`.
I believe this is more relevant now.
