### PR TITLE
Fix the unit test on permalink_root_prefix - virtual

### DIFF
--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -88,12 +88,13 @@ describe('Post', function() {
   });
 
   it('permalink_root_prefix - virtual', function() {
+    hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';
     return Post.insert({
       source: 'foo.md',
       slug: 'bar'
     }).then(function(data) {
-      data.permalink.should.eql(hexo.config.url + '/root/' + data.path);
+      data.permalink.should.eql('http://yoursite.com/root/' + data.path);
       return Post.removeById(data._id);
     });
   });

--- a/test/scripts/tags/img.js
+++ b/test/scripts/tags/img.js
@@ -24,6 +24,7 @@ describe('img', function() {
     var $ = cheerio.load(img(['/images/test.jpg']));
     $('img').attr('src').should.eql('/images/test.jpg');
 
+    hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img(['/images/test.jpg']));
     $('img').attr('src').should.eql('/root/images/test.jpg');
@@ -42,6 +43,7 @@ describe('img', function() {
     $('img').attr('src').should.eql('/images/test.jpg');
     $('img').attr('class').should.eql('left');
 
+    hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img('left /images/test.jpg'.split(' ')));
     $('img').attr('src').should.eql('/root/images/test.jpg');
@@ -61,6 +63,7 @@ describe('img', function() {
     $('img').attr('src').should.eql('/images/test.jpg');
     $('img').attr('class').should.eql('left top');
 
+    hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img('left top /images/test.jpg'.split(' ')));
     $('img').attr('src').should.eql('/root/images/test.jpg');


### PR DESCRIPTION
When the site is put in a subdirectory we have the
`url = 'http://yoursite.com/root';` and
`root = '/root/';`
But the test only set `hexo.config.root` but not `hexo.config.url`.
So the test cannot catch the bug in issue #1812 .

I cannot pass the unit test when I fix the bug.