### PR TITLE
Fix backtick_code_block for ignore tab character.

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -34,13 +34,15 @@ function backtickCodeBlock(data){
         match = args.match(rLangCaption);
       }
 
-      options.lang = match[1];
+      if (match) {
+        options.lang = match[1];
 
-      if (match[2]){
-        options.caption = '<span>' + match[2] + '</span>';
+        if (match[2]){
+          options.caption = '<span>' + match[2] + '</span>';
 
-        if (match[3]){
-          options.caption += '<a href="' + match[3] + '">' + (match[4] ? match[4] : 'link') + '</a>';
+          if (match[3]){
+            options.caption += '<a href="' + match[3] + '">' + (match[4] ? match[4] : 'link') + '</a>';
+          }
         }
       }
     }

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -54,6 +54,36 @@ describe('Backtick code block', function(){
     data.content.should.eql('<escape>' + highlight(code, {lang: 'js'}) + '</escape>');
   });
 
+  it('without language name', function(){
+    var data = {
+      content: [
+        '```',
+        code,
+        '```'
+      ].join('\n')
+    };
+
+    var expected = highlight(code);
+
+    codeBlock(data);
+    data.content.should.eql('<escape>' + expected + '</escape>');
+  });
+
+  it('without language name - ignore tab character', function(){
+    var data = {
+      content: [
+        '``` \t',
+        code,
+        '```'
+      ].join('\n')
+    };
+
+    var expected = highlight(code);
+
+    codeBlock(data);
+    data.content.should.eql('<escape>' + expected + '</escape>');
+  });
+
   it('title', function(){
     var data = {
       content: [


### PR DESCRIPTION
<raw>``` (tab)
Hello world!
</new>

The expressions like this causes a bug.

In this case, `args` in `backtickCodeBlock()` is not blank (it contains a tab character).
Then the `args` will not match both of `rAllOptions` and `rLangCaption`.
So `match` will be `null`. and we can't get `match[1]` in this case.

To fix it, I check whether `match` is `null` or not.

This pull request may solve #1228.