### PR TITLE
Don't add /(?:og:|twitter:)?description/ meta tags if there is no description (invalid HTML)

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -63,7 +63,10 @@ function openGraphHelper(options) {
     });
   }
 
-  result += meta('description', description);
+  if (description) {
+    result += meta('description', description);
+  }
+
   if (keywords && Array.isArray(keywords)) {
     result += meta('keywords', keywords.map(function(tag) {
       return tag.name;
@@ -76,7 +79,9 @@ function openGraphHelper(options) {
   result += og('og:title', title);
   result += og('og:url', url);
   result += og('og:site_name', siteName);
-  result += og('og:description', description);
+  if (description) {
+    result += og('og:description', description);
+  }
 
   images = images.map(function(path) {
     if (!urlFn.parse(path).host) {
@@ -99,7 +104,9 @@ function openGraphHelper(options) {
 
   result += meta('twitter:card', twitterCard);
   result += meta('twitter:title', title);
-  result += meta('twitter:description', description);
+  if (description) {
+    result += meta('twitter:description', description);
+  }
 
   if (images.length) {
     result += meta('twitter:image', images[0]);

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -27,16 +27,13 @@ describe('open_graph', function() {
     });
 
     result.should.eql([
-      meta({name: 'description'}),
       meta({name: 'keywords', content: 'optimize,web'}),
       meta({property: 'og:type', content: 'website'}),
       meta({property: 'og:title', content: hexo.config.title}),
       meta({property: 'og:url'}),
       meta({property: 'og:site_name', content: hexo.config.title}),
-      meta({property: 'og:description'}),
       meta({name: 'twitter:card', content: 'summary'}),
-      meta({name: 'twitter:title', content: hexo.config.title}),
-      meta({name: 'twitter:description'})
+      meta({name: 'twitter:title', content: hexo.config.title})
     ].join('\n'));
   });
 
@@ -401,6 +398,18 @@ describe('open_graph', function() {
     }, { updated: false });
 
     result.should.not.contain(meta({property: 'og:updated_time', content: '2016-05-23T21:20:21.372Z'}));
+  });
+
+  it('description - do not add /(?:og:|twitter:)?description/ meta tags if there is no description', function() {
+    var result = openGraph.call({
+      page: { },
+      config: {},
+      is_post: isPost
+    }, { });
+
+    result.should.not.contain(meta({property: 'og:description'}));
+    result.should.not.contain(meta({property: 'twitter:description'}));
+    result.should.not.contain(meta({property: 'description'}));
   });
 
 });


### PR DESCRIPTION
I believe `content` is a required attribute, so without it and without a description you get invalid markup.
http://htmldoctor.info/reference/html/meta.html

A suggested fix and tests ☺️ 