### PR TITLE
[Bugfix] `hexo help list` command causes OutOfMemory

### DIFF
--- a/lib/plugins/console/help.js
+++ b/lib/plugins/console/help.js
@@ -60,21 +60,14 @@ function printList(title, list){
   var length = 0;
   var str = title + ':\n';
 
-  if (list.length > 0) {
-    length = list[0].name.length;
-  }
+  list.forEach(function(item) {
+    length = Math.max(length, item.name.length);
+  });
 
   list.sort(function(a, b){
     var nameA = a.name;
     var nameB = b.name;
-    var cmp = nameA.length - nameB.length;
-
-    if (cmp > 0){
-      if (nameA.length > length) length = nameA.length;
-    } else {
-      if (nameB.length > length) length = nameB.length;
-    }
-
+    
     if (nameA < nameB) return -1;
     else if (nameA > nameB) return 1;
     else return 0;

--- a/lib/plugins/console/help.js
+++ b/lib/plugins/console/help.js
@@ -60,6 +60,10 @@ function printList(title, list){
   var length = 0;
   var str = title + ':\n';
 
+  if (list.length > 0) {
+    length = list[0].name.length;
+  }
+
   list.sort(function(a, b){
     var nameA = a.name;
     var nameB = b.name;

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "hexo-renderer-marked": "^0.2.3",
     "jshint-stylish": "^1.0.0",
     "mocha": "^2.0.1",
+    "mute": "^1.0.0",
     "sinon": "^1.12.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "hexo-renderer-marked": "^0.2.3",
     "jshint-stylish": "^1.0.0",
     "mocha": "^2.0.1",
-    "mute": "^1.0.0",
     "sinon": "^1.12.2"
   }
 }

--- a/test/scripts/console/help.js
+++ b/test/scripts/console/help.js
@@ -3,7 +3,7 @@
 var should = require('chai').should();
 var fs = require('hexo-fs');
 var pathFn = require('path');
-var mute = require('mute');
+var sinon = require('sinon');
 
 describe('help', function(){
   var Hexo = require('../../../lib/hexo');
@@ -16,15 +16,21 @@ describe('help', function(){
     });
   });
 
+  beforeEach(function() {
+    sinon.stub(console, "log").returns(void 0);
+    sinon.stub(console, "error").returns(void 0);
+  });
+
+  afterEach(function() {
+    console.log.restore();
+  });
+
   after(function(){
     return fs.rmdir(hexo.base_dir);
   });
-  
+
   // Only check that the error does not occur
   it('help list', function(){
-    return mute(function(unmute) {
-      help({_: ['list']});
-      unmute();
-    });
+    return help({_: ['list']});
   });
 });

--- a/test/scripts/console/help.js
+++ b/test/scripts/console/help.js
@@ -18,7 +18,6 @@ describe('help', function(){
 
   beforeEach(function() {
     sinon.stub(console, "log").returns(void 0);
-    sinon.stub(console, "error").returns(void 0);
   });
 
   afterEach(function() {

--- a/test/scripts/console/help.js
+++ b/test/scripts/console/help.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var should = require('chai').should();
+var fs = require('hexo-fs');
+var pathFn = require('path');
+var mute = require('mute');
+
+describe('help', function(){
+  var Hexo = require('../../../lib/hexo');
+  var hexo = new Hexo(pathFn.join(__dirname, 'help_test'), {silent: true});
+  var help = require('../../../lib/plugins/console/help').bind(hexo);
+
+  before(function(){
+    return fs.mkdirs(hexo.base_dir).then(function(){
+      return hexo.init();
+    });
+  });
+
+  after(function(){
+    return fs.rmdir(hexo.base_dir);
+  });
+  
+  // Only check that the error does not occur
+  it('help list', function(){
+    return mute(function(unmute) {
+      help({_: ['list']});
+      unmute();
+    });
+  });
+});

--- a/test/scripts/console/index.js
+++ b/test/scripts/console/index.js
@@ -5,6 +5,7 @@ describe('Console', function(){
   require('./config');
   require('./deploy');
   require('./generate');
+  require('./help');
   require('./migrate');
   require('./new');
   require('./publish');


### PR DESCRIPTION
```bash
$ hexo help list
```

Above command causes OutOfMemory.

### Cause

At hexo v3.0.1, `printList(title, list)` ( https://github.com/hexojs/hexo/blob/e8e45ed0f379f975147a214fbf52b2c28a6c806a/lib/plugins/console/help.js#L59 ) has a problem.
If `list` have only one element, variable `length` becomes zero (because of the list is not sorted).

Then `while (padding--){ ... }` causes infinite loop.

### Solution

Now `length` becomes length of the name of first element.