### PR TITLE
Set scrolling="no" to make iframe responsive

### DIFF
--- a/lib/plugins/tag/jsfiddle.js
+++ b/lib/plugins/tag/jsfiddle.js
@@ -13,8 +13,8 @@ function jsfiddleTag(args, content){
   var skin = args[2] && args[2] !== 'default' ? args[2] : 'light';
   var width = args[3] && args[3] !== 'default' ? args[3] : '100%';
   var height = args[4] && args[4] !== 'default' ? args[4] : '300';
-
-  return '<iframe width="' + width + '" height="' + height + '" src="http://jsfiddle.net/' + id + '/embedded/' + tabs + '/' + skin + '" frameborder="0" allowfullscreen></iframe>';
+  
+  return '<iframe scrolling="no" width="' + width + '" height="' + height + '" src="http://jsfiddle.net/' + id + '/embedded/' + tabs + '/' + skin + '" frameborder="0" allowfullscreen></iframe>';
 }
 
 module.exports = jsfiddleTag;


### PR DESCRIPTION
the fiddle iframe is not responsive in iOS safari and Chrome. By setting `scrolling="no"` makes it possible to fix this issue, by setting `width=1px; min-width=100%` in CSS. [See StackOverflow](http://stackoverflow.com/questions/23083462/how-to-get-an-iframe-to-be-responsive-in-ios-safari)