### PR TITLE
Default to using ISO-8601 date format

### DIFF
--- a/assets/_config.yml
+++ b/assets/_config.yml
@@ -51,8 +51,8 @@ tag_map:
 ## Hexo uses Moment.js to parse and display date
 ## You can customize the date format as defined in
 ## http://momentjs.com/docs/#/displaying/format/
-date_format: MMM D YYYY
-time_format: H:mm:ss
+date_format: YYYY-MM-DD
+time_format: HH:mm:ss
 
 # Pagination
 ## Set per_page to 0 to disable pagination

--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -42,8 +42,8 @@ module.exports = {
   category_map: {},
   tag_map: {},
   // Date / Time format
-  date_format: 'MMM D YYYY',
-  time_format: 'H:mm:ss',
+  date_format: 'YYYY-MM-DD',
+  time_format: 'HH:mm:ss',
   // Pagination
   per_page: 10,
   pagination_dir: 'page',


### PR DESCRIPTION
We should encourage people use use the ISO standard date by making it the default.

[If we really need a why...](http://xkcd.com/1179/)