### PR TITLE
Fix is_post() helper not validating permalinks with language tags

### DIFF
--- a/lib/plugins/helper/is.js
+++ b/lib/plugins/helper/is.js
@@ -44,6 +44,7 @@ function isPostHelper(){
 
   if (!r){
     var rUrl = escapeRegExp(permalink)
+      .replace(':lang', '[a-zA-Z]{1,8}(-[a-zA-Z0-9]{1,8})*')
       .replace(':id', '\\d+')
       .replace(':category', '(\\w+\\/?)+')
       .replace(':year', '\\d{4}')


### PR DESCRIPTION
I decided to use the regex validator that the W3C defines in
http://www.w3.org/TR/xmlschema11-2/#language for BCP 47 language identifiers.

This fixes hexojs/hexo#1236.