### PR TITLE
Allow specifying classes of code blocks to be excluded from processing.

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -37,6 +37,7 @@ module.exports = {
     auto_detect: true, // Maintain consistent with previous version.
     line_number: true,
     tab_replace: '',
+    exclude: '',
   },
   // Category & Tag
   default_category: 'uncategorized',

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -22,7 +22,8 @@ function backtickCodeBlock(data){
     var options = {
       autoDetect: config.auto_detect,
       gutter: config.line_number,
-      tab: config.tab_replace
+      tab: config.tab_replace,
+      exclude: config.exclude
     };
 
     if (args){
@@ -36,6 +37,10 @@ function backtickCodeBlock(data){
 
       if (match) {
         options.lang = match[1];
+        if(options.exclude &&
+           options.exclude.indexOf(options.lang) > -1) {
+          return arguments[0];
+        }
 
         if (match[2]){
           options.caption = '<span>' + match[2] + '</span>';


### PR DESCRIPTION
Pandocfilters, for example, uses code block classes to allow extra types of content. This PR allows a user to specify which code blocks (if any) are to be excluded from processing, so that another program can process them instead.