### PR TITLE
Use npm v2.x at AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,8 @@ matrix:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
-  - cmd: npm update -g npm
+  - cmd: npm install -g npm@2
+  - set PATH=%APPDATA%\npm;%PATH%
   - npm install
 
 # Post-install test scripts.


### PR DESCRIPTION
During test at AppVeyor, sometimes error occurs such like https://ci.appveyor.com/project/tommy351/hexo/build/145/job/iyx86d12grv6ficy .

About this problem, AppVeyor support said "Use npm v2" ( http://help.appveyor.com/discussions/questions/534-npm-cache#comment_35761655 ) .

So I modified appveyor.yml.