### PR TITLE
Fix HTML issue with RSS/Atom feeds: rel="alternate"

### DIFF
--- a/lib/plugins/helper/feed_tag.js
+++ b/lib/plugins/helper/feed_tag.js
@@ -6,7 +6,7 @@ function feedTagHelper(path, options) {
   var title = options.title || this.config.title;
   var type = options.type || 'atom';
 
-  return '<link rel="alternative" href="' + this.url_for(path) + '" title="' + title + '" type="application/' + type + '+xml">';
+  return '<link rel="alternate" href="' + this.url_for(path) + '" title="' + title + '" type="application/' + type + '+xml">';
 }
 
 module.exports = feedTagHelper;

--- a/test/scripts/helpers/feed_tag.js
+++ b/test/scripts/helpers/feed_tag.js
@@ -15,14 +15,14 @@ describe('feed_tag', function() {
   var feed = require('../../../lib/plugins/helper/feed_tag').bind(ctx);
 
   it('path', function() {
-    feed('atom.xml').should.eql('<link rel="alternative" href="/atom.xml" title="Hexo" type="application/atom+xml">');
+    feed('atom.xml').should.eql('<link rel="alternate" href="/atom.xml" title="Hexo" type="application/atom+xml">');
   });
 
   it('title', function() {
-    feed('atom.xml', {title: 'RSS Feed'}).should.eql('<link rel="alternative" href="/atom.xml" title="RSS Feed" type="application/atom+xml">');
+    feed('atom.xml', {title: 'RSS Feed'}).should.eql('<link rel="alternate" href="/atom.xml" title="RSS Feed" type="application/atom+xml">');
   });
 
   it('type', function() {
-    feed('rss.xml', {type: 'rss'}).should.eql('<link rel="alternative" href="/rss.xml" title="Hexo" type="application/rss+xml">');
+    feed('rss.xml', {type: 'rss'}).should.eql('<link rel="alternate" href="/rss.xml" title="Hexo" type="application/rss+xml">');
   });
 });


### PR DESCRIPTION
According to the W3C, "alternative" is not a valid value for attribute "rel" on
element "link". The HTML5 standard uses <link rel="alternate" to provide an
alternate representation, such as RSS or Atom.

https://html.spec.whatwg.org/multipage/semantics.html#rel-alternate