### PR TITLE
tag: fix special tag names

### DIFF
--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -3,6 +3,7 @@
 var Schema = require('warehouse').Schema;
 var util = require('hexo-util');
 var slugize = util.slugize;
+var hasOwn = Object.prototype.hasOwnProperty;
 
 module.exports = function(ctx) {
   var Tag = new Schema({
@@ -14,7 +15,9 @@ module.exports = function(ctx) {
     var name = this.name;
     if (!name) return;
 
-    name = map[name] || name;
+    if(hasOwn.call(map, name)) {
+      name = map[name] || name;
+    }
     return slugize(name, {transform: ctx.config.filename_case});
   });
 

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -15,9 +15,10 @@ module.exports = function(ctx) {
     var name = this.name;
     if (!name) return;
 
-    if(hasOwn.call(map, name)) {
+    if (hasOwn.call(map, name)) {
       name = map[name] || name;
     }
+
     return slugize(name, {transform: ctx.config.filename_case});
   });
 


### PR DESCRIPTION
I have a post got tags like this https://gitcafe.com/magicdawn/magicdawn/raw/master/source/_posts/js-constructor-return-value.md

```
tags: 
- js
- constructor
- return
```

Cause `constructor` is a special key. `map['constructor'] === Object`, And will error `str must be string`.


