### PR TITLE
Support root path configure for img tag

### DIFF
--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -47,7 +47,8 @@ module.exports = function(ctx) {
   });
 
   Post.virtual('permalink').get(function() {
-    return ctx.config.url + '/' + this.path;
+    var url_for = ctx.extend.helper.get('url_for');
+    return ctx.config.url + url_for.call(ctx, this.path);
   });
 
   Post.virtual('full_source').get(function() {

--- a/lib/plugins/tag/img.js
+++ b/lib/plugins/tag/img.js
@@ -12,69 +12,69 @@ var rMeta = /["']?([^"']+)?["']?\s*["']?([^"']+)?["']?/;
 * Syntax:
 *   {% img [class names] /path/to/image [width] [height] [title text [alt text]] %}
 */
+module.exports = function(ctx) {
+  return function imgTag(args, content) {
+    var classes = [];
+    var meta = '';
+    var width;
+    var height;
+    var title;
+    var alt;
+    var src;
+    var item = '';
+    var i = 0;
+    var len = args.length;
+    var url_for = ctx.extend.helper.get('url_for');
 
-function imgTag(args, content) {
-  var classes = [];
-  var meta = '';
-  var width;
-  var height;
-  var title;
-  var alt;
-  var src;
-  var item = '';
-  var i = 0;
-  var len = args.length;
+    // Find image URL and class name
+    for (; i < len; i++) {
+      item = args[i];
 
-  // Find image URL and class name
-  for (; i < len; i++) {
-    item = args[i];
-
-    if (rUrl.test(item)) {
-      src = item;
-      break;
-    } else {
-      if (item[0] === '/') {
-        src = item;
+      if (rUrl.test(item)) {
+        src = url_for.call(ctx, item);
         break;
       } else {
-        classes.push(item);
-      }
-    }
-  }
-
-  // Delete image URL and class name from arguments
-  args = args.slice(i + 1);
-
-  // Find image width and height
-  if (args.length) {
-    if (!/\D+/.test(args[0])) {
-      width = args.shift();
-
-      if (args.length && !/\D+/.test(args[0])) {
-        height = args.shift();
+        if (item[0] === '/') {
+          src = url_for.call(ctx, item);
+          break;
+        } else {
+          classes.push(item);
+        }
       }
     }
 
-    meta = args.join(' ');
-  }
+    // Delete image URL and class name from arguments
+    args = args.slice(i + 1);
 
-  // Find image title and alt
-  if (meta && rMeta.test(meta)) {
-    var match = meta.match(rMeta);
-    title = match[1];
-    alt = match[2];
-  }
+    // Find image width and height
+    if (args.length) {
+      if (!/\D+/.test(args[0])) {
+        width = args.shift();
 
-  var attrs = {
-    src: src,
-    class: classes.join(' '),
-    width: width,
-    height: height,
-    title: title,
-    alt: alt
+        if (args.length && !/\D+/.test(args[0])) {
+          height = args.shift();
+        }
+      }
+
+      meta = args.join(' ');
+    }
+
+    // Find image title and alt
+    if (meta && rMeta.test(meta)) {
+      var match = meta.match(rMeta);
+      title = match[1];
+      alt = match[2];
+    }
+
+    var attrs = {
+      src: src,
+      class: classes.join(' '),
+      width: width,
+      height: height,
+      title: title,
+      alt: alt
+    };
+
+    return htmlTag('img', attrs);
   };
-
-  return htmlTag('img', attrs);
-}
-
-module.exports = imgTag;
+};

--- a/lib/plugins/tag/index.js
+++ b/lib/plugins/tag/index.js
@@ -17,7 +17,7 @@ module.exports = function(ctx) {
 
   tag.register('iframe', require('./iframe'));
 
-  var img = require('./img');
+  var img = require('./img')(ctx);
 
   tag.register('img', img);
   tag.register('image', img);

--- a/test/scripts/helpers/list_archives.js
+++ b/test/scripts/helpers/list_archives.js
@@ -22,12 +22,14 @@ describe('list_archives', function() {
   }
 
   before(function() {
-    return Post.insert([
-      {source: 'foo', slug: 'foo', date: new Date(2014, 1, 2)},
-      {source: 'bar', slug: 'bar', date: new Date(2013, 5, 6)},
-      {source: 'baz', slug: 'baz', date: new Date(2013, 9, 10)},
-      {source: 'boo', slug: 'boo', date: new Date(2013, 5, 8)}
-    ]).then(function() {
+    return hexo.init().then(function() {
+      return Post.insert([
+        {source: 'foo', slug: 'foo', date: new Date(2014, 1, 2)},
+        {source: 'bar', slug: 'bar', date: new Date(2013, 5, 6)},
+        {source: 'baz', slug: 'baz', date: new Date(2013, 9, 10)},
+        {source: 'boo', slug: 'boo', date: new Date(2013, 5, 8)}
+      ]);
+    }).then(function() {
       resetLocals();
     });
   });

--- a/test/scripts/helpers/list_categories.js
+++ b/test/scripts/helpers/list_categories.js
@@ -18,12 +18,14 @@ describe('list_categories', function() {
   var listCategories = require('../../../lib/plugins/helper/list_categories').bind(ctx);
 
   before(function() {
-    return Post.insert([
-      {source: 'foo', slug: 'foo'},
-      {source: 'bar', slug: 'bar'},
-      {source: 'baz', slug: 'baz'},
-      {source: 'boo', slug: 'boo'}
-    ]).then(function(posts) {
+    return hexo.init().then(function() {
+      return Post.insert([
+        {source: 'foo', slug: 'foo'},
+        {source: 'bar', slug: 'bar'},
+        {source: 'baz', slug: 'baz'},
+        {source: 'boo', slug: 'boo'}
+      ]);
+    }).then(function(posts) {
       return Promise.each([
         ['baz'],
         ['baz', 'bar'],

--- a/test/scripts/helpers/list_posts.js
+++ b/test/scripts/helpers/list_posts.js
@@ -18,12 +18,12 @@ describe('list_posts', function() {
   hexo.config.permalink = ':title/';
 
   before(function() {
-    return Post.insert([
-      {source: 'foo', slug: 'foo', title: 'Its', date: 1e8},
-      {source: 'bar', slug: 'bar', title: 'Chemistry', date: 1e8 + 1},
-      {source: 'baz', slug: 'baz', title: 'Bitch', date: 1e8 - 1}
-    ]).then(function() {
-      return hexo.init();
+    return hexo.init().then(function() {
+      return Post.insert([
+        {source: 'foo', slug: 'foo', title: 'Its', date: 1e8},
+        {source: 'bar', slug: 'bar', title: 'Chemistry', date: 1e8 + 1},
+        {source: 'baz', slug: 'baz', title: 'Bitch', date: 1e8 - 1}
+      ]);
     }).then(function() {
       hexo.locals.invalidate();
       ctx.site = hexo.locals.toObject();

--- a/test/scripts/helpers/list_tags.js
+++ b/test/scripts/helpers/list_tags.js
@@ -18,12 +18,14 @@ describe('list_tags', function() {
   var listTags = require('../../../lib/plugins/helper/list_tags').bind(ctx);
 
   before(function() {
-    return Post.insert([
-      {source: 'foo', slug: 'foo'},
-      {source: 'bar', slug: 'bar'},
-      {source: 'baz', slug: 'baz'},
-      {source: 'boo', slug: 'boo'}
-    ]).then(function(posts) {
+    return hexo.init().then(function() {
+      return Post.insert([
+        {source: 'foo', slug: 'foo'},
+        {source: 'bar', slug: 'bar'},
+        {source: 'baz', slug: 'baz'},
+        {source: 'boo', slug: 'boo'}
+      ]);
+    }).then(function(posts) {
       // TODO: Warehouse needs to add a mutex lock when writing data to avoid data sync problem
       return Promise.each([
         ['foo'],

--- a/test/scripts/helpers/tagcloud.js
+++ b/test/scripts/helpers/tagcloud.js
@@ -18,12 +18,14 @@ describe('tagcloud', function() {
   var tagcloud = require('../../../lib/plugins/helper/tagcloud').bind(ctx);
 
   before(function() {
-    return Post.insert([
-      {source: 'foo', slug: 'foo'},
-      {source: 'bar', slug: 'bar'},
-      {source: 'baz', slug: 'baz'},
-      {source: 'boo', slug: 'boo'}
-    ]).then(function(posts) {
+    return hexo.init().then(function() {
+      return Post.insert([
+        {source: 'foo', slug: 'foo'},
+        {source: 'bar', slug: 'bar'},
+        {source: 'baz', slug: 'baz'},
+        {source: 'boo', slug: 'boo'}
+      ]);
+    }).then(function(posts) {
       // TODO: Warehouse needs to add a mutex lock when writing data to avoid data sync problem
       return Promise.each([
         ['bcd'],

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -77,11 +77,23 @@ describe('Post', function() {
   });
 
   it('permalink - virtual', function() {
+    hexo.config.root = '/';
     return Post.insert({
       source: 'foo.md',
       slug: 'bar'
     }).then(function(data) {
       data.permalink.should.eql(hexo.config.url + '/' + data.path);
+      return Post.removeById(data._id);
+    });
+  });
+
+  it('permalink_root_prefix - virtual', function() {
+    hexo.config.root = '/root/';
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bar'
+    }).then(function(data) {
+      data.permalink.should.eql(hexo.config.url + '/root/' + data.path);
       return Post.removeById(data._id);
     });
   });

--- a/test/scripts/tags/img.js
+++ b/test/scripts/tags/img.js
@@ -1,10 +1,17 @@
 'use strict';
 
+var pathFn = require('path');
 var cheerio = require('cheerio');
 var should = require('chai').should(); // eslint-disable-line
 
 describe('img', function() {
-  var img = require('../../../lib/plugins/tag/img');
+  var Hexo = require('../../../lib/hexo');
+  var hexo = new Hexo(pathFn.join(__dirname, 'img_test'));
+  var img = require('../../../lib/plugins/tag/img')(hexo);
+
+  before(function() {
+    return hexo.init();
+  });
 
   it('src', function() {
     var $ = cheerio.load(img(['http://placekitten.com/200/300']));
@@ -13,9 +20,13 @@ describe('img', function() {
   });
 
   it('internal src', function() {
+    hexo.config.root = '/';
     var $ = cheerio.load(img(['/images/test.jpg']));
-
     $('img').attr('src').should.eql('/images/test.jpg');
+
+    hexo.config.root = '/root/';
+    $ = cheerio.load(img(['/images/test.jpg']));
+    $('img').attr('src').should.eql('/root/images/test.jpg');
   });
 
   it('class + src', function() {
@@ -26,9 +37,14 @@ describe('img', function() {
   });
 
   it('class + internal src', function() {
+    hexo.config.root = '/';
     var $ = cheerio.load(img('left /images/test.jpg'.split(' ')));
-
     $('img').attr('src').should.eql('/images/test.jpg');
+    $('img').attr('class').should.eql('left');
+
+    hexo.config.root = '/root/';
+    $ = cheerio.load(img('left /images/test.jpg'.split(' ')));
+    $('img').attr('src').should.eql('/root/images/test.jpg');
     $('img').attr('class').should.eql('left');
   });
 
@@ -40,9 +56,14 @@ describe('img', function() {
   });
 
   it('multiple classes + internal src', function() {
+    hexo.config.root = '/';
     var $ = cheerio.load(img('left top /images/test.jpg'.split(' ')));
-
     $('img').attr('src').should.eql('/images/test.jpg');
+    $('img').attr('class').should.eql('left top');
+
+    hexo.config.root = '/root/';
+    $ = cheerio.load(img('left top /images/test.jpg'.split(' ')));
+    $('img').attr('src').should.eql('/root/images/test.jpg');
     $('img').attr('class').should.eql('left top');
   });
 


### PR DESCRIPTION
Current img tag doesn't prepend root path if it's not a slash. With
this fix, the root path will be prepend to the img src if it's not a
slash.
This fix only works for the hexo tags, does not work for the markdown
syntax of links and images. The issues of markdown links and images should
be fixed in the hexo-renderer-marked module.

Resolves: #1440