### PR TITLE
support for multiple config files (#2210)

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -22,7 +22,6 @@ var Router = require('./router');
 var Theme = require('../theme');
 var Locals = require('./locals');
 var defaultConfig = require('./default_config');
-var multiConfigPath = require('./multi_config_path');
 var loadDatabase = require('./load_database');
 
 var libDir = pathFn.dirname(__dirname);
@@ -54,8 +53,9 @@ function Hexo(base, args) {
     init: false
   };
 
+  var multiConfigPath = require('./multi_config_path')(this);
   this.config_path = args.config ? multiConfigPath(base, args.config)
-                                 : pathFn.join(base, '_config.yml');
+                                   : pathFn.join(base, '_config.yml');
 
   this.extend = {
     console: new extend.Console(),
@@ -325,7 +325,7 @@ Hexo.prototype._generate = function(options) {
   Locals.prototype.view_dir = pathFn.join(this.theme_dir, 'layout') + sep;
 
   // Run before_generate filters
-  return this.execFilter('before_generate', self.locals.get('data'), {context: this})
+  return this.execFilter('before_generate', null, {context: this})
   .then(function() {
     self.locals.invalidate();
     siteLocals = self.locals.toObject();

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -22,6 +22,7 @@ var Router = require('./router');
 var Theme = require('../theme');
 var Locals = require('./locals');
 var defaultConfig = require('./default_config');
+var multiConfigPath = require('./multiconfig_path');
 var loadDatabase = require('./load_database');
 
 var libDir = pathFn.dirname(__dirname);
@@ -53,7 +54,7 @@ function Hexo(base, args) {
     init: false
   };
 
-  this.config_path = args.config ? pathFn.resolve(base, args.config)
+  this.config_path = args.config ? multiConfigPath(base, args.config)
                                  : pathFn.join(base, '_config.yml');
 
   this.extend = {

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -55,7 +55,7 @@ function Hexo(base, args) {
 
   var multiConfigPath = require('./multi_config_path')(this);
   this.config_path = args.config ? multiConfigPath(base, args.config)
-                                   : pathFn.join(base, '_config.yml');
+                                 : pathFn.join(base, '_config.yml');
 
   this.extend = {
     console: new extend.Console(),
@@ -325,7 +325,7 @@ Hexo.prototype._generate = function(options) {
   Locals.prototype.view_dir = pathFn.join(this.theme_dir, 'layout') + sep;
 
   // Run before_generate filters
-  return this.execFilter('before_generate', null, {context: this})
+  return this.execFilter('before_generate', self.locals.get('data'), {context: this})
   .then(function() {
     self.locals.invalidate();
     siteLocals = self.locals.toObject();

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -22,7 +22,7 @@ var Router = require('./router');
 var Theme = require('../theme');
 var Locals = require('./locals');
 var defaultConfig = require('./default_config');
-var multiConfigPath = require('./multiconfig_path');
+var multiConfigPath = require('./multi_config_path');
 var loadDatabase = require('./load_database');
 
 var libDir = pathFn.dirname(__dirname);

--- a/lib/hexo/multi_config_path.js
+++ b/lib/hexo/multi_config_path.js
@@ -2,66 +2,69 @@
 
 var pathFn = require('path');
 var fs = require('hexo-fs');
-var log = require('hexo-log')();
 var deepAssign = require('deep-assign');
 var yml = require('js-yaml');
 
-module.exports = function multiConfigPath(base, configPaths) {
-  var defaultPath = pathFn.join(base, '_config.yml');
-  var outputPath = pathFn.join(base, '_multiconfig.yml');
-  var paths;
+module.exports = function(ctx) {
+  return function multiConfigPath(base, configPaths) {
+    var log = require('hexo-log')(ctx.env);
 
-  if (!configPaths) {
-    log.w('No config file entered.');
-    return pathFn.join(base, '_config.yml');
-  }
+    var defaultPath = pathFn.join(base, '_config.yml');
+    var outputPath = pathFn.join(base, '_multiconfig.yml');
+    var paths;
 
-  // determine if comma or space separated
-  if (configPaths.indexOf(',') > -1) {
-    paths = configPaths.replace(' ', '').split(',');
-
-  } else {
-    // only one config
-    if (!fs.existsSync(pathFn.join(base, configPaths))) {
-      log.w('Config file ' + configPaths + ' not found, using default.');
-      return defaultPath;
+    if (!configPaths) {
+      log.w('No config file entered.');
+      return pathFn.join(base, '_config.yml');
     }
 
-    return pathFn.resolve(base, configPaths);
-  }
+    // determine if comma or space separated
+    if (configPaths.indexOf(',') > -1) {
+      paths = configPaths.replace(' ', '').split(',');
 
-  var numPaths = paths.length;
-
-  // combine files
-  var combinedConfig = {};
-  var count = 0;
-  for (var i = 0; i < numPaths; i++) {
-    if (!fs.existsSync(pathFn.join(base, paths[i]))) {
-      log.w('Config file ' + paths[i] + ' not found.');
-      continue;
-    }
-
-    // files read synchronously to ensure proper overwrite order
-    var file = fs.readFileSync(paths[i]);
-    var ext = pathFn.extname(paths[i]).toLowerCase();
-
-    if (ext === '.yml') {
-      deepAssign(combinedConfig, yml.safeLoad(file));
-      count++;
-    } else if (ext === '.json') {
-      deepAssign(combinedConfig, yml.safeLoad(file, {json: true}));
-      count++;
     } else {
-      log.w('Config file ' + paths[i] +
-                                ' not supported type.');
+      // only one config
+      if (!fs.existsSync(pathFn.join(base, configPaths))) {
+        log.w('Config file ' + configPaths + ' not found, using default.');
+        return defaultPath;
+      }
+
+      return pathFn.resolve(base, configPaths);
     }
-  }
 
-  log.i('Config based on', count, 'files');
+    var numPaths = paths.length;
 
-  outputPath = pathFn.join(base, outputPath);
-  fs.writeFileSync(outputPath, yml.dump(combinedConfig));
+    // combine files
+    var combinedConfig = {};
+    var count = 0;
+    for (var i = 0; i < numPaths; i++) {
+      if (!fs.existsSync(pathFn.join(base, paths[i]))) {
+        log.w('Config file ' + paths[i] + ' not found.');
+        continue;
+      }
 
-  // write file and return path
-  return outputPath;
+      // files read synchronously to ensure proper overwrite order
+      var file = fs.readFileSync(paths[i]);
+      var ext = pathFn.extname(paths[i]).toLowerCase();
+
+      if (ext === '.yml') {
+        deepAssign(combinedConfig, yml.safeLoad(file));
+        count++;
+      } else if (ext === '.json') {
+        deepAssign(combinedConfig, yml.safeLoad(file, {json: true}));
+        count++;
+      } else {
+        log.w('Config file ' + paths[i] +
+                                  ' not supported type.');
+      }
+    }
+
+    log.i('Config based on', count, 'files');
+
+    outputPath = pathFn.join(base, outputPath);
+    fs.writeFileSync(outputPath, yml.dump(combinedConfig));
+
+    // write file and return path
+    return outputPath;
+  };
 };

--- a/lib/hexo/multi_config_path.js
+++ b/lib/hexo/multi_config_path.js
@@ -10,7 +10,6 @@ module.exports = function(ctx) {
     var log = require('hexo-log')(ctx.env);
 
     var defaultPath = pathFn.join(base, '_config.yml');
-    var outputPath = pathFn.join(base, '_multiconfig.yml');
     var paths;
 
     if (!configPaths) {
@@ -44,7 +43,7 @@ module.exports = function(ctx) {
       }
 
       // files read synchronously to ensure proper overwrite order
-      var file = fs.readFileSync(paths[i]);
+      var file = fs.readFileSync(pathFn.join(base, paths[i]));
       var ext = pathFn.extname(paths[i]).toLowerCase();
 
       if (ext === '.yml') {
@@ -61,7 +60,7 @@ module.exports = function(ctx) {
 
     log.i('Config based on', count, 'files');
 
-    outputPath = pathFn.join(base, outputPath);
+    var outputPath = pathFn.join(base, '_multiconfig.yml');
     fs.writeFileSync(outputPath, yml.dump(combinedConfig));
 
     // write file and return path

--- a/lib/hexo/multi_config_path.js
+++ b/lib/hexo/multi_config_path.js
@@ -2,13 +2,19 @@
 
 var pathFn = require('path');
 var fs = require('hexo-fs');
-var chalk = require('chalk');
+var log = require('hexo-log')();
 var deepAssign = require('deep-assign');
 var yml = require('js-yaml');
 
 module.exports = function multiConfigPath(base, configPaths) {
-  var outputPath = '_multiconfig.yml';
+  var defaultPath = pathFn.join(base, '_config.yml');
+  var outputPath = pathFn.join(base, '_multiconfig.yml');
   var paths;
+
+  if (!configPaths) {
+    log.w('No config file entered.');
+    return pathFn.join(base, '_config.yml');
+  }
 
   // determine if comma or space separated
   if (configPaths.indexOf(',') > -1) {
@@ -16,9 +22,10 @@ module.exports = function multiConfigPath(base, configPaths) {
 
   } else {
     // only one config
-    if(!fs.existsSync(pathFn.join(base, configPaths)))
-      console.warn(chalk.yellow('Config file '+configPaths+
-                                ' not found, using default.'));
+    if (!fs.existsSync(pathFn.join(base, configPaths))) {
+      log.w('Config file ' + configPaths + ' not found, using default.');
+      return defaultPath;
+    }
 
     return pathFn.resolve(base, configPaths);
   }
@@ -27,9 +34,10 @@ module.exports = function multiConfigPath(base, configPaths) {
 
   // combine files
   var combinedConfig = {};
-  for (var i = 0 ; i < numPaths ; i++) {
+  var count = 0;
+  for (var i = 0; i < numPaths; i++) {
     if (!fs.existsSync(pathFn.join(base, paths[i]))) {
-      console.warn(chalk.yellow('Config file '+paths[i]+' not found, using default.'));
+      log.w('Config file ' + paths[i] + ' not found.');
       continue;
     }
 
@@ -39,16 +47,21 @@ module.exports = function multiConfigPath(base, configPaths) {
 
     if (ext === '.yml') {
       deepAssign(combinedConfig, yml.safeLoad(file));
+      count++;
     } else if (ext === '.json') {
       deepAssign(combinedConfig, yml.safeLoad(file, {json: true}));
+      count++;
     } else {
-      console.warn(chalk.yellow('Config file '+paths[i]+' not found, using default.'));
+      log.w('Config file ' + paths[i] +
+                                ' not supported type.');
     }
   }
 
+  log.i('Config based on', count, 'files');
+
   outputPath = pathFn.join(base, outputPath);
-  fs.writeFileSync(outputPath, yml.dump(combinedConfig))
+  fs.writeFileSync(outputPath, yml.dump(combinedConfig));
 
   // write file and return path
   return outputPath;
-}
+};

--- a/lib/hexo/multi_config_path.js
+++ b/lib/hexo/multi_config_path.js
@@ -7,7 +7,7 @@ var yml = require('js-yaml');
 
 module.exports = function(ctx) {
   return function multiConfigPath(base, configPaths) {
-    var log = require('hexo-log')(ctx.env);
+    var log = ctx.log;
 
     var defaultPath = pathFn.join(base, '_config.yml');
     var paths;
@@ -56,6 +56,11 @@ module.exports = function(ctx) {
         log.w('Config file ' + paths[i] +
                                   ' not supported type.');
       }
+    }
+
+    if (count === 0) {
+      log.e('No config files found. Using _config.yml.');
+      return defaultPath;
     }
 
     log.i('Config based on', count, 'files');

--- a/lib/hexo/multi_config_path.js
+++ b/lib/hexo/multi_config_path.js
@@ -16,7 +16,10 @@ module.exports = function multiConfigPath(base, configPaths) {
 
   } else {
     // only one config
-    console.warn(chalk.yellow('Config file '+configPaths+' not found, using default.'));
+    if(!fs.existsSync(pathFn.join(base, configPaths)))
+      console.warn(chalk.yellow('Config file '+configPaths+
+                                ' not found, using default.'));
+
     return pathFn.resolve(base, configPaths);
   }
 

--- a/lib/hexo/multiconfig_path.js
+++ b/lib/hexo/multiconfig_path.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var pathFn = require('path');
+var fs = require('hexo-fs');
+var chalk = require('chalk');
+var deepAssign = require('deep-assign');
+var yml = require('js-yaml');
+
+module.exports = function multiConfigPath(base, configPaths) {
+  var outputPath = '_multiconfig.yml';
+  var paths;
+
+  // determine if comma or space separated
+  if (configPaths.indexOf(',') > -1) {
+    paths = configPaths.replace(' ', '').split(',');
+
+  } else {
+    // only one config
+    console.warn(chalk.yellow('Config file '+configPaths+' not found, using default.'));
+    return pathFn.resolve(base, configPaths);
+  }
+
+  var numPaths = paths.length;
+
+  // combine files
+  var combinedConfig = {};
+  for (var i = 0 ; i < numPaths ; i++) {
+    if (!fs.existsSync(pathFn.join(base, paths[i]))) {
+      console.warn(chalk.yellow('Config file '+paths[i]+' not found, using default.'));
+      continue;
+    }
+
+    // files read synchronously to ensure proper overwrite order
+    var file = fs.readFileSync(paths[i]);
+    var ext = pathFn.extname(paths[i]).toLowerCase();
+
+    if (ext === '.yml') {
+      deepAssign(combinedConfig, yml.safeLoad(file));
+    } else if (ext === '.json') {
+      deepAssign(combinedConfig, yml.safeLoad(file, {json: true}));
+    } else {
+      console.warn(chalk.yellow('Config file '+paths[i]+' not found, using default.'));
+    }
+  }
+
+  outputPath = pathFn.join(base, outputPath);
+  fs.writeFileSync(outputPath, yml.dump(combinedConfig))
+
+  // write file and return path
+  return outputPath;
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "bluebird": "^3.4.0",
     "chalk": "^1.1.3",
     "cheerio": "^0.20.0",
+    "deep-assign": "^2.0.0",
     "hexo-cli": "^1.0.2",
     "hexo-front-matter": "^0.2.2",
     "hexo-fs": "^0.1.5",

--- a/test/scripts/hexo/index.js
+++ b/test/scripts/hexo/index.js
@@ -6,6 +6,7 @@ describe('Core', function() {
   require('./load_database');
   require('./load_plugins');
   require('./locals');
+  require('./multi_config_path');
   require('./post');
   require('./render');
   require('./router');

--- a/test/scripts/hexo/multi_config_path.js
+++ b/test/scripts/hexo/multi_config_path.js
@@ -1,0 +1,173 @@
+'use strict';
+
+var pathFn = require('path');
+var should = require('chai').should(); // eslint-disable-line
+var fs = require('hexo-fs');
+var yml = require('js-yaml');
+
+describe('config flag handling', function() {
+  var Hexo = require('../../../lib/hexo');
+  var hexo = new Hexo(pathFn.join(__dirname, 'test_dir'), {
+      silent: true,
+      debug: true
+    });
+
+  var mcp = require('../../../lib/hexo/multi_config_path')(hexo);
+  var base = hexo.base_dir;
+
+  var debugPath = pathFn.resolve('debug.log');
+
+  function readDebug() {
+    return fs.readFile(debugPath).then(function(out) {
+      var lines = out.split('\n');
+
+      var debug = [];
+      for (var i = 0; i < lines.length; i++) {
+        debug.push(yml.safeLoad(lines[i]), {'json': true});
+      }
+
+      return debug;
+    });
+  }
+
+  var testYaml1 = [
+    'author: foo',
+    'type: dinosaur',
+    'favorites:',
+    '  food: sushi',
+    '  color: purple'
+  ].join('\n');
+
+  var testYaml2 = [
+    'author: bar',
+    'favorites:',
+    '  food: candy',
+    '  ice_cream: chocolate'
+  ].join('\n');
+
+  var testJson1 = [
+    '{',
+    '"author": "dinosaur",',
+    '"type": "elephant",',
+    '"favorites": {"food": "burgers"}',
+    '}'
+  ].join('\n');
+
+  var testJson2 = [
+    '{',
+    '"author": "waldo",',
+    '"favorites": {',
+    '  "food": "ice cream",',
+    '  "ice_cream": "strawberry"',
+    '  }',
+    '}'
+  ].join('\n');
+
+  before(function() {
+    if (fs.existsSync(debugPath)) fs.unlinkSync(debugPath);
+
+    fs.writeFileSync(base + 'test1.yml', testYaml1);
+    fs.writeFileSync(base + 'test2.yml', testYaml2);
+    fs.writeFileSync(base + 'test1.json', testJson1);
+    fs.writeFileSync(base + 'test2.json', testJson2);
+    return;
+  });
+
+  afterEach(function() {
+    if (fs.existsSync(debugPath)) fs.unlinkSync(debugPath);
+    return;
+  });
+
+  after(function() {
+    return fs.rmdir(hexo.base_dir);
+  });
+
+  it('no file', function() {
+    mcp(base).should.equal(base + '_config.yml');
+    readDebug().then(function(debug) {
+      debug[0].level.should.eql(40);
+      debug[0].msg.should.eql('No config file entered.');
+    });
+  });
+
+  it('1 file', function() {
+    mcp(base, 'test1.yml').should.eql(
+            pathFn.resolve(base + 'test1.yml'));
+
+    mcp(base, 'test1.json').should.eql(
+            pathFn.resolve(base + 'test1.json'));
+  });
+
+  it('1 not found file warning', function() {
+    var notFile = 'not_a_file.json';
+
+    mcp(base, notFile).should.eql(pathFn.join(base, '_config.yml'));
+    readDebug().then(function(debug) {
+      debug[0].level.should.eql(40);
+      debug[0].msg.should.eql('Config file ' + notFile +
+                              ' not found, using default.');
+    });
+  });
+
+  it('combined config output', function() {
+    var combinedPath = pathFn.join(base, '_multiconfig.yml');
+
+    mcp(base, 'test1.yml').should.not.eql(combinedPath);
+    mcp(base, 'test1.yml,test2.yml').should.eql(combinedPath);
+    mcp(base, 'test1.yml,test1.json').should.eql(combinedPath);
+    mcp(base, 'test1.json,test2.json').should.eql(combinedPath);
+    mcp(base, 'notafile.yml,test1.json').should.eql(combinedPath);
+  });
+
+  it('2 YAML overwrite', function() {
+    var config = fs.readFileSync(mcp(base, 'test1.yml,test2.yml'));
+    config = yml.safeLoad(config);
+
+    config.author.should.eql('bar');
+    config.favorites.food.should.eql('candy');
+    config.type.should.eql('dinosaur');
+
+    config = fs.readFileSync(mcp(base, 'test2.yml,test1.yml'));
+    config = yml.safeLoad(config);
+
+    config.author.should.eql('foo');
+    config.favorites.food.should.eql('sushi');
+    config.type.should.eql('dinosaur');
+  });
+
+  it('2 JSON overwrite', function() {
+    var config = fs.readFileSync(mcp(base, 'test1.json,test2.json'));
+    config = yml.safeLoad(config);
+
+    config.author.should.eql('waldo');
+    config.favorites.food.should.eql('ice cream');
+    config.type.should.eql('elephant');
+
+    config = fs.readFileSync(mcp(base, 'test2.json,test1.json'));
+    config = yml.safeLoad(config);
+
+    config.author.should.eql('dinosaur');
+    config.favorites.food.should.eql('burgers');
+    config.type.should.eql('elephant');
+  });
+
+  it('JSON \& YAML overwrite', function() {
+    var config = fs.readFileSync(mcp(base, 'test1.yml,test1.json'));
+    config = yml.safeLoad(config);
+
+    config.author.should.eql('dinosaur');
+    config.favorites.food.should.eql('burgers');
+    config.type.should.eql('elephant');
+
+    config = fs.readFileSync(mcp(base, 'test1.json,test1.yml'));
+    config = yml.safeLoad(config);
+
+    config.author.should.eql('foo');
+    config.favorites.food.should.eql('sushi');
+    config.type.should.eql('dinosaur');
+  });
+
+  it('multifile warnings', function() {
+
+  });
+});

--- a/test/scripts/hexo/multi_config_path.js
+++ b/test/scripts/hexo/multi_config_path.js
@@ -4,8 +4,6 @@ var pathFn = require('path');
 var should = require('chai').should(); // eslint-disable-line
 var fs = require('hexo-fs');
 var yml = require('js-yaml');
-var sinon = require('sinon')
-var rewire = require('rewire')
 
 describe('config flag handling', function() {
   var Hexo = require('../../../lib/hexo');
@@ -14,52 +12,58 @@ describe('config flag handling', function() {
   var mcp = require('../../../lib/hexo/multi_config_path')(hexo);
   var base = hexo.base_dir;
 
-  function consoleReader() {
-    this.reader = []
+  function ConsoleReader() {
+    this.reader = [];
     this.i = function() {
       var type = 'info';
       var message = '';
       for (var i = 0; i < arguments.length;) {
         message += arguments[i];
-        if (++i < arguments.length)
+        if (++i < arguments.length) {
           message += ' ';
+        }
       }
+
       this.reader.push({
         type: type,
         msg: message
-      })
+      });
     }.bind(this);
 
-    this.w = function(){
+    this.w = function() {
       var type = 'warning';
       var message = '';
       for (var i = 0; i < arguments.length;) {
         message += arguments[i];
-        if (++i < arguments.length)
+        if (++i < arguments.length) {
           message += ' ';
+        }
       }
+
       this.reader.push({
         type: type,
         msg: message
-      })
+      });
     }.bind(this);
 
-    this.e = function(){
+    this.e = function() {
       var type = 'error';
       var message = '';
       for (var i = 0; i < arguments.length;) {
         message += arguments[i];
-        if (++i < arguments.length)
-        message += ' ';
+        if (++i < arguments.length) {
+          message += ' ';
+        }
       }
+
       this.reader.push({
         type: type,
         msg: message
-      })
+      });
     }.bind(this);
   }
 
-  hexo.log = new consoleReader();
+  hexo.log = new ConsoleReader();
 
   var testYaml1 = [
     'author: foo',
@@ -103,7 +107,7 @@ describe('config flag handling', function() {
   });
 
   afterEach(function() {
-    hexo.log.reader = []
+    hexo.log.reader = [];
     return;
   });
 
@@ -127,7 +131,6 @@ describe('config flag handling', function() {
 
   it('1 not found file warning', function() {
     var notFile = 'not_a_file.json';
-
 
     mcp(base, notFile).should.eql(pathFn.join(base, '_config.yml'));
     hexo.log.reader[0].type.should.eql('warning');


### PR DESCRIPTION
Give the `--config` flag support for multiple config files when generating or serving your site.

Inspired by Jekyll as suggested by @Lindsor in #2210.
## Usage

List the desired config files (JSON or YAML) in a comma-separated list (no spaces) after the config flag:

```
hexo server --config config1.yml,config2.json
```

This will combine all the config files and save the merged settings to `_multiconfig.yml`. The later values take precedence. It works with any number of JSON and YAML files with arbitrarily deep objects.

For instance, in the above example if `foo: bar` is in `config1.yml`, but `"foo": "dinosaur"` is in `config2.json`, `_multiconfig.yml` will contain `foo: dinosaur`.
