### PR TITLE
Execute 'after_render' filter when rendering with precompiled renderer

### DIFF
--- a/lib/theme/view.js
+++ b/lib/theme/view.js
@@ -104,15 +104,28 @@ View.prototype._precompile = function() {
   };
 
   if (typeof renderer.compile === 'function') {
-    var compiled = this._compiledSync = renderer.compile(data);
+    var compiled = renderer.compile(data);
+
+    function buildFilterArguments(result) {
+      var output = render.getOutput(ext) || ext;
+      return [
+        'after_render:' + output,
+        result,
+        {
+          context: ctx,
+          args: [data]
+        }
+      ];
+    }
+
+    this._compiledSync = function(locals) {
+      var result = compiled(locals);
+      return ctx.execFilterSync.apply(ctx, buildFilterArguments(result));
+    };
     this._compiled = (function(locals) {
       return Promise.resolve(compiled(locals))
         .then(function(result) {
-          var output = render.getOutput(ext) || ext;
-          return ctx.execFilter('after_render:' + output, result, {
-            context: ctx,
-            args: [data]
-          });
+          return ctx.execFilter.apply(ctx, buildFilterArguments(result));
         });
     });
   } else {

--- a/lib/theme/view.js
+++ b/lib/theme/view.js
@@ -105,13 +105,15 @@ View.prototype._precompile = function() {
 
   if (typeof renderer.compile === 'function') {
     var compiled = this._compiledSync = renderer.compile(data);
-    this._compiled = Promise.method(function(locals) {
-      var result = compiled(locals);
-      var output = render.getOutput(ext) || ext;
-      return ctx.execFilter('after_render:' + output, result, {
-        context: ctx,
-        args: [data]
-      });
+    this._compiled = (function(locals) {
+      return Promise.resolve(compiled(locals))
+        .then(function(result) {
+          var output = render.getOutput(ext) || ext;
+          return ctx.execFilter('after_render:' + output, result, {
+            context: ctx,
+            args: [data]
+          });
+        });
     });
   } else {
     this._compiledSync = function(locals) {

--- a/lib/theme/view.js
+++ b/lib/theme/view.js
@@ -103,25 +103,26 @@ View.prototype._precompile = function() {
     text: this.data._content
   };
 
+  function buildFilterArguments(result) {
+    var output = render.getOutput(ext) || ext;
+    return [
+      'after_render:' + output,
+      result,
+      {
+        context: ctx,
+        args: [data]
+      }
+    ];
+  }
+
   if (typeof renderer.compile === 'function') {
     var compiled = renderer.compile(data);
-
-    function buildFilterArguments(result) {
-      var output = render.getOutput(ext) || ext;
-      return [
-        'after_render:' + output,
-        result,
-        {
-          context: ctx,
-          args: [data]
-        }
-      ];
-    }
 
     this._compiledSync = function(locals) {
       var result = compiled(locals);
       return ctx.execFilterSync.apply(ctx, buildFilterArguments(result));
     };
+
     this._compiled = (function(locals) {
       return Promise.resolve(compiled(locals))
         .then(function(result) {

--- a/lib/theme/view.js
+++ b/lib/theme/view.js
@@ -95,7 +95,9 @@ View.prototype._resolveLayout = function(name) {
 
 View.prototype._precompile = function() {
   var render = this._render;
-  var renderer = render.getRenderer(pathFn.extname(this.path));
+  var ctx = render.context;
+  var ext = pathFn.extname(this.path);
+  var renderer = render.getRenderer(ext);
   var data = {
     path: this.source,
     text: this.data._content
@@ -103,7 +105,14 @@ View.prototype._precompile = function() {
 
   if (typeof renderer.compile === 'function') {
     var compiled = this._compiledSync = renderer.compile(data);
-    this._compiled = Promise.method(compiled);
+    this._compiled = Promise.method(function(locals) {
+      var result = compiled(locals);
+      var output = render.getOutput(ext) || ext;
+      return ctx.execFilter('after_render:' + output, result, {
+        context: ctx,
+        args: [data]
+      });
+    });
   } else {
     this._compiledSync = function(locals) {
       return render.renderSync(data, locals);

--- a/test/scripts/theme/view.js
+++ b/test/scripts/theme/view.js
@@ -5,6 +5,7 @@ var pathFn = require('path');
 var fs = require('hexo-fs');
 var Promise = require('bluebird');
 var moment = require('moment');
+var sinon = require('sinon');
 
 describe('View', function() {
   var Hexo = require('../../../lib/hexo');
@@ -201,6 +202,29 @@ describe('View', function() {
     });
   });
 
+  it('render() - execute after_render:html', function() {
+    var body = [
+      '{{ test }}'
+    ].join('\n');
+
+    var view = newView('index.swig', body);
+
+    var filter = sinon.spy(function(result) {
+      result.should.eql('foo');
+      return 'bar';
+    });
+
+    hexo.extend.filter.register('after_render:html', filter);
+
+    return view.render({
+      test: 'foo'
+    }).then(function(content) {
+      content.should.eql('bar');
+    }).finally(function() {
+      hexo.extend.filter.unregister('after_render:html', filter);
+    });
+  });
+
   it('renderSync()', function() {
     var body = [
       '{{ test }}'
@@ -256,6 +280,23 @@ describe('View', function() {
     view.renderSync({
       layout: 'wtf'
     }).should.eql(body);
+  });
+
+  it('renderSync() - execute after_render:html', function() {
+    var body = [
+      '{{ test }}'
+    ].join('\n');
+
+    var view = newView('index.swig', body);
+
+    var filter = sinon.spy(function(result) {
+      result.should.eql('foo');
+      return 'bar';
+    });
+
+    hexo.extend.filter.register('after_render:html', filter);
+    view.renderSync({test: 'foo'}).should.eql('bar');
+    hexo.extend.filter.unregister('after_render:html', filter);
   });
 
   it('_resolveLayout()', function() {


### PR DESCRIPTION
As reported in #1791, if a renderer supports precompilation, the `'after_render'` filter will not be executed after the actual rendering is done. This is different from previous version's behavior and will potentially break plugins that consume this filter.

In previous version, rendering layout `layouts/foo.ejs` will trigger `after_render:html` filter. An important use case for this behavior is that a plugin can inject `<script>` tags once per generated page dynamically based on its content. 

For example, [hexo-math](https://github.com/akfish/hexo-math) scans generated html for MathJax expressions and inject MathJax on-demand from `after_render:html`. With this behavior gone, the alternative would be modifying theme layouts directly, which is too messy and error-prone.
