### PR TITLE
fix child categories duplication issue

### DIFF
--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -126,9 +126,12 @@ module.exports = function(ctx){
     // MUST USE "Promise.each".
     return Promise.each(cats, function(cat, i){
       // Find the category by name
+      // Note that cats[i - 1] refers to the name of parent category,
+      // not the CUID, but arr[i - 1] is the CUID of parent category.
+      // Category needs parent's CUID to detect category duplication
       var data = Category.findOne({
         name: cat,
-        parent: i ? cats[i - 1] : {$exists: false}
+        parent: i ? arr[i - 1] : {$exists: false}
       });
 
       if (data){


### PR DESCRIPTION
I note that cats[i - 1] refers to the name of parent category, not the CUID, but arr[i - 1] is the CUID of parent category, and Category schema needs parent's CUID to detect category duplication. So I changed cats[i - 1] to arr[i - 1].

Front-matter:
```yml
categories: 
- Front-End
- JavaScript
```

Child categories before fix:
![before](https://cloud.githubusercontent.com/assets/8849362/6885207/70fad064-d648-11e4-83cb-286d17c8d895.png)

Child categories after fix:
![after](https://cloud.githubusercontent.com/assets/8849362/6885233/ebc7f178-d648-11e4-9b2b-66ae5360ea66.png)
