### PR TITLE
Fix issue cannot correctly analyze arguments with space in tag 

### DIFF
--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -77,11 +77,27 @@ NunjucksTag.prototype._parseArgs = function(parser, nodes, lexer) {
   var args = [];
   var token;
 
-  while ((token = parser.nextToken(true)) && token.type !== lexer.TOKEN_BLOCK_END) {
-    args += token.value;
+  var argarray = new nodes.Array(tag.lineno, tag.colno);
+
+  var argitem = "";
+  while( (token = parser.nextToken(true)) ){
+    if( token.type == lexer.TOKEN_WHITESPACE || token.type == lexer.TOKEN_BLOCK_END ){
+      if( argitem != "" ){
+        var argnode = new nodes.Literal(tag.lineno, tag.colno, argitem.trim());
+        argarray.addChild(argnode);
+        argitem = "";
+      }
+
+      if( token.type == lexer.TOKEN_BLOCK_END ){
+        break;
+      }
+    }
+    else {
+      argitem += token.value;
+    }
   }
 
-  node.addChild(new nodes.Literal(token.lineno, token.colno, args.trim()));
+  node.addChild(argarray);
 
   return node;
 };
@@ -91,7 +107,7 @@ NunjucksTag.prototype.run = function(context, args) {
 };
 
 NunjucksTag.prototype._run = function(context, args, body) {
-  return this.fn.call(context.ctx, args.split(' '), body);
+  return this.fn.call(context.ctx, args, body);
 };
 
 function NunjucksBlock(name, fn) {

--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -74,21 +74,20 @@ NunjucksTag.prototype.parse = function(parser, nodes, lexer) {
 NunjucksTag.prototype._parseArgs = function(parser, nodes, lexer) {
   var tag = parser.nextToken();
   var node = new nodes.NodeList(tag.lineno, tag.colno);
-  var args = [];
   var token;
 
   var argarray = new nodes.Array(tag.lineno, tag.colno);
 
   var argitem = "";
   while( (token = parser.nextToken(true)) ){
-    if( token.type == lexer.TOKEN_WHITESPACE || token.type == lexer.TOKEN_BLOCK_END ){
-      if( argitem != "" ){
+    if( token.type === lexer.TOKEN_WHITESPACE || token.type === lexer.TOKEN_BLOCK_END ){
+      if( argitem !== "" ){
         var argnode = new nodes.Literal(tag.lineno, tag.colno, argitem.trim());
         argarray.addChild(argnode);
         argitem = "";
       }
 
-      if( token.type == lexer.TOKEN_BLOCK_END ){
+      if( token.type === lexer.TOKEN_BLOCK_END ){
         break;
       }
     }

--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -78,20 +78,19 @@ NunjucksTag.prototype._parseArgs = function(parser, nodes, lexer) {
 
   var argarray = new nodes.Array(tag.lineno, tag.colno);
 
-  var argitem = "";
-  while( (token = parser.nextToken(true)) ){
-    if( token.type === lexer.TOKEN_WHITESPACE || token.type === lexer.TOKEN_BLOCK_END ){
-      if( argitem !== "" ){
+  var argitem = '';
+  while ((token = parser.nextToken(true))) {
+    if (token.type === lexer.TOKEN_WHITESPACE || token.type === lexer.TOKEN_BLOCK_END) {
+      if (argitem !== '') {
         var argnode = new nodes.Literal(tag.lineno, tag.colno, argitem.trim());
         argarray.addChild(argnode);
-        argitem = "";
+        argitem = '';
       }
 
-      if( token.type === lexer.TOKEN_BLOCK_END ){
+      if (token.type === lexer.TOKEN_BLOCK_END) {
         break;
       }
-    }
-    else {
+    } else {
       argitem += token.value;
     }
   }


### PR DESCRIPTION
I found that when use the tag with space in parameter, even i wrapped it within a string literal, it do not work. For example:

> {% qnimg "image path with space" %}

when this (custom) tag is process, the arguments will become an array of

> ["image", "path", "with", "space"]

instead of 

>["image path with space"]

This is a big issue for any kind of tag ( no matter hexo native tag or custom tag plugin).

I found that the issue is, hexo simply connect all the lexical node to a string and then split it with space, this is not correct and result in the issue i mention.

So i fix it.