### PR TITLE
Correct tag trimming

### DIFF
--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -119,7 +119,7 @@ NunjucksBlock.prototype.run = function(context, args, body) {
 };
 
 function trimBody(body) {
-  return stripIndent(body()).trim();
+  return stripIndent(body()).replace(/^\n?|\n?$/g, '');
 }
 
 function NunjucksAsyncTag(name, fn) {

--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -51,7 +51,7 @@ module.exports = function(ctx) {
       caption = '<span>' + match[1] + '</span>';
     }
 
-    content = stripIndent(content).trim();
+    content = stripIndent(content);
 
     content = highlight(content, {
       lang: lang,

--- a/test/scripts/tags/code.js
+++ b/test/scripts/tags/code.js
@@ -29,6 +29,19 @@ describe('code', function() {
     result.should.eql(highlight(fixture));
   });
 
+  it('non standard indent', function() {
+    var nonStandardIndent = [
+        '  ',
+        '  return x;',
+        '}',
+        '',
+        fixture,
+        '  '
+    ].join('/n');
+    var result = code('', nonStandardIndent);
+    result.should.eql(highlight(nonStandardIndent));
+  });
+
   it('lang', function() {
     var result = code('lang:js', fixture);
     result.should.eql(highlight(fixture, {lang: 'js'}));


### PR DESCRIPTION
fixing a bug with tag trimming which leads to incorrect indentation for some code blocks.
---
currently, when this is put inside of a codeblock:

```
    return result;
  }
  if (tired && night){
    sleep();
  }
```

it will incorrectly be rendered as (approximately, can't reproduce the exact error with the github editor):

```
return result;
  }
  if (tired && night){
    sleep();
  }
```
