### PR TITLE
More strict error assertion

### DIFF
--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -67,7 +67,7 @@ module.exports = function(ctx){
       parent: parent || {$exists: false}
     });
 
-    if (cat && cat._id === data._id){
+    if (cat){
       throw new Error('Category `' + name + '` has already existed!');
     }
   });

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -53,7 +53,7 @@ module.exports = function(ctx){
     var Tag = ctx.model('Tag');
     var tag = Tag.findOne({name: name});
 
-    if (tag && tag._id === data._id){
+    if (tag){
       throw new Error('Tag `' + name + '` has already existed!');
     }
   });

--- a/test/scripts/box/box.js
+++ b/test/scripts/box/box.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
@@ -85,6 +86,7 @@ describe('Box', function(){
 
     try {
       box.addProcessor('test');
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'fn must be a function');
     }
@@ -432,7 +434,9 @@ describe('Box', function(){
     var box = newBox();
 
     box.watch().then(function(){
-      box.watch().catch(function(err){
+      box.watch().then(function(){
+        assert.fail();
+      }).catch(function(err){
         err.should.have.property('message', 'Watcher has already started.');
         box.unwatch();
         callback();
@@ -485,6 +489,7 @@ describe('Box', function(){
 
     try {
       box.unwatch();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'Watcher hasn\'t started yet.');
     }

--- a/test/scripts/box/box.js
+++ b/test/scripts/box/box.js
@@ -1,12 +1,12 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
 var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
 var crypto = require('crypto');
 var util = require('hexo-util');
+var sinon = require('sinon');
 var Pattern = util.Pattern;
 var testUtil = require('../../util');
 
@@ -83,13 +83,17 @@ describe('Box', function(){
 
   it('addProcessor() - no fn', function(){
     var box = newBox();
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'fn must be a function');
+    });
 
     try {
       box.addProcessor('test');
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'fn must be a function');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('_loadFiles() - create', function(){
@@ -432,13 +436,16 @@ describe('Box', function(){
 
   it.skip('watch() - watcher has started', function(callback){
     var box = newBox();
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'Watcher has already started.');
+    });
 
     box.watch().then(function(){
-      box.watch().then(function(){
-        assert.fail();
-      }).catch(function(err){
-        err.should.have.property('message', 'Watcher has already started.');
+      box.watch().catch(function(err){
+        errorCallback(err);
         box.unwatch();
+      }).finally(function() {
+        errorCallback.calledOnce.should.be.false;
         callback();
       });
     });
@@ -486,13 +493,17 @@ describe('Box', function(){
 
   it('unwatch() - watcher not started', function(){
     var box = newBox();
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'Watcher hasn\'t started yet.');
+    });
 
     try {
       box.unwatch();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'Watcher hasn\'t started yet.');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it.skip('isWatching()', function(){

--- a/test/scripts/extend/filter.js
+++ b/test/scripts/extend/filter.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
 var sinon = require('sinon');
 
 describe('Filter', function(){
@@ -76,24 +75,32 @@ describe('Filter', function(){
 
   it('unregister() - type is required', function(){
     var f = new Filter();
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'type is required');
+    });
 
     try {
       f.unregister();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'type is required');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('unregister() - fn must be a function', function(){
     var f = new Filter();
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'fn must be a function');
+    });
 
     try {
       f.unregister('test');
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'fn must be a function');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('list()', function(){

--- a/test/scripts/extend/filter.js
+++ b/test/scripts/extend/filter.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var sinon = require('sinon');
 
 describe('Filter', function(){
@@ -78,6 +79,7 @@ describe('Filter', function(){
 
     try {
       f.unregister();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'type is required');
     }
@@ -88,6 +90,7 @@ describe('Filter', function(){
 
     try {
       f.unregister('test');
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'fn must be a function');
     }

--- a/test/scripts/extend/tag.js
+++ b/test/scripts/extend/tag.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var Promise = require('bluebird');
 
 describe('Tag', function(){
@@ -125,6 +126,7 @@ describe('Tag', function(){
   it('register() - name is required', function(){
     try {
       tag.register();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'name is required');
     }
@@ -133,6 +135,7 @@ describe('Tag', function(){
   it('register() - fn must be a function', function(){
     try {
       tag.register('test');
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'fn must be a function');
     }

--- a/test/scripts/extend/tag.js
+++ b/test/scripts/extend/tag.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var Promise = require('bluebird');
 
 describe('Tag', function(){
@@ -124,21 +124,31 @@ describe('Tag', function(){
   });
 
   it('register() - name is required', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'name is required');
+    });
+
     try {
       tag.register();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'name is required');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('register() - fn must be a function', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'fn must be a function');
+    });
+
     try {
       tag.register('test');
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'fn must be a function');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('render() - context', function(){

--- a/test/scripts/filters/new_post_path.js
+++ b/test/scripts/filters/new_post_path.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var pathFn = require('path');
 var moment = require('moment');
 var Promise = require('bluebird');
@@ -170,7 +171,9 @@ describe('new_post_path', function(){
   });
 
   it('data is required', function(){
-    return newPostPath().catch(function(err){
+    return newPostPath().then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', 'Either data.path or data.slug is required!');
     });
   });

--- a/test/scripts/filters/new_post_path.js
+++ b/test/scripts/filters/new_post_path.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var pathFn = require('path');
 var moment = require('moment');
 var Promise = require('bluebird');
@@ -171,10 +171,12 @@ describe('new_post_path', function(){
   });
 
   it('data is required', function(){
-    return newPostPath().then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err){
       err.should.have.property('message', 'Either data.path or data.slug is required!');
+    });
+
+    return newPostPath().catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 });

--- a/test/scripts/helpers/partial.js
+++ b/test/scripts/helpers/partial.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
@@ -81,11 +81,16 @@ describe('partial', function(){
   });
 
   it('name must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'name must be a string!');
+    });
+
     try {
       partial();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'name must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 });

--- a/test/scripts/helpers/partial.js
+++ b/test/scripts/helpers/partial.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
@@ -82,6 +83,7 @@ describe('partial', function(){
   it('name must be a string', function(){
     try {
       partial();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'name must be a string!');
     }

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
 var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
@@ -90,10 +89,12 @@ describe('Hexo', function(){
   });
 
   it('call() - console not registered', function(){
-    return hexo.call('nothing').then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err){
       err.should.have.property('message', 'Console `nothing` has not been registered yet!');
+    });
+
+    return hexo.call('nothing').catch(errorCallback).finally(function(){
+      errorCallback.calledOnce.should.be.true;
     });
   });
 

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
@@ -89,7 +90,9 @@ describe('Hexo', function(){
   });
 
   it('call() - console not registered', function(){
-    return hexo.call('nothing').catch(function(err){
+    return hexo.call('nothing').then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', 'Console `nothing` has not been registered yet!');
     });
   });

--- a/test/scripts/hexo/locals.js
+++ b/test/scripts/hexo/locals.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 
 describe('Locals', function(){
   var Locals = require('../../../lib/hexo/locals');
@@ -9,6 +10,7 @@ describe('Locals', function(){
   it('get() - name must be a string', function(){
     try {
       locals.get();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'name must be a string!');
     }
@@ -34,6 +36,7 @@ describe('Locals', function(){
   it('set() - name must be a string', function(){
     try {
       locals.set();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'name must be a string!');
     }
@@ -42,6 +45,7 @@ describe('Locals', function(){
   it('set() - value is required', function(){
     try {
       locals.set('test');
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'value is required!');
     }
@@ -59,6 +63,7 @@ describe('Locals', function(){
   it('remove() - name must be a string', function(){
     try {
       locals.remove();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'name must be a string!');
     }

--- a/test/scripts/hexo/locals.js
+++ b/test/scripts/hexo/locals.js
@@ -1,19 +1,24 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 
 describe('Locals', function(){
   var Locals = require('../../../lib/hexo/locals');
   var locals = new Locals();
 
   it('get() - name must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'name must be a string!');
+    });
+
     try {
       locals.get();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'name must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('set() - function', function(){
@@ -34,21 +39,31 @@ describe('Locals', function(){
   });
 
   it('set() - name must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'name must be a string!');
+    });
+
     try {
       locals.set();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'name must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('set() - value is required', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'value is required!');
+    });
+
     try {
       locals.set('test');
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'value is required!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('remove()', function(){
@@ -61,12 +76,17 @@ describe('Locals', function(){
   });
 
   it('remove() - name must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'name must be a string!');
+    });
+
     try {
       locals.remove();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'name must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('toObject()', function(){

--- a/test/scripts/hexo/render.js
+++ b/test/scripts/hexo/render.js
@@ -99,7 +99,9 @@ describe('Render', function(){
   });
 
   it('render() - no path and text', function(){
-    return hexo.render.render().catch(function(err){
+    return hexo.render.render().then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', 'No input file or string!');
     });
   });
@@ -222,6 +224,7 @@ describe('Render', function(){
   it('renderSync() - no path and text', function(){
     try {
       hexo.render.renderSync();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'No input file or string!');
     }

--- a/test/scripts/hexo/render.js
+++ b/test/scripts/hexo/render.js
@@ -99,10 +99,12 @@ describe('Render', function(){
   });
 
   it('render() - no path and text', function(){
-    return hexo.render.render().then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err){
       err.should.have.property('message', 'No input file or string!');
+    })
+
+    return hexo.render.render().catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 
@@ -222,12 +224,17 @@ describe('Render', function(){
   });
 
   it('renderSync() - no path and text', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'No input file or string!');
+    });
+
     try {
       hexo.render.renderSync();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'No input file or string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('renderSync() - options', function(){

--- a/test/scripts/hexo/router.js
+++ b/test/scripts/hexo/router.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
 var Promise = require('bluebird');
 var Readable = require('stream').Readable;
 var pathFn = require('path');
@@ -59,12 +58,17 @@ describe('Router', function(){
   });
 
   it('format() - path must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'path must be a string!');
+    })
+
     try {
       router.format(function(){});
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'path must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   })
 
   it('set() - string', function(){
@@ -121,21 +125,31 @@ describe('Router', function(){
   });
 
   it('set() - path must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'path must be a string!');
+    });
+
     try {
       router.set();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'path must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('set() - data is required', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'data is required!');
+    });
+
     try {
       router.set('test');
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'data is required!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('get() - error handling', function(){
@@ -143,10 +157,12 @@ describe('Router', function(){
       throw new Error('error test');
     });
 
-    return testUtil.stream.read(router.get('test')).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err){
       err.should.have.property('message', 'error test');
+    });
+
+    return testUtil.stream.read(router.get('test')).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 
@@ -185,12 +201,17 @@ describe('Router', function(){
   });
 
   it('get() - path must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'path must be a string!');
+    });
+
     try {
       router.get();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'path must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('get() - export stringified JSON object', function(){
@@ -220,12 +241,17 @@ describe('Router', function(){
   });
 
   it('isModified() - path must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'path must be a string!');
+    });
+
     try {
       router.isModified();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'path must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 
   it('remove()', function(){
@@ -242,11 +268,16 @@ describe('Router', function(){
   });
 
   it('remove() - path must be a string', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'path must be a string!');
+    });
+
     try {
       router.remove();
-      assert.fail();
     } catch (err){
-      err.should.have.property('message', 'path must be a string!');
+      errorCallback(err);
     }
+
+    errorCallback.calledOnce.should.be.true;
   });
 });

--- a/test/scripts/hexo/router.js
+++ b/test/scripts/hexo/router.js
@@ -60,7 +60,7 @@ describe('Router', function(){
 
   it('format() - path must be a string', function(){
     try {
-      router.format();
+      router.format(function(){});
       assert.fail();
     } catch (err){
       err.should.have.property('message', 'path must be a string!');

--- a/test/scripts/hexo/router.js
+++ b/test/scripts/hexo/router.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var Promise = require('bluebird');
 var Readable = require('stream').Readable;
 var pathFn = require('path');
@@ -60,6 +61,7 @@ describe('Router', function(){
   it('format() - path must be a string', function(){
     try {
       router.format();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'path must be a string!');
     }
@@ -121,6 +123,7 @@ describe('Router', function(){
   it('set() - path must be a string', function(){
     try {
       router.set();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'path must be a string!');
     }
@@ -129,6 +132,7 @@ describe('Router', function(){
   it('set() - data is required', function(){
     try {
       router.set('test');
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'data is required!');
     }
@@ -139,7 +143,9 @@ describe('Router', function(){
       throw new Error('error test');
     });
 
-    return testUtil.stream.read(router.get('test')).catch(function(err){
+    return testUtil.stream.read(router.get('test')).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', 'error test');
     });
   });
@@ -181,6 +187,7 @@ describe('Router', function(){
   it('get() - path must be a string', function(){
     try {
       router.get();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'path must be a string!');
     }
@@ -215,6 +222,7 @@ describe('Router', function(){
   it('isModified() - path must be a string', function(){
     try {
       router.isModified();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'path must be a string!');
     }
@@ -236,6 +244,7 @@ describe('Router', function(){
   it('remove() - path must be a string', function(){
     try {
       router.remove();
+      assert.fail();
     } catch (err){
       err.should.have.property('message', 'path must be a string!');
     }

--- a/test/scripts/models/asset.js
+++ b/test/scripts/models/asset.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var pathFn = require('path');
 
 describe('Asset', function(){
@@ -20,20 +20,24 @@ describe('Asset', function(){
   });
 
   it('_id - required', function(){
-    return Asset.insert({}).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', 'ID is not defined');
+    });
+
+    return Asset.insert({}).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 
   it('path - required', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', '`path` is required!');
+    });
+
     return Asset.insert({
       _id: 'foo'
-    }).then(function(){
-      assert.fail();
-    }).catch(function(err){
-      err.should.have.property('message', '`path` is required!');
+    }).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 

--- a/test/scripts/models/asset.js
+++ b/test/scripts/models/asset.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var pathFn = require('path');
 
 describe('Asset', function(){
@@ -19,7 +20,9 @@ describe('Asset', function(){
   });
 
   it('_id - required', function(){
-    return Asset.insert({}).catch(function(err){
+    return Asset.insert({}).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', 'ID is not defined');
     });
   });
@@ -27,6 +30,8 @@ describe('Asset', function(){
   it('path - required', function(){
     return Asset.insert({
       _id: 'foo'
+    }).then(function(){
+      assert.fail();
     }).catch(function(err){
       err.should.have.property('message', '`path` is required!');
     });

--- a/test/scripts/models/cache.js
+++ b/test/scripts/models/cache.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 
 describe('Cache', function(){
   var Hexo = require('../../../lib/hexo');
@@ -8,7 +9,9 @@ describe('Cache', function(){
   var Cache = hexo.model('Cache');
 
   it('_id - required', function(){
-    return Cache.insert({}).catch(function(err){
+    return Cache.insert({}).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', 'ID is not defined');
     });
   });

--- a/test/scripts/models/cache.js
+++ b/test/scripts/models/cache.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 
 describe('Cache', function(){
   var Hexo = require('../../../lib/hexo');
@@ -9,10 +9,12 @@ describe('Cache', function(){
   var Cache = hexo.model('Cache');
 
   it('_id - required', function(){
-    return Cache.insert({}).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', 'ID is not defined');
+    });
+
+    return Cache.insert({}).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 });

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var Promise = require('bluebird');
 
 describe('Category', function(){
@@ -16,10 +16,12 @@ describe('Category', function(){
   });
 
   it('name - required', function(){
-    return Category.insert({}).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', '`name` is required!');
+    });
+
+    return Category.insert({}).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 
@@ -212,18 +214,22 @@ describe('Category', function(){
   });
 
   it('check whether a category exists', function(){
+    var errorCallback = sinon.spy(function(err){
+      err.should.have.property('message', 'Category `foo` has already existed!');
+    });
+
     return Category.insert({
       name: 'foo'
     }).then(function(data){
+      var errorCall
+
       Category.insert({
         name: 'foo'
-      }).then(function(){
-        assert.fail();
-      }).catch(function(err){
-        err.should.have.property('message', 'Category `foo` has already existed!');
-      });
+      }).catch(errorCallback);
 
       return Category.removeById(data._id);
+    }).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var Promise = require('bluebird');
 
 describe('Category', function(){
@@ -15,7 +16,9 @@ describe('Category', function(){
   });
 
   it('name - required', function(){
-    return Category.insert({}).catch(function(err){
+    return Category.insert({}).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', '`name` is required!');
     });
   });
@@ -214,6 +217,8 @@ describe('Category', function(){
     }).then(function(data){
       Category.insert({
         name: 'foo'
+      }).then(function(){
+        assert.fail();
       }).catch(function(err){
         err.should.have.property('message', 'Category `foo` has already existed!');
       });

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var pathFn = require('path');
 
 describe('Page', function(){
@@ -31,7 +32,9 @@ describe('Page', function(){
   });
 
   it('source - required', function(){
-    return Page.insert({}).catch(function(err){
+    return Page.insert({}).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', '`source` is required!');
     });
   });
@@ -39,6 +42,8 @@ describe('Page', function(){
   it('path - required', function(){
     return Page.insert({
       source: 'foo'
+    }).then(function(){
+      assert.fail();
     }).catch(function(err){
       err.should.have.property('message', '`path` is required!');
     });

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var pathFn = require('path');
 
 describe('Page', function(){
@@ -32,20 +32,24 @@ describe('Page', function(){
   });
 
   it('source - required', function(){
-    return Page.insert({}).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', '`source` is required!');
+    });
+
+    return Page.insert({}).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 
   it('path - required', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', '`path` is required!');
+    });
+
     return Page.insert({
       source: 'foo'
-    }).then(function(){
-      assert.fail();
-    }).catch(function(err){
-      err.should.have.property('message', '`path` is required!');
+    }).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var pathFn = require('path');
 var Promise = require('bluebird');
 
@@ -45,20 +45,24 @@ describe('Post', function(){
   });
 
   it('source - required', function(){
-    return Post.insert({}).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err){
       err.should.have.property('message', '`source` is required!');
+    });
+
+    return Post.insert({}).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 
   it('slug - required', function(){
+    var errorCallback = sinon.spy(function(err){
+      err.should.have.property('message', '`slug` is required!');
+    });
+
     return Post.insert({
       source: 'foo.md'
-    }).then(function(){
-      assert.fail();
-    }).catch(function(err){
-      err.should.have.property('message', '`slug` is required!');
+    }).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var pathFn = require('path');
 var Promise = require('bluebird');
 
@@ -44,7 +45,9 @@ describe('Post', function(){
   });
 
   it('source - required', function(){
-    return Post.insert({}).catch(function(err){
+    return Post.insert({}).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', '`source` is required!');
     });
   });
@@ -52,6 +55,8 @@ describe('Post', function(){
   it('slug - required', function(){
     return Post.insert({
       source: 'foo.md'
+    }).then(function(){
+      assert.fail();
     }).catch(function(err){
       err.should.have.property('message', '`slug` is required!');
     });

--- a/test/scripts/models/post_asset.js
+++ b/test/scripts/models/post_asset.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var url = require('url');
 var pathFn = require('path');
 
@@ -34,7 +35,9 @@ describe('PostAsset', function(){
   });
 
   it('_id - required', function(){
-    return PostAsset.insert({}).catch(function(err){
+    return PostAsset.insert({}).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', 'ID is not defined');
     });
   });
@@ -42,6 +45,8 @@ describe('PostAsset', function(){
   it('slug - required', function(){
     return PostAsset.insert({
       _id: 'foo'
+    }).then(function(){
+      assert.fail();
     }).catch(function(err){
       err.should.have.property('message', '`slug` is required!');
     });

--- a/test/scripts/models/post_asset.js
+++ b/test/scripts/models/post_asset.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var url = require('url');
 var pathFn = require('path');
 
@@ -35,21 +35,25 @@ describe('PostAsset', function(){
   });
 
   it('_id - required', function(){
-    return PostAsset.insert({}).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', 'ID is not defined');
     });
+
+    return PostAsset.insert({}).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
+    });;
   });
 
   it('slug - required', function(){
-    return PostAsset.insert({
-      _id: 'foo'
-    }).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', '`slug` is required!');
     });
+
+    return PostAsset.insert({
+      _id: 'foo'
+    }).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
+    });;
   });
 
   it('path - virtual', function(){

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var Promise = require('bluebird');
 var _ = require('lodash');
 
@@ -16,7 +17,9 @@ describe('Tag', function(){
   });
 
   it('name - required', function(){
-    return Tag.insert({}).catch(function(err){
+    return Tag.insert({}).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', '`name` is required!');
     });
   });
@@ -196,6 +199,8 @@ describe('Tag', function(){
     }).then(function(data){
       Tag.insert({
         name: 'foo'
+      }).then(function(){
+        assert.fail();
       }).catch(function(err){
         err.should.have.property('message', 'Tag `foo` has already existed!');
       });

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var Promise = require('bluebird');
 var _ = require('lodash');
 
@@ -17,10 +17,12 @@ describe('Tag', function(){
   });
 
   it('name - required', function(){
-    return Tag.insert({}).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', '`name` is required!');
+    });
+
+    return Tag.insert({}).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 
@@ -194,18 +196,20 @@ describe('Tag', function(){
   });
 
   it('check whether a tag exists', function(){
+    var errorCallback = sinon.spy(function(err) {
+      err.should.have.property('message', 'Tag `foo` has already existed!');
+    });
+
     return Tag.insert({
       name: 'foo'
     }).then(function(data){
       Tag.insert({
         name: 'foo'
-      }).then(function(){
-        assert.fail();
-      }).catch(function(err){
-        err.should.have.property('message', 'Tag `foo` has already existed!');
-      });
+      }).catch(errorCallback);
 
       return Tag.removeById(data._id);
+    }).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     });
   });
 

--- a/test/scripts/theme_processors/config.js
+++ b/test/scripts/theme_processors/config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
-var assert = require('chai').assert;
+var sinon = require('sinon');
 var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
@@ -83,10 +83,12 @@ describe('config', function(){
       type: 'create'
     });
 
-    return process(file).then(function(){
-      assert.fail();
-    }).catch(function(err){
+    var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', 'Theme config load failed.');
+    });
+
+    return process(file).catch(errorCallback).finally(function() {
+      errorCallback.calledOnce.should.be.true;
     }).catch(function(){}); // Catch again because it throws error
   });
 });

--- a/test/scripts/theme_processors/config.js
+++ b/test/scripts/theme_processors/config.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var should = require('chai').should();
+var assert = require('chai').assert;
 var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
@@ -82,7 +83,9 @@ describe('config', function(){
       type: 'create'
     });
 
-    return process(file).catch(function(err){
+    return process(file).then(function(){
+      assert.fail();
+    }).catch(function(err){
       err.should.have.property('message', 'Theme config load failed.');
     }).catch(function(){}); // Catch again because it throws error
   });


### PR DESCRIPTION
I found some of test were not working.

For example...

```javascript
  it('name - required', function(){
    return Tag.insert({}).catch(function(err){
      err.should.have.property('message', '`name` is required!');
    });
  });
```

If `Tag.insert({})` doesn't throw any error, `err.should.have.property` will be skipped.
So this test didn't check whether hexo throws error or not.

**modified**

added sinon.spy and calledOnce to check it.

```javascript
  it('name - required', function(){
    var errorCallback = sinon.spy(function(err) {
      err.should.have.property('message', '`name` is required!');
    });

    return Tag.insert({}).catch(errorCallback).finally(function() {
      errorCallback.calledOnce.should.be.true;
    });
  });
```

----

And I found two more problems.

One is problem of test. Please check https://github.com/hexojs/hexo/commit/1483589185118ff3ba832b02a4dadb417bec5009.
The another is https://github.com/hexojs/hexo/commit/f655f594554e8ce574aad8b89448bc695cacc56a

I fixed these to let test pass.