### PR TITLE
Fix category path when placed on root

### DIFF
--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -30,7 +30,8 @@ module.exports = function(ctx) {
 
   Category.virtual('path').get(function() {
     var catDir = ctx.config.category_dir;
-    if (catDir[catDir.length - 1] !== '/') catDir += '/';
+    if (catDir === '/') catDir = '';
+    if (catDir.length > 0 && catDir[catDir.length - 1] !== '/') catDir += '/';
 
     return catDir + this.slug + '/';
   });

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -31,7 +31,7 @@ module.exports = function(ctx) {
   Category.virtual('path').get(function() {
     var catDir = ctx.config.category_dir;
     if (catDir === '/') catDir = '';
-    if (catDir.length && catDir[catDir.length - 1] !== '/') catDir += '/';
+    if (catDir.length && catDir[catDir.length - 1] !== '/') catDir += '/'; 
 
     return catDir + this.slug + '/';
   });

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -31,7 +31,7 @@ module.exports = function(ctx) {
   Category.virtual('path').get(function() {
     var catDir = ctx.config.category_dir;
     if (catDir === '/') catDir = '';
-    if (catDir.length > 0 && catDir[catDir.length - 1] !== '/') catDir += '/';
+    if (catDir.length && catDir[catDir.length - 1] !== '/') catDir += '/';
 
     return catDir + this.slug + '/';
   });


### PR DESCRIPTION
This patch fixes the double slashes (i.e. http://site.com//cat1) in the category path, when you configure `category_dir` with '/' or ''