### PR TITLE
Fixed is_home() helper which always return false

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -296,7 +296,8 @@ Hexo.prototype._generate = function(options){
 
   function Locals(path, locals){
     this.page = _.extend({
-      path: path
+      path: path,
+      __index: true
     }, locals);
 
     this.path = path;


### PR DESCRIPTION
`is_home` helper is simplified at this [commit](https://github.com/hexojs/hexo/commit/62f521b32b7e750d88a8e3207278c0f5b1c14fdf) using `__index` flag, but this flag has not been set by default, so it's value always be false.