### PR TITLE
override line_number, highlight settings at the codeblock level

### DIFF
--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -11,23 +11,31 @@ var rCaptionUrl = /(\S[\S\s]*)\s+(https?:\/\/)(\S+)/i;
 var rCaption = /(\S[\S\s]*)/;
 var rLang = /\s*lang:(\w+)/i;
 var rLineNumber = /\s*line_number:(\w+)/i;
+var rHighlight = /\s*highlight:(\w+)/i;
 
 /**
  * Code block tag
  *
  * Syntax:
- *   {% codeblock [title] [lang:language] [url] [link text] [line_number:(true|false)] %}
+ *   {% codeblock [title] [lang:language] [url] [link text] [line_number:(true|false)] [highlight:(true|false)] %}
  *   code snippet
  *   {% endcodeblock %}
  */
 
 module.exports = function(ctx) {
-
   return function codeTag(args, content) {
     var arg = args.join(' ');
     var config = ctx.config.highlight || {};
+    var enable = config.enable;
 
-    if (!config.enable) {
+    if (rHighlight.test(arg)) {
+      arg = arg.replace(rHighlight, function() {
+        enable = arguments[1] === 'true';
+        return '';
+      });
+    }
+
+    if (!enable) {
       return '<pre><code>' + content + '</code></pre>';
     }
 

--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -10,17 +10,19 @@ var rCaptionUrlTitle = /(\S[\S\s]*)\s+(https?:\/\/)(\S+)\s+(.+)/i;
 var rCaptionUrl = /(\S[\S\s]*)\s+(https?:\/\/)(\S+)/i;
 var rCaption = /(\S[\S\s]*)/;
 var rLang = /\s*lang:(\w+)/i;
+var rLineNumber = /\s*line_number:(\w+)/i;
 
 /**
-* Code block tag
-*
-* Syntax:
-*   {% codeblock [title] [lang:language] [url] [link text] %}
-*   code snippet
-*   {% endcodeblock %}
-*/
+ * Code block tag
+ *
+ * Syntax:
+ *   {% codeblock [title] [lang:language] [url] [link text] [line_number:(true|false)] %}
+ *   code snippet
+ *   {% endcodeblock %}
+ */
 
 module.exports = function(ctx) {
+
   return function codeTag(args, content) {
     var arg = args.join(' ');
     var config = ctx.config.highlight || {};
@@ -31,11 +33,19 @@ module.exports = function(ctx) {
 
     var caption = '';
     var lang = '';
+    var line_number = config.line_number;
     var match;
 
     if (rLang.test(arg)) {
       arg = arg.replace(rLang, function() {
         lang = arguments[1];
+        return '';
+      });
+    }
+
+    if (rLineNumber.test(arg)) {
+      arg = arg.replace(rLineNumber, function() {
+        line_number = arguments[1] === 'true';
         return '';
       });
     }
@@ -56,7 +66,7 @@ module.exports = function(ctx) {
     content = highlight(content, {
       lang: lang,
       caption: caption,
-      gutter: config.line_number,
+      gutter: line_number,
       tab: config.tab_replace,
       autoDetect: config.auto_detect
     });

--- a/test/scripts/tags/code.js
+++ b/test/scripts/tags/code.js
@@ -34,6 +34,11 @@ describe('code', function() {
     result.should.eql(highlight(fixture, {lang: 'js'}));
   });
 
+  it('highlight disable', function() {
+    var result = code('highlight:false', fixture);
+    result.should.eql("<pre><code>" + fixture + "</code></pre>");
+  });
+
   it('title', function() {
     var result = code('Hello world', fixture);
     result.should.eql(highlight(fixture, {caption: '<span>Hello world</span>'}));

--- a/test/scripts/tags/code.js
+++ b/test/scripts/tags/code.js
@@ -31,17 +31,32 @@ describe('code', function() {
 
   it('lang', function() {
     var result = code('lang:js', fixture);
-    result.should.eql(highlight(fixture, {lang: 'js'}));
+    result.should.eql(highlight(fixture, {
+      lang: 'js'
+    }));
+  });
+
+  it('line_number', function() {
+    var result = code('line_number:false', fixture);
+    result.should.eql(highlight(fixture, {
+      gutter: false
+    }));
+    result = code('line_number:true', fixture);
+    result.should.eql(highlight(fixture, {
+      gutter: true
+    }));
   });
 
   it('highlight disable', function() {
     var result = code('highlight:false', fixture);
-    result.should.eql("<pre><code>" + fixture + "</code></pre>");
+    result.should.eql('<pre><code>' + fixture + '</code></pre>');
   });
 
   it('title', function() {
     var result = code('Hello world', fixture);
-    result.should.eql(highlight(fixture, {caption: '<span>Hello world</span>'}));
+    result.should.eql(highlight(fixture, {
+      caption: '<span>Hello world</span>'
+    }));
   });
 
   it('link', function() {


### PR DESCRIPTION
this addresses issue: https://github.com/hexojs/hexo/issues/1537, adding options to override the line_number and highlight configuration options at the code block tag level

the new syntax will be:

```
  {% codeblock [title] [lang:language] [url] [link text] [line_number:(true|false)] [highlight:(true|false)]%}
    code snippet
  {% endcodeblock %}
```