### PR TITLE
[helper] add log()

### DIFF
--- a/lib/plugins/helper/debug.js
+++ b/lib/plugins/helper/debug.js
@@ -2,9 +2,15 @@
 
 var util = require('util');
 
-// this solves circular reference in object
+// this format object as string, resolves circular reference
 function inspectObject(object, options){
   return util.inspect(object, options);
 }
 
+// wrapper to log to console
+function log(){
+  return console.log.apply(null, arguments);
+}
+
 exports.inspectObject = inspectObject;
+exports.log = log;

--- a/lib/plugins/helper/index.js
+++ b/lib/plugins/helper/index.js
@@ -72,4 +72,5 @@ module.exports = function(ctx){
 
   var debug = require('./debug');
   helper.register('inspect', debug.inspectObject);
+  helper.register('log', debug.log);
 };

--- a/test/scripts/helpers/debug.js
+++ b/test/scripts/helpers/debug.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var should = require('chai').should();
+
+describe('debug', function(){
+  var debug = require('../../../lib/plugins/helper/debug');
+  var inspect = require('util').inspect;
+
+  it('inspect simple object', function(){
+    var obj = { foo: "bar" };
+    debug.inspectObject(obj).should.eql(inspect(obj));
+  });
+
+  it('inspect circular object', function(){
+    var obj = { foo: "bar" };
+    obj.circular = obj;
+    debug.inspectObject(obj).should.eql(inspect(obj));
+  });
+
+  it('inspect deep object', function(){
+    var obj = { baz: { thud: "narf", dur: { foo: "bar", baz: { bang: "zoom" } } } };
+    debug.inspectObject(obj).should.not.eql(inspect(obj, {depth: 5}));
+    debug.inspectObject(obj, {depth: 5}).should.eql(inspect(obj, {depth: 5}));
+  });
+
+  it('log should print to console', function(){
+    debug.log('Hello %s from debug.log()!', 'World');
+    // console should print 'Hello World from debug.log()!'
+    debug.should.be.a('object'); // void assert
+  });
+});

--- a/test/scripts/helpers/index.js
+++ b/test/scripts/helpers/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 describe('Helpers', function(){
+  require('./debug');
   require('./css');
   require('./date');
   require('./favicon_tag');


### PR DESCRIPTION
Good for logging objects in theme and plugin
originally #1389

 Changes to be committed:
	modified:   lib/plugins/helper/debug.js
	modified:   lib/plugins/helper/index.js
	new file:   test/scripts/helpers/debug.js
	modified:   test/scripts/helpers/index.js