### PR TITLE
Remove unnecessary `npm install` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ $ npm install hexo-cli -g
 ``` bash
 $ hexo init blog
 $ cd blog
-$ npm install
 ```
 
 **Start the server**


### PR DESCRIPTION
`hexo init blog` already performs `npm install`.