### PR TITLE
disable Nunjucks when the renderer spcify that

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -33,7 +33,7 @@ function Post(context) {
   this.context = context;
 }
 
-Post.prototype.create = function (data, replace, callback) {
+Post.prototype.create = function(data, replace, callback) {
   if (!callback && typeof replace === 'function') {
     callback = replace;
     replace = false;
@@ -53,21 +53,25 @@ Post.prototype.create = function (data, replace, callback) {
       context: ctx
     }),
     this._renderScaffold(data)
-  ]).spread(function (path, content) {
-    var result = {
-      path: path,
-      content: content
-    };
+  ])
+    .spread(function(path, content) {
+      var result = {
+        path: path,
+        content: content
+      };
 
-    return Promise.all([
-      // Write content to file
-      fs.writeFile(path, content),
-      // Create asset folder
-      createAssetFolder(path, config.post_asset_folder)
-    ]).then(function () {
-      ctx.emit('new', result);
-    }).thenReturn(result);
-  }).asCallback(callback);
+      return Promise.all([
+        // Write content to file
+        fs.writeFile(path, content),
+        // Create asset folder
+        createAssetFolder(path, config.post_asset_folder)
+      ])
+        .then(function() {
+          ctx.emit('new', result);
+        })
+        .thenReturn(result);
+    })
+    .asCallback(callback);
 };
 
 function prepareFrontMatter(data) {
@@ -91,65 +95,67 @@ function prepareFrontMatter(data) {
   return data;
 }
 
-Post.prototype._getScaffold = function (layout) {
+Post.prototype._getScaffold = function(layout) {
   var ctx = this.context;
 
-  return ctx.scaffold.get(layout).then(function (result) {
+  return ctx.scaffold.get(layout).then(function(result) {
     if (result != null) return result;
     return ctx.scaffold.get('normal');
   });
 };
 
-Post.prototype._renderScaffold = function (data) {
+Post.prototype._renderScaffold = function(data) {
   var tag = this.context.extend.tag;
   var yfmSplit;
 
-  return this._getScaffold(data.layout).then(function (scaffold) {
-    var frontMatter = prepareFrontMatter(_.clone(data));
-    yfmSplit = yfm.split(scaffold);
+  return this._getScaffold(data.layout)
+    .then(function(scaffold) {
+      var frontMatter = prepareFrontMatter(_.clone(data));
+      yfmSplit = yfm.split(scaffold);
 
-    return tag.render(yfmSplit.data, frontMatter);
-  }).then(function (frontMatter) {
-    var separator = yfmSplit.separator;
-    var jsonMode = separator[0] === ';';
-    var content = '';
-    var obj;
+      return tag.render(yfmSplit.data, frontMatter);
+    })
+    .then(function(frontMatter) {
+      var separator = yfmSplit.separator;
+      var jsonMode = separator[0] === ';';
+      var content = '';
+      var obj;
 
-    // Parse front-matter
-    if (jsonMode) {
-      obj = JSON.parse('{' + frontMatter + '}');
-    } else {
-      obj = yaml.load(frontMatter);
-    }
-
-    // Add data which are not in the front-matter
-    var keys = Object.keys(data);
-    var key = '';
-
-    for (var i = 0, len = keys.length; i < len; i++) {
-      key = keys[i];
-
-      if (!preservedKeys[key] && obj[key] == null) {
-        obj[key] = data[key];
+      // Parse front-matter
+      if (jsonMode) {
+        obj = JSON.parse('{' + frontMatter + '}');
+      } else {
+        obj = yaml.load(frontMatter);
       }
-    }
 
-    // Prepend the separator
-    if (yfmSplit.prefixSeparator) content += separator + '\n';
+      // Add data which are not in the front-matter
+      var keys = Object.keys(data);
+      var key = '';
 
-    content += yfm.stringify(obj, {
-      mode: jsonMode ? 'json' : ''
+      for (var i = 0, len = keys.length; i < len; i++) {
+        key = keys[i];
+
+        if (!preservedKeys[key] && obj[key] == null) {
+          obj[key] = data[key];
+        }
+      }
+
+      // Prepend the separator
+      if (yfmSplit.prefixSeparator) content += separator + '\n';
+
+      content += yfm.stringify(obj, {
+        mode: jsonMode ? 'json' : ''
+      });
+
+      // Concat content
+      content += yfmSplit.content;
+
+      if (data.content) {
+        content += '\n' + data.content;
+      }
+
+      return content;
     });
-
-    // Concat content
-    content += yfmSplit.content;
-
-    if (data.content) {
-      content += '\n' + data.content;
-    }
-
-    return content;
-  });
 };
 
 function createAssetFolder(path, assetFolder) {
@@ -157,7 +163,7 @@ function createAssetFolder(path, assetFolder) {
 
   var target = removeExtname(path);
 
-  return fs.exists(target).then(function (exist) {
+  return fs.exists(target).then(function(exist) {
     if (!exist) return fs.mkdirs(target);
   });
 }
@@ -166,7 +172,7 @@ function removeExtname(str) {
   return str.substring(0, str.length - pathFn.extname(str).length);
 }
 
-Post.prototype.publish = function (data, replace, callback) {
+Post.prototype.publish = function(data, replace, callback) {
   if (!callback && typeof replace === 'function') {
     callback = replace;
     replace = false;
@@ -177,7 +183,7 @@ Post.prototype.publish = function (data, replace, callback) {
   var ctx = this.context;
   var config = ctx.config;
   var draftDir = pathFn.join(ctx.source_dir, '_drafts');
-  var slug = data.slug = slugize(data.slug.toString(), { transform: config.filename_case });
+  var slug = (data.slug = slugize(data.slug.toString(), { transform: config.filename_case }));
   var regex = new RegExp('^' + escapeRegExp(slug) + '(?:[^\\/\\\\]+)');
   var self = this;
   var src = '';
@@ -186,50 +192,58 @@ Post.prototype.publish = function (data, replace, callback) {
   data.layout = (data.layout || config.default_layout).toLowerCase();
 
   // Find the draft
-  return fs.listDir(draftDir).then(function (list) {
-    var item = '';
+  return fs
+    .listDir(draftDir)
+    .then(function(list) {
+      var item = '';
 
-    for (var i = 0, len = list.length; i < len; i++) {
-      item = list[i];
-      if (regex.test(item)) return item;
-    }
-  }).then(function (item) {
-    if (!item) throw new Error('Draft "' + slug + '" does not exist.');
+      for (var i = 0, len = list.length; i < len; i++) {
+        item = list[i];
+        if (regex.test(item)) return item;
+      }
+    })
+    .then(function(item) {
+      if (!item) throw new Error('Draft "' + slug + '" does not exist.');
 
-    // Read the content
-    src = pathFn.join(draftDir, item);
-    return fs.readFile(src);
-  }).then(function (content) {
-    // Create post
-    _.extend(data, yfm(content));
-    data.content = data._content;
-    delete data._content;
+      // Read the content
+      src = pathFn.join(draftDir, item);
+      return fs.readFile(src);
+    })
+    .then(function(content) {
+      // Create post
+      _.extend(data, yfm(content));
+      data.content = data._content;
+      delete data._content;
 
-    return self.create(data, replace).then(function (post) {
-      result.path = post.path;
-      result.content = post.content;
-    });
-  }).then(function () {
-    // Remove the original draft file
-    return fs.unlink(src);
-  }).then(function () {
-    if (!config.post_asset_folder) return;
-
-    // Copy assets
-    var assetSrc = removeExtname(src);
-    var assetDest = removeExtname(result.path);
-
-    return fs.exists(assetSrc).then(function (exist) {
-      if (!exist) return;
-
-      return fs.copyDir(assetSrc, assetDest).then(function () {
-        return fs.rmdir(assetSrc);
+      return self.create(data, replace).then(function(post) {
+        result.path = post.path;
+        result.content = post.content;
       });
-    });
-  }).thenReturn(result).asCallback(callback);
+    })
+    .then(function() {
+      // Remove the original draft file
+      return fs.unlink(src);
+    })
+    .then(function() {
+      if (!config.post_asset_folder) return;
+
+      // Copy assets
+      var assetSrc = removeExtname(src);
+      var assetDest = removeExtname(result.path);
+
+      return fs.exists(assetSrc).then(function(exist) {
+        if (!exist) return;
+
+        return fs.copyDir(assetSrc, assetDest).then(function() {
+          return fs.rmdir(assetSrc);
+        });
+      });
+    })
+    .thenReturn(result)
+    .asCallback(callback);
 };
 
-Post.prototype.render = function (source, data, callback) {
+Post.prototype.render = function(source, data, callback) {
   data = data || {};
 
   var ctx = this.context;
@@ -237,12 +251,12 @@ Post.prototype.render = function (source, data, callback) {
   var cache = [];
   var tag = ctx.extend.tag;
   var ext = data.engine || pathFn.extname(source);
-  var isSwig = ext === "swig";
+  var isSwig = ext === 'swig';
 
   var disableNunjucks = false;
   if (ext && ctx.render.renderer.get(ext)) {
     // disable disableNunjucks when the renderer spcify that.
-    disableNunjucks = disableNunjucks || !!(ctx.render.renderer.get(ext).disableNunjucks);
+    disableNunjucks = disableNunjucks || !!ctx.render.renderer.get(ext).disableNunjucks;
   }
 
   function escapeContent(str) {
@@ -252,7 +266,7 @@ Post.prototype.render = function (source, data, callback) {
   function tagFilter(content) {
     if (disableNunjucks) return content;
     // Replace cache data with real contents
-    content = content.replace(rPlaceholder, function () {
+    content = content.replace(rPlaceholder, function() {
       return cache[arguments[1]];
     });
 
@@ -261,60 +275,67 @@ Post.prototype.render = function (source, data, callback) {
     return tag.render(data.content, data);
   }
 
-  return new Promise(function (resolve, reject) {
+  return new Promise(function(resolve, reject) {
     if (data.content != null) return resolve(data.content);
     if (!source) return reject(new Error('No input file or string!'));
 
     // Read content from files
     fs.readFile(source).then(resolve, reject);
-  }).then(function (content) {
-    data.content = content;
+  })
+    .then(function(content) {
+      data.content = content;
 
-    // Run "before_post_render" filters
-    return ctx.execFilter('before_post_render', data, { context: ctx }).then(function () {
-      data.content = data.content.replace(rEscapeContent, function (match, content) {
-        return escapeContent(content);
+      // Run "before_post_render" filters
+      return ctx.execFilter('before_post_render', data, { context: ctx }).then(function() {
+        data.content = data.content.replace(rEscapeContent, function(match, content) {
+          return escapeContent(content);
+        });
       });
+    })
+    .then(function() {
+      // Skip rendering if this is a swig file
+      if (isSwig) return data.content;
+
+      // Escape all Swig tags
+      if (!disableNunjucks) {
+        data.content = data.content
+          .replace(rSwigFullBlock, escapeContent)
+          .replace(rSwigBlock, escapeContent)
+          .replace(rSwigComment, '')
+          .replace(rSwigVar, escapeContent);
+      }
+
+      var options = data.markdown || {};
+      if (!config.highlight.enable) options.highlight = null;
+
+      // Render with markdown or other renderer
+      return ctx.render.render(
+        {
+          text: data.content,
+          path: source,
+          engine: data.engine,
+          toString: true,
+          onRenderEnd: tagFilter
+        },
+        options
+      );
+    })
+    .then(function(content) {
+      data.content = content;
+
+      if (!isSwig) {
+        return data.content;
+      }
+
+      // Render with Nunjucks
+      return tag.render(data.content, data);
+    })
+    .then(function(content) {
+      data.content = content;
+
+      // Run "after_post_render" filters
+      return ctx.execFilter('after_post_render', data, { context: ctx });
     });
-  }).then(function () {
-    // Skip rendering if this is a swig file
-    if (isSwig) return data.content;
-
-    // Escape all Swig tags
-    if (!disableNunjucks) {
-      data.content = data.content
-        .replace(rSwigFullBlock, escapeContent)
-        .replace(rSwigBlock, escapeContent)
-        .replace(rSwigComment, '')
-        .replace(rSwigVar, escapeContent);
-    }
-
-    var options = data.markdown || {};
-    if (!config.highlight.enable) options.highlight = null;
-
-    // Render with markdown or other renderer
-    return ctx.render.render({
-      text: data.content,
-      path: source,
-      engine: data.engine,
-      toString: true,
-      onRenderEnd: tagFilter
-    }, options);
-  }).then(function (content) {
-    data.content = content;
-
-    if (!isSwig) {
-      return data.content;
-    }
-
-    // Render with Nunjucks
-    return tag.render(data.content, data);
-  }).then(function (content) {
-    data.content = content;
-
-    // Run "after_post_render" filters
-    return ctx.execFilter('after_post_render', data, { context: ctx });
-  });
 };
 
 module.exports = Post;

--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -42,7 +42,7 @@ Post.prototype.create = function(data, replace, callback) {
   var ctx = this.context;
   var config = ctx.config;
 
-  data.slug = slugize((data.slug || data.title).toString(), { transform: config.filename_case });
+  data.slug = slugize((data.slug || data.title).toString(), {transform: config.filename_case});
   data.layout = (data.layout || config.default_layout).toLowerCase();
   data.date = data.date ? moment(data.date) : moment();
 
@@ -53,25 +53,21 @@ Post.prototype.create = function(data, replace, callback) {
       context: ctx
     }),
     this._renderScaffold(data)
-  ])
-    .spread(function(path, content) {
-      var result = {
-        path: path,
-        content: content
-      };
+  ]).spread(function(path, content) {
+    var result = {
+      path: path,
+      content: content
+    };
 
-      return Promise.all([
-        // Write content to file
-        fs.writeFile(path, content),
-        // Create asset folder
-        createAssetFolder(path, config.post_asset_folder)
-      ])
-        .then(function() {
-          ctx.emit('new', result);
-        })
-        .thenReturn(result);
-    })
-    .asCallback(callback);
+    return Promise.all([
+      // Write content to file
+      fs.writeFile(path, content),
+      // Create asset folder
+      createAssetFolder(path, config.post_asset_folder)
+    ]).then(function() {
+      ctx.emit('new', result);
+    }).thenReturn(result);
+  }).asCallback(callback);
 };
 
 function prepareFrontMatter(data) {
@@ -108,54 +104,52 @@ Post.prototype._renderScaffold = function(data) {
   var tag = this.context.extend.tag;
   var yfmSplit;
 
-  return this._getScaffold(data.layout)
-    .then(function(scaffold) {
-      var frontMatter = prepareFrontMatter(_.clone(data));
-      yfmSplit = yfm.split(scaffold);
+  return this._getScaffold(data.layout).then(function(scaffold) {
+    var frontMatter = prepareFrontMatter(_.clone(data));
+    yfmSplit = yfm.split(scaffold);
 
-      return tag.render(yfmSplit.data, frontMatter);
-    })
-    .then(function(frontMatter) {
-      var separator = yfmSplit.separator;
-      var jsonMode = separator[0] === ';';
-      var content = '';
-      var obj;
+    return tag.render(yfmSplit.data, frontMatter);
+  }).then(function(frontMatter) {
+    var separator = yfmSplit.separator;
+    var jsonMode = separator[0] === ';';
+    var content = '';
+    var obj;
 
-      // Parse front-matter
-      if (jsonMode) {
-        obj = JSON.parse('{' + frontMatter + '}');
-      } else {
-        obj = yaml.load(frontMatter);
+    // Parse front-matter
+    if (jsonMode) {
+      obj = JSON.parse('{' + frontMatter + '}');
+    } else {
+      obj = yaml.load(frontMatter);
+    }
+
+    // Add data which are not in the front-matter
+    var keys = Object.keys(data);
+    var key = '';
+
+    for (var i = 0, len = keys.length; i < len; i++) {
+      key = keys[i];
+
+      if (!preservedKeys[key] && obj[key] == null) {
+        obj[key] = data[key];
       }
+    }
 
-      // Add data which are not in the front-matter
-      var keys = Object.keys(data);
-      var key = '';
+    // Prepend the separator
+    if (yfmSplit.prefixSeparator) content += separator + '\n';
 
-      for (var i = 0, len = keys.length; i < len; i++) {
-        key = keys[i];
-
-        if (!preservedKeys[key] && obj[key] == null) {
-          obj[key] = data[key];
-        }
-      }
-
-      // Prepend the separator
-      if (yfmSplit.prefixSeparator) content += separator + '\n';
-
-      content += yfm.stringify(obj, {
-        mode: jsonMode ? 'json' : ''
-      });
-
-      // Concat content
-      content += yfmSplit.content;
-
-      if (data.content) {
-        content += '\n' + data.content;
-      }
-
-      return content;
+    content += yfm.stringify(obj, {
+      mode: jsonMode ? 'json' : ''
     });
+
+    // Concat content
+    content += yfmSplit.content;
+
+    if (data.content) {
+      content += '\n' + data.content;
+    }
+
+    return content;
+  });
 };
 
 function createAssetFolder(path, assetFolder) {
@@ -183,7 +177,7 @@ Post.prototype.publish = function(data, replace, callback) {
   var ctx = this.context;
   var config = ctx.config;
   var draftDir = pathFn.join(ctx.source_dir, '_drafts');
-  var slug = (data.slug = slugize(data.slug.toString(), { transform: config.filename_case }));
+  var slug = data.slug = slugize(data.slug.toString(), {transform: config.filename_case});
   var regex = new RegExp('^' + escapeRegExp(slug) + '(?:[^\\/\\\\]+)');
   var self = this;
   var src = '';
@@ -192,55 +186,47 @@ Post.prototype.publish = function(data, replace, callback) {
   data.layout = (data.layout || config.default_layout).toLowerCase();
 
   // Find the draft
-  return fs
-    .listDir(draftDir)
-    .then(function(list) {
-      var item = '';
+  return fs.listDir(draftDir).then(function(list) {
+    var item = '';
 
-      for (var i = 0, len = list.length; i < len; i++) {
-        item = list[i];
-        if (regex.test(item)) return item;
-      }
-    })
-    .then(function(item) {
-      if (!item) throw new Error('Draft "' + slug + '" does not exist.');
+    for (var i = 0, len = list.length; i < len; i++) {
+      item = list[i];
+      if (regex.test(item)) return item;
+    }
+  }).then(function(item) {
+    if (!item) throw new Error('Draft "' + slug + '" does not exist.');
 
-      // Read the content
-      src = pathFn.join(draftDir, item);
-      return fs.readFile(src);
-    })
-    .then(function(content) {
-      // Create post
-      _.extend(data, yfm(content));
-      data.content = data._content;
-      delete data._content;
+    // Read the content
+    src = pathFn.join(draftDir, item);
+    return fs.readFile(src);
+  }).then(function(content) {
+    // Create post
+    _.extend(data, yfm(content));
+    data.content = data._content;
+    delete data._content;
 
-      return self.create(data, replace).then(function(post) {
-        result.path = post.path;
-        result.content = post.content;
+    return self.create(data, replace).then(function(post) {
+      result.path = post.path;
+      result.content = post.content;
+    });
+  }).then(function() {
+    // Remove the original draft file
+    return fs.unlink(src);
+  }).then(function() {
+    if (!config.post_asset_folder) return;
+
+    // Copy assets
+    var assetSrc = removeExtname(src);
+    var assetDest = removeExtname(result.path);
+
+    return fs.exists(assetSrc).then(function(exist) {
+      if (!exist) return;
+
+      return fs.copyDir(assetSrc, assetDest).then(function() {
+        return fs.rmdir(assetSrc);
       });
-    })
-    .then(function() {
-      // Remove the original draft file
-      return fs.unlink(src);
-    })
-    .then(function() {
-      if (!config.post_asset_folder) return;
-
-      // Copy assets
-      var assetSrc = removeExtname(src);
-      var assetDest = removeExtname(result.path);
-
-      return fs.exists(assetSrc).then(function(exist) {
-        if (!exist) return;
-
-        return fs.copyDir(assetSrc, assetDest).then(function() {
-          return fs.rmdir(assetSrc);
-        });
-      });
-    })
-    .thenReturn(result)
-    .asCallback(callback);
+    });
+  }).thenReturn(result).asCallback(callback);
 };
 
 Post.prototype.render = function(source, data, callback) {
@@ -251,12 +237,17 @@ Post.prototype.render = function(source, data, callback) {
   var cache = [];
   var tag = ctx.extend.tag;
   var ext = data.engine || (source ? pathFn.extname(source) : '');
+
   var isSwig = ext === 'swig';
 
   var disableNunjucks = false;
+
   if (ext && ctx.render.renderer.get(ext)) {
-    // disable disableNunjucks when the renderer spcify that.
+
+    // disable Nunjucks when the renderer spcify that.
+
     disableNunjucks = disableNunjucks || !!ctx.render.renderer.get(ext).disableNunjucks;
+
   }
 
   function escapeContent(str) {
@@ -281,61 +272,54 @@ Post.prototype.render = function(source, data, callback) {
 
     // Read content from files
     fs.readFile(source).then(resolve, reject);
-  })
-    .then(function(content) {
-      data.content = content;
+  }).then(function(content) {
+    data.content = content;
 
-      // Run "before_post_render" filters
-      return ctx.execFilter('before_post_render', data, { context: ctx }).then(function() {
-        data.content = data.content.replace(rEscapeContent, function(match, content) {
-          return escapeContent(content);
-        });
+    // Run "before_post_render" filters
+    return ctx.execFilter('before_post_render', data, {context: ctx}).then(function() {
+      data.content = data.content.replace(rEscapeContent, function(match, content) {
+        return escapeContent(content);
       });
-    })
-    .then(function() {
-      // Skip rendering if this is a swig file
-      if (isSwig) return data.content;
-
-      // Escape all Swig tags
-      if (!disableNunjucks) {
-        data.content = data.content
-          .replace(rSwigFullBlock, escapeContent)
-          .replace(rSwigBlock, escapeContent)
-          .replace(rSwigComment, '')
-          .replace(rSwigVar, escapeContent);
-      }
-
-      var options = data.markdown || {};
-      if (!config.highlight.enable) options.highlight = null;
-
-      // Render with markdown or other renderer
-      return ctx.render.render(
-        {
-          text: data.content,
-          path: source,
-          engine: data.engine,
-          toString: true,
-          onRenderEnd: tagFilter
-        },
-        options
-      );
-    })
-    .then(function(content) {
-      data.content = content;
-
-      if (!isSwig) {
-        return data.content;
-      }
-
-      // Render with Nunjucks
-      return tag.render(data.content, data);
-    })
-    .then(function(content) {
-      data.content = content;
-
-      // Run "after_post_render" filters
-      return ctx.execFilter('after_post_render', data, { context: ctx });
     });
+  }).then(function() {
+    // Skip rendering if this is a swig file
+    if (isSwig) return data.content;
+
+    // Escape all Swig tags
+    if (!disableNunjucks) {
+      data.content = data.content
+        .replace(rSwigFullBlock, escapeContent)
+        .replace(rSwigBlock, escapeContent)
+        .replace(rSwigComment, '')
+        .replace(rSwigVar, escapeContent);
+    }
+
+    var options = data.markdown || {};
+    if (!config.highlight.enable) options.highlight = null;
+
+    // Render with markdown or other renderer
+    return ctx.render.render({
+      text: data.content,
+      path: source,
+      engine: data.engine,
+      toString: true,
+      onRenderEnd: tagFilter
+    }, options);
+  }).then(function(content) {
+    data.content = content;
+
+    if (!isSwig) {
+      return data.content;
+    }
+
+    // Render with Nunjucks
+    return tag.render(data.content, data);
+  }).then(function(content) {
+    data.content = content;
+
+    // Run "after_post_render" filters
+    return ctx.execFilter('after_post_render', data, {context: ctx});
+  });
 };
 
 module.exports = Post;

--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -33,7 +33,7 @@ function Post(context) {
   this.context = context;
 }
 
-Post.prototype.create = function(data, replace, callback) {
+Post.prototype.create = function (data, replace, callback) {
   if (!callback && typeof replace === 'function') {
     callback = replace;
     replace = false;
@@ -42,7 +42,7 @@ Post.prototype.create = function(data, replace, callback) {
   var ctx = this.context;
   var config = ctx.config;
 
-  data.slug = slugize((data.slug || data.title).toString(), {transform: config.filename_case});
+  data.slug = slugize((data.slug || data.title).toString(), { transform: config.filename_case });
   data.layout = (data.layout || config.default_layout).toLowerCase();
   data.date = data.date ? moment(data.date) : moment();
 
@@ -53,7 +53,7 @@ Post.prototype.create = function(data, replace, callback) {
       context: ctx
     }),
     this._renderScaffold(data)
-  ]).spread(function(path, content) {
+  ]).spread(function (path, content) {
     var result = {
       path: path,
       content: content
@@ -64,7 +64,7 @@ Post.prototype.create = function(data, replace, callback) {
       fs.writeFile(path, content),
       // Create asset folder
       createAssetFolder(path, config.post_asset_folder)
-    ]).then(function() {
+    ]).then(function () {
       ctx.emit('new', result);
     }).thenReturn(result);
   }).asCallback(callback);
@@ -91,25 +91,25 @@ function prepareFrontMatter(data) {
   return data;
 }
 
-Post.prototype._getScaffold = function(layout) {
+Post.prototype._getScaffold = function (layout) {
   var ctx = this.context;
 
-  return ctx.scaffold.get(layout).then(function(result) {
+  return ctx.scaffold.get(layout).then(function (result) {
     if (result != null) return result;
     return ctx.scaffold.get('normal');
   });
 };
 
-Post.prototype._renderScaffold = function(data) {
+Post.prototype._renderScaffold = function (data) {
   var tag = this.context.extend.tag;
   var yfmSplit;
 
-  return this._getScaffold(data.layout).then(function(scaffold) {
+  return this._getScaffold(data.layout).then(function (scaffold) {
     var frontMatter = prepareFrontMatter(_.clone(data));
     yfmSplit = yfm.split(scaffold);
 
     return tag.render(yfmSplit.data, frontMatter);
-  }).then(function(frontMatter) {
+  }).then(function (frontMatter) {
     var separator = yfmSplit.separator;
     var jsonMode = separator[0] === ';';
     var content = '';
@@ -157,7 +157,7 @@ function createAssetFolder(path, assetFolder) {
 
   var target = removeExtname(path);
 
-  return fs.exists(target).then(function(exist) {
+  return fs.exists(target).then(function (exist) {
     if (!exist) return fs.mkdirs(target);
   });
 }
@@ -166,7 +166,7 @@ function removeExtname(str) {
   return str.substring(0, str.length - pathFn.extname(str).length);
 }
 
-Post.prototype.publish = function(data, replace, callback) {
+Post.prototype.publish = function (data, replace, callback) {
   if (!callback && typeof replace === 'function') {
     callback = replace;
     replace = false;
@@ -177,7 +177,7 @@ Post.prototype.publish = function(data, replace, callback) {
   var ctx = this.context;
   var config = ctx.config;
   var draftDir = pathFn.join(ctx.source_dir, '_drafts');
-  var slug = data.slug = slugize(data.slug.toString(), {transform: config.filename_case});
+  var slug = data.slug = slugize(data.slug.toString(), { transform: config.filename_case });
   var regex = new RegExp('^' + escapeRegExp(slug) + '(?:[^\\/\\\\]+)');
   var self = this;
   var src = '';
@@ -186,65 +186,73 @@ Post.prototype.publish = function(data, replace, callback) {
   data.layout = (data.layout || config.default_layout).toLowerCase();
 
   // Find the draft
-  return fs.listDir(draftDir).then(function(list) {
+  return fs.listDir(draftDir).then(function (list) {
     var item = '';
 
     for (var i = 0, len = list.length; i < len; i++) {
       item = list[i];
       if (regex.test(item)) return item;
     }
-  }).then(function(item) {
+  }).then(function (item) {
     if (!item) throw new Error('Draft "' + slug + '" does not exist.');
 
     // Read the content
     src = pathFn.join(draftDir, item);
     return fs.readFile(src);
-  }).then(function(content) {
+  }).then(function (content) {
     // Create post
     _.extend(data, yfm(content));
     data.content = data._content;
     delete data._content;
 
-    return self.create(data, replace).then(function(post) {
+    return self.create(data, replace).then(function (post) {
       result.path = post.path;
       result.content = post.content;
     });
-  }).then(function() {
+  }).then(function () {
     // Remove the original draft file
     return fs.unlink(src);
-  }).then(function() {
+  }).then(function () {
     if (!config.post_asset_folder) return;
 
     // Copy assets
     var assetSrc = removeExtname(src);
     var assetDest = removeExtname(result.path);
 
-    return fs.exists(assetSrc).then(function(exist) {
+    return fs.exists(assetSrc).then(function (exist) {
       if (!exist) return;
 
-      return fs.copyDir(assetSrc, assetDest).then(function() {
+      return fs.copyDir(assetSrc, assetDest).then(function () {
         return fs.rmdir(assetSrc);
       });
     });
   }).thenReturn(result).asCallback(callback);
 };
 
-Post.prototype.render = function(source, data, callback) {
+Post.prototype.render = function (source, data, callback) {
   data = data || {};
 
   var ctx = this.context;
   var config = ctx.config;
   var cache = [];
   var tag = ctx.extend.tag;
-  var isSwig = data.engine === 'swig' || (source && pathFn.extname(source) === '.swig');
+  var ext = data.engine || pathFn.extname(source);
+  var isSwig = ext === "swig";
+
+  var disableNunjucks = false;
+  if (ext && ctx.render.renderer.get(ext)) {
+    // disable disableNunjucks when the renderer spcify that.
+    disableNunjucks = disableNunjucks || !!(ctx.render.renderer.get(ext).disableNunjucks);
+  }
 
   function escapeContent(str) {
     return '<!--' + placeholder + (cache.push(str) - 1) + '-->';
   }
 
   function tagFilter(content) {
+    if (disableNunjucks) return content;
     // Replace cache data with real contents
-    content = content.replace(rPlaceholder, function() {
+    content = content.replace(rPlaceholder, function () {
       return cache[arguments[1]];
     });
 
@@ -253,31 +261,33 @@ Post.prototype.render = function(source, data, callback) {
     return tag.render(data.content, data);
   }
 
-  return new Promise(function(resolve, reject) {
+  return new Promise(function (resolve, reject) {
     if (data.content != null) return resolve(data.content);
     if (!source) return reject(new Error('No input file or string!'));
 
     // Read content from files
     fs.readFile(source).then(resolve, reject);
-  }).then(function(content) {
+  }).then(function (content) {
     data.content = content;
 
     // Run "before_post_render" filters
-    return ctx.execFilter('before_post_render', data, {context: ctx}).then(function() {
-      data.content = data.content.replace(rEscapeContent, function(match, content) {
+    return ctx.execFilter('before_post_render', data, { context: ctx }).then(function () {
+      data.content = data.content.replace(rEscapeContent, function (match, content) {
         return escapeContent(content);
       });
     });
-  }).then(function() {
+  }).then(function () {
     // Skip rendering if this is a swig file
     if (isSwig) return data.content;
 
     // Escape all Swig tags
-    data.content = data.content
-      .replace(rSwigFullBlock, escapeContent)
-      .replace(rSwigBlock, escapeContent)
-      .replace(rSwigComment, '')
-      .replace(rSwigVar, escapeContent);
+    if (!disableNunjucks) {
+      data.content = data.content
+        .replace(rSwigFullBlock, escapeContent)
+        .replace(rSwigBlock, escapeContent)
+        .replace(rSwigComment, '')
+        .replace(rSwigVar, escapeContent);
+    }
 
     var options = data.markdown || {};
     if (!config.highlight.enable) options.highlight = null;
@@ -290,7 +300,7 @@ Post.prototype.render = function(source, data, callback) {
       toString: true,
       onRenderEnd: tagFilter
     }, options);
-  }).then(function(content) {
+  }).then(function (content) {
     data.content = content;
 
     if (!isSwig) {
@@ -299,11 +309,11 @@ Post.prototype.render = function(source, data, callback) {
 
     // Render with Nunjucks
     return tag.render(data.content, data);
-  }).then(function(content) {
+  }).then(function (content) {
     data.content = content;
 
     // Run "after_post_render" filters
-    return ctx.execFilter('after_post_render', data, {context: ctx});
+    return ctx.execFilter('after_post_render', data, { context: ctx });
   });
 };
 

--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -250,7 +250,7 @@ Post.prototype.render = function(source, data, callback) {
   var config = ctx.config;
   var cache = [];
   var tag = ctx.extend.tag;
-  var ext = data.engine || pathFn.extname(source);
+  var ext = data.engine || (source ? pathFn.extname(source) : '');
   var isSwig = ext === 'swig';
 
   var disableNunjucks = false;


### PR DESCRIPTION
This PR adds Nunjucks disabling if the renderer claim that it can handle “tags” on its own.
Currently it is not active (i.e., Nunjucks would work) for all existing renderers.