### PR TITLE
Correct the spelling from generatd to generated.

### DIFF
--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -121,7 +121,7 @@ function generateConsole(args){
       ]);
     }).spread(function(count){
       var interval = prettyHrtime(process.hrtime(start));
-      log.info('%d files generatd in %s', count, chalk.cyan(interval));
+      log.info('%d files generated in %s', count, chalk.cyan(interval));
     });
   }
 


### PR DESCRIPTION
Correct the spelling from `generatd` to `generated` for the file <https://github.com/hexojs/hexo/blob/master/lib/plugins/console/generate.js#L124> at line 124.