### PR TITLE
keywords meta seo: Added lean option to tag model

### DIFF
--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -76,7 +76,7 @@ module.exports = function(ctx) {
       return item.tag_id;
     });
 
-    return Tag.find({_id: {$in: ids}});
+    return Tag.find({_id: {$in: ids}}, {lean:true});
   });
 
   Post.method('setTags', function(tags) {


### PR DESCRIPTION
The keywords meta tag wasn't generating accordingly. Opened issue #1828

In open_graph.js:

```javascript
  var keywords = page.tags;
  ...
  if (keywords && Array.isArray(keywords))
```
keywords wasn't an array, was an queried object (lack of lean option). This way the keywords will never be added to result meta tag.