### PR TITLE
Add support for swig-extra

### DIFF
--- a/lib/plugins/renderer/swig.js
+++ b/lib/plugins/renderer/swig.js
@@ -10,7 +10,6 @@ extras.useTag(swig, 'case');
 
 extras.useFilter(swig, 'batch');
 extras.useFilter(swig, 'groupby');
-extras.useFilter(swig, 'indent');
 extras.useFilter(swig, 'markdown');
 extras.useFilter(swig, 'nl2br');
 extras.useFilter(swig, 'pluck');

--- a/lib/plugins/renderer/swig.js
+++ b/lib/plugins/renderer/swig.js
@@ -1,7 +1,22 @@
 'use strict';
 
 var swig = require('swig');
+var extras = require('swig-extras');
 var forTag = require('swig/lib/tags/for');
+
+extras.useTag(swig, 'markdown');
+extras.useTag(swig, 'switch');
+extras.useTag(swig, 'case');
+
+extras.useFilter(swig, 'batch');
+extras.useFilter(swig, 'groupby');
+extras.useFilter(swig, 'indent');
+extras.useFilter(swig, 'markdown');
+extras.useFilter(swig, 'nl2br');
+extras.useFilter(swig, 'pluck');
+extras.useFilter(swig, 'split');
+extras.useFilter(swig, 'trim');
+extras.useFilter(swig, 'truncate');
 
 swig.setDefaults({
   cache: false,

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "pretty-hrtime": "^1.0.0",
     "strip-indent": "^1.0.0",
     "swig": "1.4.2",
+    "swig-extras": "0.0.1",
     "text-table": "^0.2.0",
     "through2": "^1.1.1",
     "tildify": "^1.0.0",


### PR DESCRIPTION
Adds support for `swig-extra`, enabling a bunch of filters and tags to the swig templating included by default.

Had some free time and this was easy to code so feel free to merge/discard as you see fit.

Explained on #1150
 
### Adds the following:
#### Filters
batch
groupby
indent
markdown
nl2br
pluck
split
trim
truncate

#### Tags:
markdown
switch/case