### PR TITLE
Change rendering order

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -271,6 +271,17 @@ Post.prototype.render = function(source, data, callback){
     return '<!--' + placeholder + (cache.push(str) - 1) + '-->';
   }
 
+  function tagFilter(content) {
+    // Replace cache data with real contents
+    content = content.replace(rPlaceholder, function(){
+      return cache[arguments[1]];
+    });
+
+    // Render with Nunjucks
+    data.content = content;
+    return tag.render(data.content, data);
+  }
+
   return new Promise(function(resolve, reject){
     if (data.content != null) return resolve(data.content);
     if (!source) return reject(new Error('No input file or string!'));
@@ -305,16 +316,15 @@ Post.prototype.render = function(source, data, callback){
       text: data.content,
       path: source,
       engine: data.engine,
-      toString: true
+      toString: true,
+      onRenderEnd: tagFilter
     }, options);
   }).then(function(content){
-    // Replace cache data with real contents
-    data.content = content.replace(rPlaceholder, function(){
-      return cache[arguments[1]];
-    });
+    data.content = content;
 
-    // Clean cache
-    cache.length = 0;
+    if (!isSwig) {
+      return data.content;
+    }
 
     // Render with Nunjucks
     return tag.render(data.content, data);

--- a/lib/hexo/render.js
+++ b/lib/hexo/render.js
@@ -89,12 +89,12 @@ Render.prototype.renderSync = function(data, options){
     result = data.text;
   }
 
+  var output = this.getOutput(ext) || ext;
+  result = toString(result, data);
+
   if (data.onRenderEnd) {
     result = data.onRenderEnd(result);
   }
-
-  var output = this.getOutput(ext) || ext;
-  result = toString(result, data);
 
   return ctx.execFilterSync('after_render:' + output, result, {
     context: ctx,

--- a/lib/hexo/render.js
+++ b/lib/hexo/render.js
@@ -50,9 +50,14 @@ Render.prototype.render = function(data, options, callback){
     var renderer = self.renderer.get(ext);
     return renderer.call(ctx, data, options);
   }).then(function(result){
-    var output = self.getOutput(ext) || ext;
     result = toString(result, data);
-
+    if (data.onRenderEnd) {
+      return data.onRenderEnd(result);
+    } else {
+      return result;
+    }
+  }).then(function(result) {
+    var output = self.getOutput(ext) || ext;
     return ctx.execFilter('after_render:' + output, result, {
       context: ctx,
       args: [data]
@@ -82,6 +87,10 @@ Render.prototype.renderSync = function(data, options){
     result = renderer.call(ctx, data, options);
   } else {
     result = data.text;
+  }
+
+  if (data.onRenderEnd) {
+    result = data.onRenderEnd(result);
   }
 
   var output = this.getOutput(ext) || ext;

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -542,4 +542,21 @@ describe('Post', function(){
       data.content.trim().should.eql('<p><code>{{ test }}</code></p>');
     });
   });
+
+  it('render() - recover escaped swig blocks which is html escaped before post_render', function(){
+    var content = '`{% raw %}{{ test }}{% endraw %}`';
+
+    var filter = sinon.spy(function(result) {
+      result.trim().should.eql('<p><code>{{ test }}</code></p>');
+    });
+    hexo.extend.filter.register('after_render:html', filter);
+
+    return post.render(null, {
+      content: content,
+      engine: 'markdown'
+    }).then(function(data){
+      filter.calledOnce.should.be.true;
+      hexo.extend.filter.unregister('after_render:html', filter);
+    });
+  });
 });

--- a/test/scripts/hexo/render.js
+++ b/test/scripts/hexo/render.js
@@ -181,6 +181,29 @@ describe('Render', function(){
     });
   });
 
+  it('render() - onRenderEnd method', function() {
+    var onRenderEnd = sinon.spy(function(result) {
+      return result + 'bar';
+    });
+    var data = {
+      text: 'foo',
+      engine: 'txt',
+      onRenderEnd: onRenderEnd
+    };
+
+    var filter = sinon.spy(function(result) {
+      result.should.eql('foobar');
+    });
+    hexo.extend.filter.register('after_render:txt', filter);
+
+    return hexo.render.render(data).then(function(result){
+      onRenderEnd.calledOnce.should.be.true;
+      filter.calledOnce.should.be.true;
+
+      hexo.extend.filter.unregister('after_render:txt', filter);
+    });
+  });
+
   it('renderSync() - path', function(){
     var result = hexo.render.renderSync({path: path});
     result.should.eql(obj);
@@ -278,6 +301,29 @@ describe('Render', function(){
     var result = hexo.render.renderSync(data);
 
     filter.calledOnce.should.be.true;
+    hexo.extend.filter.unregister('after_render:txt', filter);
+  });
+
+  it('renderSync() - onRenderEnd', function(){
+    var onRenderEnd = sinon.spy(function(result) {
+      return result + 'bar';
+    });
+    var data = {
+      text: 'foo',
+      engine: 'txt',
+      onRenderEnd: onRenderEnd
+    };
+
+    var filter = sinon.spy(function(result) {
+      result.should.eql('foobar');
+    });
+    hexo.extend.filter.register('after_render:txt', filter);
+
+    var result = hexo.render.renderSync(data);
+
+    onRenderEnd.calledOnce.should.be.true;
+    filter.calledOnce.should.be.true;
+
     hexo.extend.filter.unregister('after_render:txt', filter);
   });
 });


### PR DESCRIPTION
To fix #1166, We must render tag plugins before 'post_render' filter works.

I added data.onRenderEnd field to render() and renderSync().
This field is a function that receives rendered content and returns processed content.

Now tag plugins be rendered in this function.

Please use this as material for further discussion.