### PR TITLE
Return null from hexo.generate

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -390,6 +390,7 @@ Hexo.prototype._generate = function(options) {
 
         log.warn('No layout: %s', chalk.magenta(path));
       });
+      return null;
     });
   }).then(function() {
     // Remove old routes


### PR DESCRIPTION
- When using hexo.generate from a gulp task, the following warning is generated:
  `Warning: a promise was created in a handler but was not returned from it` (see https://goo.gl/rRqMUw for details). Explicitly returning null here silences this warning.
