### PR TITLE
Add `:name` to the list of permalink filters

### DIFF
--- a/lib/plugins/filter/post_permalink.js
+++ b/lib/plugins/filter/post_permalink.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var util = require('hexo-util');
+var pathFn = require('path');
 var Permalink = util.Permalink;
 var permalink;
 
@@ -11,6 +12,7 @@ function postPermalinkFilter(data){
   var meta = {
     id: data.id || data._id,
     title: data.slug,
+    name: pathFn.basename(data.slug),
     year: data.date.format('YYYY'),
     month: data.date.format('MM'),
     day: data.date.format('DD'),

--- a/test/scripts/filters/post_permalink.js
+++ b/test/scripts/filters/post_permalink.js
@@ -70,4 +70,17 @@ describe('post_permalink', function(){
 
     hexo.config.permalink = PERMALINK;
   });
+
+  it('name', function(){
+    hexo.config.permalink = ':title/:name';
+
+    return Post.insert({
+      source: 'sub/bar.md',
+      slug: 'sub/bar'
+    }).then(function(post){
+      postPermalink(post).should.eql('sub/bar/bar');
+      hexo.config.permalink = PERMALINK;
+      return Post.removeById(post._id);
+    });
+  });
 });


### PR DESCRIPTION
While `:title` includes subdirectories, `:name` only expands to the file name of the slug.