### PR TITLE
codeblock tag : escape HTML code otherwise it will be interpreted by the browser

### DIFF
--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -3,6 +3,7 @@
 // Based on: https://raw.github.com/imathis/octopress/master/plugins/code_block.rb
 
 var util = require('hexo-util');
+var escapeHTML = util.escapeHTML;
 var highlight = util.highlight;
 var stripIndent = require('strip-indent');
 
@@ -38,7 +39,7 @@ module.exports = function(ctx) {
     }
 
     if (!enable) {
-      content = content.replace(/</g, '&lt;');
+      content = escapeHTML(content);
       return '<pre><code>' + content + '</code></pre>';
     }
 

--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -38,6 +38,7 @@ module.exports = function(ctx) {
     }
 
     if (!enable) {
+      content = content.replace(/</g, '&lt;');
       return '<pre><code>' + content + '</code></pre>';
     }
 

--- a/test/scripts/tags/code.js
+++ b/test/scripts/tags/code.js
@@ -8,7 +8,8 @@ describe('code', function() {
   var Hexo = require('../../../lib/hexo');
   var hexo = new Hexo();
   var codeTag = require('../../../lib/plugins/tag/code')(hexo);
-
+  var escapeHTML = util.escapeHTML;
+  
   var fixture = [
     'if (tired && night){',
     '  sleep();',
@@ -63,7 +64,7 @@ describe('code', function() {
 
   it('highlight disable', function() {
     var result = code('highlight:false', fixture);
-    result.should.eql('<pre><code>' + fixture + '</code></pre>');
+    result.should.eql('<pre><code>' + escapeHTML(fixture) + '</code></pre>');
   });
 
   it('title', function() {
@@ -95,7 +96,7 @@ describe('code', function() {
     hexo.config.highlight.enable = false;
 
     var result = code('', fixture);
-    result.should.eql('<pre><code>' + fixture + '</code></pre>');
+    result.should.eql('<pre><code>' + escapeHTML(fixture) + '</code></pre>');
 
     hexo.config.highlight.enable = true;
   });


### PR DESCRIPTION
Hey, when highlight.js is disabled, `<` must be escaped otherwise HTML code is interpreted by the browser.