### PR TITLE
Allow backtick code block in "blockquote" tag plugin (#2318)

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -244,9 +244,25 @@ Post.prototype.render = function(source, data, callback) {
 
   function tagFilter(content) {
     // Replace cache data with real contents
-    content = content.replace(rPlaceholder, function() {
-      return cache[arguments[1]];
-    });
+    var isMatching;
+
+    function readCache(substr, p1) {
+      var index = +p1;
+      if (!cache[index]) throw new Error('Unexpected placeholder!');
+      var ans = cache[index];
+      cache[index] = undefined;
+      isMatching = true;
+      return ans;
+    }
+
+    content = content.replace(rPlaceholder, readCache);
+    if (isMatching) return tagFilter(content);
+
+    function isElementNotUndefined(elem, index, arr) {
+      return elem !== undefined;
+    }
+
+    if (cache.some(isElementNotUndefined)) throw new Error('Unmatched placeholder remains!');
 
     // Render with Nunjucks
     data.content = content;


### PR DESCRIPTION
When backtick code block(s) exist as contents of a "blockquote" tag plugin,
each code block is translated to a string "undefined" in HTML (Issue #2318).

In analyzing markdown source text, while the replacement of these elements
with placeholders are nesting, recoveries from placeholders are executed
only once.  So I modify to repeat the recovery process until all
placeholders are recovered.