### PR TITLE
#1855: Addresses "TypeError: Cannot read property 'compile' of undefined" 

### DIFF
--- a/lib/theme/view.js
+++ b/lib/theme/view.js
@@ -115,6 +115,7 @@ View.prototype._precompile = function() {
     ];
   }
 
+  if (!renderer) return;
   if (typeof renderer.compile === 'function') {
     var compiled = renderer.compile(data);
 


### PR DESCRIPTION
This checks to make sure an object is returned from `render.getRenderer(ext);`.

The following snippet changes https://github.com/hexojs/hexo/blob/master/lib/theme/processors/view.js#L18 to be something like https://github.com/hexojs/hexo/blob/master/lib/theme/processors/source.js#L28-L35, but there may be cases it doesn't properly account for.
```
exports.pattern = new Pattern(function(path) {
  if (!_.startsWith(path, 'layout/')) return false;

  path = path.substring(7);
  var regex = /(^|\/)[\.]/;
  if (regex.test(path) || common.isTmpFile(path) || ~path.indexOf('node_modules')) return false;

  return {path: path};
});
```