### PR TITLE
解决 jsfiddle 标签插件在 https 下报非 https 的警告

### DIFF
--- a/lib/plugins/tag/jsfiddle.js
+++ b/lib/plugins/tag/jsfiddle.js
@@ -14,7 +14,7 @@ function jsfiddleTag(args, content) {
   var width = args[3] && args[3] !== 'default' ? args[3] : '100%';
   var height = args[4] && args[4] !== 'default' ? args[4] : '300';
 
-  return '<iframe scrolling="no" width="' + width + '" height="' + height + '" src="http://jsfiddle.net/' + id + '/embedded/' + tabs + '/' + skin + '" frameborder="0" allowfullscreen></iframe>';
+  return '<iframe scrolling="no" width="' + width + '" height="' + height + '" src="//jsfiddle.net/' + id + '/embedded/' + tabs + '/' + skin + '" frameborder="0" allowfullscreen></iframe>';
 }
 
 module.exports = jsfiddleTag;

--- a/test/scripts/tags/jsfiddle.js
+++ b/test/scripts/tags/jsfiddle.js
@@ -9,27 +9,27 @@ describe('jsfiddle', function() {
   it('id', function() {
     var $ = cheerio.load(jsfiddle(['foo']));
 
-    $('iframe').attr('src').should.eql('http://jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
+    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
   });
 
   it('tabs', function() {
     var $ = cheerio.load(jsfiddle(['foo', 'default']));
 
-    $('iframe').attr('src').should.eql('http://jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
+    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
 
     $ = cheerio.load(jsfiddle(['foo', 'html,css']));
 
-    $('iframe').attr('src').should.eql('http://jsfiddle.net/foo/embedded/html,css/light');
+    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/html,css/light');
   });
 
   it('skin', function() {
     var $ = cheerio.load(jsfiddle(['foo', 'default', 'default']));
 
-    $('iframe').attr('src').should.eql('http://jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
+    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
 
     $ = cheerio.load(jsfiddle(['foo', 'default', 'dark']));
 
-    $('iframe').attr('src').should.eql('http://jsfiddle.net/foo/embedded/js,resources,html,css,result/dark');
+    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/js,resources,html,css,result/dark');
   });
 
   it('width', function() {


### PR DESCRIPTION
在使用 jsfiddle 标签插件生成的 iframe 中的 src 地址默认是包含 `http://` 前缀的，如  `http://jsfiddle.net/xxxxxxx/embedded/result,css,html/light`

这会导致在 HTTPS 的网站中出现非 https 的内容，导致抛出警告，并且地址栏中的小锁加黄色警告标识。 jsfiddle 官方的 emmbed 插件地址已经去掉了前面的 http 前缀，所以这里可以放心的改成 `//jsfiddle.net/` 了