### PR TITLE
Fix for relative url `..//`

### DIFF
--- a/lib/plugins/helper/relative_url.js
+++ b/lib/plugins/helper/relative_url.js
@@ -17,7 +17,7 @@ function relativeUrlHelper(from, to){
     out.unshift('..');
   }
 
-  return out.join('/');
+  return out.join('/').replace(/\/{2,}/g, '/');
 }
 
 module.exports = relativeUrlHelper;

--- a/test/scripts/helpers/relative_url.js
+++ b/test/scripts/helpers/relative_url.js
@@ -23,4 +23,10 @@ describe('relative_url', function(){
     relativeURL('foo/bar/', 'css/style.css').should.eql('../../css/style.css');
     relativeURL('foo/bar/index.html', 'css/style.css').should.eql('../../css/style.css');
   });
+
+  it('to root', function(){
+    relativeURL('index.html', '/').should.eql('/');
+    relativeURL('foo/', '/').should.eql('../');
+    relativeURL('foo/index.html', '/').should.eql('../');
+  });
 });


### PR DESCRIPTION
Relative URLs from a subfolder to root lead to doubled slashes.