### PR TITLE
Add tests for og:updated_time in open_graph helper, and add ability to turn it off

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -37,7 +37,7 @@ function openGraphHelper(options) {
   var url = options.url || this.url;
   var siteName = options.site_name || config.title;
   var twitterCard = options.twitter_card || 'summary';
-  var updated = options.updated || page.updated;
+  var updated = options.updated !== false ? (options.updated || page.updated) : false;
   var result = '';
 
   if (!Array.isArray(images)) images = [images];

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var moment = require('moment');
 var should = require('chai').should(); // eslint-disable-line
 
 describe('open_graph', function() {
@@ -371,4 +372,35 @@ describe('open_graph', function() {
 
     result.should.contain(meta({property: 'fb:app_id', content: '123456789'}));
   });
+
+  it('updated - options', function() {
+    var result = openGraph.call({
+      page: { updated: moment('2016-05-23T21:20:21.372Z') },
+      config: {},
+      is_post: isPost
+    }, { });
+
+    result.should.contain(meta({property: 'og:updated_time', content: '2016-05-23T21:20:21.372Z'}));
+  });
+
+  it('updated - options - allow overriding og:updated_time', function() {
+    var result = openGraph.call({
+      page: { updated: moment('2016-05-23T21:20:21.372Z') },
+      config: {},
+      is_post: isPost
+    }, { updated: moment('2015-04-22T20:19:20.371Z') });
+
+    result.should.contain(meta({property: 'og:updated_time', content: '2015-04-22T20:19:20.371Z'}));
+  });
+
+  it('updated - options - allow disabling og:updated_time', function() {
+    var result = openGraph.call({
+      page: { updated: moment('2016-05-23T21:20:21.372Z') },
+      config: {},
+      is_post: isPost
+    }, { updated: false });
+
+    result.should.not.contain(meta({property: 'og:updated_time', content: '2016-05-23T21:20:21.372Z'}));
+  });
+
 });


### PR DESCRIPTION
I think I might be one of [very few people](https://github.com/search?utf8=%E2%9C%93&q=open_graph+updated+extension%3Aejs&type=Code&ref=advsearch&l=&l=) who have ever tried to do this…

I deploy my static site from CircleCI to S3 automatically (the tool I used to actually push the files to S3 compares the MD5 hashes of the locally generated files against those in AWS and skips any that haven't change) when I push to `master` because on each build the `og:updated_time` changes it re-uploads each article.

I've worked around this by now after discovering if you set the `updated` option of the `open_graph` helper to be a string [that removes the `og:updated_time` meta tag](https://github.com/matthew-andrews/mattandre.ws/commit/1b7559837b87b56ae46536fb7e34e8addc3f3f81)…… But this feels like a bit of a hack.

It would be nice if you could just do:-

```js
open_graph({
  twitter_id: config.twitter,
  google_plus: config.google_plus,
  updated: false
});
```

So that's what this pull requests adds support for.  Also I notice the `og:updated_time` feature didn't have any tests, so I added a couple.

Thanks.

Matt