### PR TITLE
Adding save files feature to keep files in public folder from deletion

### DIFF
--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -139,6 +139,8 @@ module.exports = function(args, callback){
       // Clear old files
       clear: ['list', function(next, results){
         var list = _.difference(results.list, keys);
+        var savefiles = hexo.config.savefiles;
+        list = _.difference(list, savefiles);
 
         async.each(list, function(i, next){
           var dest = pathFn.join(publicDir, i);


### PR DESCRIPTION
Hi, I really want to add this feature to Hexo, so that the "hexo generate" command would not remove files that the users specified not to delete. Some files would have to be in the public folder (e.g. CNAME, robots.txt, sitemap.xml, etc..), which makes blog generation more complicated since Hexo deletes these files in default.

Users could put in a field in Hexo config files which files not to delete. Like following:

```
savefiles:
  - CNAME
  - robots.txt
  - sitemap.xml
  - favicon.png
```

This feature has passed tests in my own repo. I'd appreciate it if you could add this feature to Hexo!