### PR TITLE
OpenGraph: added support for twitter image attribute

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -69,14 +69,15 @@ function openGraphHelper(options) {
   result += og('og:site_name', siteName);
   result += og('og:description', description);
 
-  images.map(function(path) {
+  images = images.map(function(path) {
     if (!urlFn.parse(path).host) {
       if (path[0] !== '/') path = '/' + path;
       return config.url + path;
     }
 
     return path;
-  }).forEach(function(path) {
+  });
+  images.forEach(function(path) {
     result += og('og:image', path);
   });
 
@@ -89,6 +90,10 @@ function openGraphHelper(options) {
   result += meta('twitter:card', twitterCard);
   result += meta('twitter:title', title);
   result += meta('twitter:description', description);
+
+  if(images.length) {
+    result += meta('twitter:image', images[0]);     
+  }
 
   if (options.twitter_id) {
     var twitterId = options.twitter_id;


### PR DESCRIPTION
Added twitter metatag image attribute.
Used the first image as twitter supports only one.