### PR TITLE
enable async tags to have more nested async tags

### DIFF
--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -180,9 +180,16 @@ NunjucksAsyncBlock.prototype.parse = function(parser, nodes, lexer) {
 };
 
 NunjucksAsyncBlock.prototype.run = function(context, args, body, callback) {
-  return this._run(context, args, trimBody(body)).then(function(result) {
-    callback(null, result);
-  }, callback);
+  // enable async tag nesting
+  body((err, result) => {
+    // wrapper for trimBody expecting
+    // body to be a function
+    body = () => result
+
+    this._run(context, args, trimBody(body)).then(function(result) {
+      callback(err, result);
+    });
+  })
 };
 
 module.exports = Tag;

--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -184,12 +184,12 @@ NunjucksAsyncBlock.prototype.run = function(context, args, body, callback) {
   body((err, result) => {
     // wrapper for trimBody expecting
     // body to be a function
-    body = () => result || ''
+    body = () => result || '';
 
     this._run(context, args, trimBody(body)).then(function(result) {
       callback(err, result);
     });
-  })
+  });
 };
 
 module.exports = Tag;

--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -184,7 +184,7 @@ NunjucksAsyncBlock.prototype.run = function(context, args, body, callback) {
   body((err, result) => {
     // wrapper for trimBody expecting
     // body to be a function
-    body = () => result
+    body = () => result || ''
 
     this._run(context, args, trimBody(body)).then(function(result) {
       callback(err, result);

--- a/test/scripts/extend/tag.js
+++ b/test/scripts/extend/tag.js
@@ -81,6 +81,29 @@ describe('Tag', () => {
     });
   });
 
+  it('register() - nested async / async test', () => {
+    var tag = new Tag();
+
+    tag.register('test', (args, content) => content, {ends: true, async: true});
+    tag.register('async', (args, content) => {
+      return Promise.resolve(args.join(' ') + ' ' + content)
+    }, {ends: true, async: true});
+
+    var str = [
+      '{% test %}',
+      '123456',
+      '  {% async %}',
+      '  async',
+      '  {% endasync %}',
+      '789012',
+      '{% endtest %}'
+    ].join('\n');
+
+    return tag.render(str).then(result => {
+      result.replace(/\s/g, '').should.eql('123456async789012');
+    });
+  });
+
   it('register() - strip indention', () => {
     var tag = new Tag();
 

--- a/test/scripts/extend/tag.js
+++ b/test/scripts/extend/tag.js
@@ -86,7 +86,7 @@ describe('Tag', () => {
 
     tag.register('test', (args, content) => content, {ends: true, async: true});
     tag.register('async', (args, content) => {
-      return Promise.resolve(args.join(' ') + ' ' + content)
+      return Promise.resolve(args.join(' ') + ' ' + content);
     }, {ends: true, async: true});
 
     var str = [


### PR DESCRIPTION
nunchucks supports nested async tags.

this PR simple uses a callback function to properly chain these tags together