### PR TITLE
Added `first_line` option to codeblock

### DIFF
--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -12,12 +12,13 @@ var rCaption = /(\S[\S\s]*)/;
 var rLang = /\s*lang:(\w+)/i;
 var rLineNumber = /\s*line_number:(\w+)/i;
 var rHighlight = /\s*highlight:(\w+)/i;
+var rFirstLine = /\s*first_line:(\d+)/i;
 
 /**
  * Code block tag
  *
  * Syntax:
- *   {% codeblock [title] [lang:language] [url] [link text] [line_number:(true|false)] [highlight:(true|false)] %}
+ *   {% codeblock [title] [lang:language] [url] [link text] [line_number:(true|false)] [highlight:(true|false)] [first_line:number] %}
  *   code snippet
  *   {% endcodeblock %}
  */
@@ -42,6 +43,7 @@ module.exports = function(ctx) {
     var caption = '';
     var lang = '';
     var line_number = config.line_number;
+    var first_line = 1;
     var match;
 
     if (rLang.test(arg)) {
@@ -54,6 +56,13 @@ module.exports = function(ctx) {
     if (rLineNumber.test(arg)) {
       arg = arg.replace(rLineNumber, function() {
         line_number = arguments[1] === 'true';
+        return '';
+      });
+    }
+
+    if (rFirstLine.test(arg)) {
+      arg = arg.replace(rFirstLine, function() {
+        first_line = arguments[1];
         return '';
       });
     }
@@ -73,6 +82,7 @@ module.exports = function(ctx) {
 
     content = highlight(content, {
       lang: lang,
+      firstLine: first_line,
       caption: caption,
       gutter: line_number,
       tab: config.tab_replace,

--- a/test/scripts/tags/code.js
+++ b/test/scripts/tags/code.js
@@ -98,4 +98,16 @@ describe('code', function() {
 
     hexo.config.highlight.enable = true;
   });
+
+  it('first_line', function() {
+    var result = code('first_line:1234', fixture);
+    result.should.eql(highlight(fixture, {
+      firstLine: 1234
+    }));
+    result = code('', fixture);
+    result.should.eql(highlight(fixture, {
+      firstLine: 1
+    }));
+  });
+
 });

--- a/test/scripts/tags/code.js
+++ b/test/scripts/tags/code.js
@@ -109,5 +109,4 @@ describe('code', function() {
       firstLine: 1
     }));
   });
-
 });


### PR DESCRIPTION
This way we can use codeblock with any of the fisrt line number , e.g. by doing :

```
{% codeblock lib/hexo/index.js first_line:418 %}
Hexo.prototype.execFilter = function(type, data, options) {
  return this.extend.filter.exec(type, data, options);
};

Hexo.prototype.execFilterSync = function(type, data, options) {
  return this.extend.filter.execSync(type, data, options);
};

{% endcodeblock %}
```

![hexo_firstline_screen](https://cloud.githubusercontent.com/assets/1484327/11330552/6dbbea64-91f0-11e5-8abd-833b245f68a3.png)
