### PR TITLE
fixes Hexo multi-config

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -53,6 +53,8 @@ function Hexo(base, args) {
     init: false
   };
 
+  this.log = logger(this.env);
+
   var multiConfigPath = require('./multi_config_path')(this);
   this.config_path = args.config ? multiConfigPath(base, args.config)
                                  : pathFn.join(base, '_config.yml');
@@ -70,8 +72,6 @@ function Hexo(base, args) {
   };
 
   this.config = _.cloneDeep(defaultConfig);
-
-  this.log = logger(this.env);
 
   this.render = new Render(this);
 

--- a/test/fixtures/_config.json
+++ b/test/fixtures/_config.json
@@ -1,0 +1,6 @@
+{
+	"author": "waldo",
+	"favorites": {
+		"food": "ice cream"
+	}
+}

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -7,8 +7,9 @@ var sep = pathFn.sep;
 var testUtil = require('../../util');
 
 describe('Hexo', () => {
+  var base_dir = pathFn.join(__dirname, 'hexo_test');
   var Hexo = require('../../../lib/hexo');
-  var hexo = new Hexo(pathFn.join(__dirname, 'hexo_test'), {silent: true});
+  var hexo = new Hexo(base_dir, {silent: true});
   var coreDir = pathFn.join(__dirname, '../../..');
   var version = require('../../../package.json').version;
   var Post = hexo.model('Post');
@@ -63,6 +64,13 @@ describe('Hexo', () => {
       init: false
     });
     hexo.config_path.should.eql(pathFn.join(__dirname, '_config.yml'));
+  });
+
+  it('constructs mutli-config', () => {
+    var configs = [ '../../../fixtures/_config.json', '../../../fixtures/_config.json' ];
+    var args = { _: [], config: configs.join(',') };
+    var hexo = new Hexo(base_dir, args);
+    hexo.config_path.should.eql(pathFn.join(base_dir, '_multiconfig.yml'));
   });
 
   it('call()', () => hexo.call('test', {foo: 'bar'}).then(data => {


### PR DESCRIPTION
`multi_config_path` depends on the passed context to have a `log()` method available to it; however, Hexo doesn't initialize `log` until later. This change moves the initialization of `log` above `multi_config_path`.

Resolves #2499 and adds tests to ensure proper integration of Hexo w/ multi_config_path

