### PR TITLE
Fix the wrong share link when the site is in subdirectory

### DIFF
--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -55,9 +55,10 @@ module.exports = function(ctx) {
   });
 
   Post.virtual('permalink').get(function() {
+    var url_for = ctx.extend.helper.get('url_for');
     var config = ctx.config;
-
-    return config.url + config.root + this.path;
+    var partial_url = url_for.call(ctx, this.path);
+    return config.url + _.replace(partial_url, config.root, '/');
   });
 
   Post.virtual('full_source').get(function() {

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -88,12 +88,13 @@ describe('Post', function() {
   });
 
   it('permalink_root_prefix - virtual', function() {
+    hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';
     return Post.insert({
       source: 'foo.md',
       slug: 'bar'
     }).then(function(data) {
-      data.permalink.should.eql(hexo.config.url + '/root/' + data.path);
+      data.permalink.should.eql('http://yoursite.com/root/' + data.path);
       return Post.removeById(data._id);
     });
   });

--- a/test/scripts/tags/img.js
+++ b/test/scripts/tags/img.js
@@ -24,6 +24,7 @@ describe('img', function() {
     var $ = cheerio.load(img(['/images/test.jpg']));
     $('img').attr('src').should.eql('/images/test.jpg');
 
+    hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img(['/images/test.jpg']));
     $('img').attr('src').should.eql('/root/images/test.jpg');
@@ -42,6 +43,7 @@ describe('img', function() {
     $('img').attr('src').should.eql('/images/test.jpg');
     $('img').attr('class').should.eql('left');
 
+    hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img('left /images/test.jpg'.split(' ')));
     $('img').attr('src').should.eql('/root/images/test.jpg');
@@ -61,6 +63,7 @@ describe('img', function() {
     $('img').attr('src').should.eql('/images/test.jpg');
     $('img').attr('class').should.eql('left top');
 
+    hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img('left top /images/test.jpg'.split(' ')));
     $('img').attr('src').should.eql('/root/images/test.jpg');


### PR DESCRIPTION
Fix the bug mentioned in #1812 

When the site is in subdirectory, we are suggest to have set url
as 'http://yoursite.com/child' and root as '/child/'.
But the share link in article footer will become
'http://yoursite.com/child/child/slug'.

Fix the bug by replace '/child/' by '/' in virtual link.