### PR TITLE
Adding save files to keep files from generator deletion

### DIFF
--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -52,7 +52,9 @@ function generateConsole(args){
 
   function cleanFiles(files){
     var deleted = _.difference(files, route.list());
-
+    var savefiles = hexo.config.savefiles;
+    deleted = _.difference(files, savefiles);
+    
     return Promise.each(deleted, deleteFile);
   }
 


### PR DESCRIPTION
Same as https://github.com/hexojs/hexo/pull/996. To save files from deletion from hexo generator.

Add in the config file to keep the files from deletion. For example:

```
savefiles:
  - CNAME
  - robots.txt
  - sitemap.xml
  - favicon.png
```

