### PR TITLE
Adds swig-lodash support

### DIFF
--- a/lib/plugins/renderer/swig.js
+++ b/lib/plugins/renderer/swig.js
@@ -13,7 +13,6 @@ extras.useFilter(swig, 'batch');
 extras.useFilter(swig, 'groupby');
 extras.useFilter(swig, 'markdown');
 extras.useFilter(swig, 'nl2br');
-extras.useFilter(swig, 'pluck');
 extras.useFilter(swig, 'split');
 extras.useFilter(swig, 'trim');
 extras.useFilter(swig, 'truncate');

--- a/lib/plugins/renderer/swig.js
+++ b/lib/plugins/renderer/swig.js
@@ -2,6 +2,7 @@
 
 var swig = require('swig');
 var extras = require('swig-extras');
+var swigLodash = require('swig-lodash');
 var forTag = require('swig/lib/tags/for');
 
 extras.useTag(swig, 'markdown');
@@ -16,6 +17,8 @@ extras.useFilter(swig, 'pluck');
 extras.useFilter(swig, 'split');
 extras.useFilter(swig, 'trim');
 extras.useFilter(swig, 'truncate');
+
+swigLodash.useFilter(swig);
 
 swig.setDefaults({
   cache: false,

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "strip-indent": "^1.0.0",
     "swig": "1.4.2",
     "swig-extras": "0.0.1",
+    "swig-lodash": "^1.2.1",
     "text-table": "^0.2.0",
     "through2": "^2.0.0",
     "tildify": "^1.0.0",


### PR DESCRIPTION
This adds the support for the `swig-lodash` package. 
All of lodash v2.4.1 functionality as a swig filter.

I added it side-by-side to the, already implemented, `swig-extra` package. The only overlap was the `pluck` filter. So i removed the `swig-extra` version in favour of the `lodash` version.

Once the author of the `swig-lodash` package upgrades to the latest `lodash` version (3.10.1), more overlapping filters can be removed. I will post a pull request to that package as well.
