### PR TITLE
Allow plugins to be stored as devDependencies too.

### DIFF
--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -31,7 +31,7 @@ function loadModuleList(ctx) {
     // Read package.json and find dependencies
     return fs.readFile(packagePath).then(function(content) {
       var json = JSON.parse(content);
-      var deps = json.dependencies || {};
+      var deps = json.dependencies || json.devDependencies || {};
 
       return Object.keys(deps);
     });

--- a/test/scripts/hexo/load_plugins.js
+++ b/test/scripts/hexo/load_plugins.js
@@ -43,6 +43,21 @@ describe('Load plugins', () => {
     return fs.writeFile(pathFn.join(hexo.base_dir, 'package.json'), JSON.stringify(pkg, null, '  '));
   }
 
+  function createPackageFileWithDevDeps(...args) {
+    var pkg = {
+      name: 'hexo-site',
+      version: '0.0.0',
+      private: true,
+      devDependencies: {}
+    };
+
+    for (var i = 0, len = args.length; i < len; i++) {
+      pkg.devDependencies[args[i]] = '*';
+    }
+
+    return fs.writeFile(pathFn.join(hexo.base_dir, 'package.json'), JSON.stringify(pkg, null, '  '));
+  }
+
   hexo.env.init = true;
   hexo.theme_script_dir = pathFn.join(hexo.base_dir, 'themes', 'test', 'scripts');
 
@@ -69,6 +84,19 @@ describe('Load plugins', () => {
 
     return Promise.all([
       createPackageFile(name),
+      fs.writeFile(path, script)
+    ]).then(() => loadPlugins(hexo)).then(() => {
+      validate(path);
+      return fs.unlink(path);
+    });
+  });
+
+  it('load devDep plugins', () => {
+    var name = 'hexo-plugin-test';
+    var path = pathFn.join(hexo.plugin_dir, name, 'index.js');
+
+    return Promise.all([
+      createPackageFileWithDevDeps(name),
       fs.writeFile(path, script)
     ]).then(() => loadPlugins(hexo)).then(() => {
       validate(path);


### PR DESCRIPTION
When using a custom server, I would like to store only the output of hexo's build process, and no extra dependencies, and the way I can do that is by storing the plugins in devDep and running npm install --production to get the server dependencies.

Thank you for creating a pull request to contribute to Hexo code! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- [x] Add test cases for the changes.
- [ ] Passed the CI test. (this was failing on an untouched test on my machine, so I guess I'll have to wait and see what the CI does with the PR)
