### PR TITLE
Access data files from source folder

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -324,7 +324,7 @@ Hexo.prototype._generate = function(options) {
   Locals.prototype.view_dir = pathFn.join(this.theme_dir, 'layout') + sep;
 
   // Run before_generate filters
-  return this.execFilter('before_generate', null, {context: this})
+  return this.execFilter('before_generate', self.locals.get('data'), {context: this})
   .then(function() {
     self.locals.invalidate();
     siteLocals = self.locals.toObject();

--- a/lib/plugins/filter/before_generate/render_post.js
+++ b/lib/plugins/filter/before_generate/render_post.js
@@ -2,7 +2,7 @@
 
 var Promise = require('bluebird');
 
-function renderPostFilter() {
+function renderPostFilter(data) {
   var self = this;
 
   function renderPosts(model) {
@@ -12,6 +12,7 @@ function renderPostFilter() {
 
     return Promise.map(posts, function(post) {
       post.content = post._content;
+      post.site = {data: data};
 
       return self.post.render(post.full_source, post).then(function() {
         return post.save();

--- a/test/scripts/box/box.js
+++ b/test/scripts/box/box.js
@@ -479,7 +479,7 @@ describe('Box', function() {
     var box = newBox('test');
     var processor = sinon.spy();
 
-    box.watch().then(function() {
+    return box.watch().then(function() {
       box.addProcessor(processor);
       box.unwatch();
 

--- a/test/scripts/filters/render_post.js
+++ b/test/scripts/filters/render_post.js
@@ -51,4 +51,23 @@ describe('Render post', function() {
       return page.remove();
     });
   });
+
+  it('use data variables', function() {
+    var id;
+
+    return Page.insert({
+      source: 'foo.md',
+      path: 'foo.html',
+      _content: '<p>Hello {{site.data.foo.name}}</p>'
+    }).then(function(page) {
+      id = page._id;
+      return renderPost({foo: {name: 'Hexo'}});
+    }).then(function() {
+      var page = Page.findById(id);
+      page.content.trim().should.eql('<p>Hello Hexo</p>');
+
+      return page.remove();
+    });
+  });
+
 });

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -90,6 +90,15 @@ describe('Hexo', function() {
     });
   });
 
+  it('call() - callback without args', function(callback) {
+    hexo.call('test', function(err, data) {
+      should.not.exist(err);
+      data.should.eql({});
+
+      callback();
+    });
+  });
+
   it('call() - console not registered', function() {
     var errorCallback = sinon.spy(function(err) {
       err.should.have.property('message', 'Console `nothing` has not been registered yet!');


### PR DESCRIPTION
This allows pages in the `source` folder to access properties in the `source/_data` files.

For example, in `source/index.html`:
```
<p>Hello {{site.data.foo.name}}</p>
```