### PR TITLE
Replace new lines by spaces in description

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -49,7 +49,8 @@ function openGraphHelper(options) {
       .replace(/>/g, '&gt;')
       .replace(/&/g, '&amp;')
       .replace(/"/g, '&quot;')
-      .replace(/'/g, '&apos;');
+      .replace(/'/g, '&apos;')
+      .replace(/\n/g, ' '); // Replace new lines by spaces
   }
 
   if (!images.length && content) {


### PR DESCRIPTION
If first 200 characters have new line(s), Hexo will generate something like this:

```html
<meta name="description" content="We’ve continuously been hearing for a couple of years now that Samsung is working on foldable smartphones.

 The company has a plethora of patents to its name that detail some of the technology">
```


This PR fix this little problem.

```html
<meta name="description" content="We’ve continuously been hearing for a couple of years now that Samsung is working on foldable smartphones. The company has a plethora of patents to its name that detail some of the technology">
```