### PR TITLE
Allow backtick code block in "blockquote" tag plugin (#2318)

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -29,7 +29,14 @@ PostRenderCache.prototype.escapeContent = function(str) {
 
 PostRenderCache.prototype.loadContent = function(str) {
   const rPlaceholder = /(?:<|&lt;)!--\uFFFC(\d+)--(?:>|&gt;)/g;
-  return str.replace(rPlaceholder, (_, index) => this.cache[index]);
+  const restored = str.replace(rPlaceholder, (_, index) => {
+    assert(this.cache[index]);
+    const value = this.cache[index];
+    this.cache[index] = null;
+    return value;
+  });
+  if (restored === str) return restored;
+  return this.loadContent(restored); // self-recursive for nexted escaping
 };
 
 PostRenderCache.prototype.escapeAllSwigTags = function(str) {

--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const assert = require('assert');
 const moment = require('moment');
 const Promise = require('bluebird');
 const { join, extname } = require('path');

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -687,7 +687,7 @@ describe('Post', () => {
     });
   });
 
-  // test for PR [#3573](https://github.com/hexojs/hexo/pull/3573)
+  // test for PR #3573
   it('render() - (disableNunjucks === true)', () => {
     const renderer = hexo.render.renderer.get('markdown');
     renderer.disableNunjucks = true;
@@ -702,7 +702,7 @@ describe('Post', () => {
     });
   });
 
-  // test for PR [#3573](https://github.com/hexojs/hexo/pull/3573)
+  // test for PR #3573
   it('render() - (disableNunjucks === false)', () => {
     const renderer = hexo.render.renderer.get('markdown');
     renderer.disableNunjucks = false;
@@ -717,8 +717,8 @@ describe('Post', () => {
     });
   });
 
-  // test for Issue [#2318](https://github.com/hexojs/hexo/issues/2318)
-  it('render() - allow backtick code block in "blockquote" tag plugn (Issue#2318)', () => {
+  // test for PR #2321
+  it('render() - allow backtick code block in "blockquote" tag plugin', () => {
     const code = 'alert("Hello world")';
     const highlighted = util.highlight(code);
 

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -717,4 +717,26 @@ describe('Post', () => {
     });
   });
 
+  // test for Issue [#2318](https://github.com/hexojs/hexo/issues/2318)
+  it('render() - allow backtick code block in "blockquote" tag plugn (Issue#2318)', () => {
+    const code = 'alert("Hello world")';
+    const highlighted = util.highlight(code);
+
+    const content = [
+      '{% blockquote %}',
+      '```',
+      code,
+      '```',
+      '{% endblockquote %}'
+    ].join('\n');
+
+    return post.render(null, {
+      content
+    }).then(data => {
+      data.content.trim().should.eql([
+        '<blockquote>' + highlighted,
+        '</blockquote>'
+      ].join('\n'));
+    });
+  });
 });


### PR DESCRIPTION
When backtick code block(s) exist as contents of a "blockquote" tag plugin,
each code block is translated to a string "undefined" in HTML (Issue #2318).

In analyzing markdown source text, while the replacement of these elements
with placeholders are nesting, recoveries from placeholders are executed
only once.  So I modify to repeat the recovery process until all
placeholders are recovered.

NOTE: From Pull Request #2319, I correct the condition of exception (accept empty string as escape content).