### PR TITLE
fix this.relative_url is not a function

### DIFF
--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -2,6 +2,7 @@
 
 var url = require('url');
 var _ = require('lodash');
+var relativeUrl = require('./relative_url');
 
 function urlForHelper(path, options) {
   path = path || '/';
@@ -25,7 +26,7 @@ function urlForHelper(path, options) {
 
   // Resolve relative url
   if (options.relative) {
-    return this.relative_url(this.path, path);
+    return relativeUrl(this.path, path);
   }
 
   // Prepend root path


### PR DESCRIPTION
#1680 
fix `TypeError: this.relative_url is not a function` when config `relative_link: true`