### PR TITLE
Fix the problem that occurs when every tag has the same number of posts.

### DIFF
--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -214,12 +214,12 @@ function tagcloudHelper(tags, options){
   var length = sizes.length - 1;
 
   tags.forEach(function(tag){
-    var index = sizes.indexOf(tag.length);
-    var size = min + (max - min) / length * index;
+    var ratio = length? (sizes.indexOf(tag.length) / length): 0;
+    var size = min + (max - min) * ratio;
     var style = 'font-size: ' + parseFloat(size.toFixed(2)) + unit + ';';
 
     if (color){
-      var midColor = startColor.mix(endColor, index / length);
+      var midColor = startColor.mix(endColor, ratio);
       style += ' color: ' + midColor.toString();
     }
 

--- a/test/scripts/helpers/tagcloud.js
+++ b/test/scripts/helpers/tagcloud.js
@@ -75,6 +75,19 @@ describe('tagcloud', function(){
     ].join(''));
   });
 
+  it('font size - when every tag has the same number of posts, font-size should be minimum.', function() {
+    var result = tagcloud(Tag.find({
+      name: /abc/
+    }), {
+      min_font: 15,
+      max_font: 30
+    });
+
+    result.should.eql([
+      '<a href="/tags/abc/" style="font-size: 15px;">abc</a>'
+    ].join(''));
+  });
+
   it('font unit', function(){
     var result = tagcloud({
       unit: 'em'
@@ -199,4 +212,19 @@ describe('tagcloud', function(){
       '<a href="/tags/def/" style="font-size: 10px; color: rgba(70, 130, 180, 0.3)">def</a>'
     ].join(''));
   });
+
+  it('color - when every tag has the same number of posts, start_color should be used.', function() {
+    var result = tagcloud(Tag.find({
+      name: /abc/
+    }), {
+      color: true,
+      start_color: 'red',
+      end_color: 'pink'
+    });
+
+    result.should.eql([
+      '<a href="/tags/abc/" style="font-size: 10px; color: #f00">abc</a>'
+    ].join(''));
+  });
+
 });


### PR DESCRIPTION
If every tag has the same number of posts, tagcloud was broken because of division by zero.

Now every tag share the lowest level in this case.

  * font ... smallest
  * color ... same with start_color

this PR will fix #1123 .