### PR TITLE
Remove the extension from internal links.

### DIFF
--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -20,6 +20,10 @@ function urlForHelper(path, options){
     return path;
   }
 
+  if (config.permalink_remove_ext_and_dir) {
+    path = path.replace(/(\/index)?\.html$/, '');
+  }
+
   // Resolve relative url
   if (options.relative){
     return this.relative_url(this.path, path);

--- a/test/scripts/helpers/url_for.js
+++ b/test/scripts/helpers/url_for.js
@@ -48,4 +48,15 @@ describe('url_for', function(){
       urlFor(url).should.eql(url);
     });
   });
+
+  it('internal url (options.permalink_remove_ext_and_dir)', function(){
+    ctx.path = '';
+    urlFor('a/test/index.html', {relative: true}).should.eql('a/test/index.html');
+    urlFor('b/test.html', {relative: true}).should.eql('b/test.html');
+
+    ctx.config.permalink_remove_ext_and_dir = true;
+    urlFor('c/test/index.html', {relative: true}).should.eql('c/test');
+    urlFor('d/test.html', {relative: true}).should.eql('d/test');
+    ctx.config.permalink_remove_ext_and_dir = false;
+  });
 });


### PR DESCRIPTION
Add a new option `permalink_remove_ext_and_dir` to allow links to internal pages and posts without `.html` and without `/index.html` at the end.

For example, instead of a link to `/2015/05/01/test.html` or alternatively to `/2015/05/01/test/`, I want a link to `/2015/05/01/test` without changing the option `permalink` (I want to keep `.html` as a file extension, but not in the URLs).

This needs a change on hexo-server to work with this option, too!