### PR TITLE
include og:locale

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -97,6 +97,7 @@ function openGraphHelper(options) {
   if (description) {
     result += og('og:description', description, false);
   }
+
   if (language) {
     result += og('og:locale', language, false);
   }

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -47,6 +47,7 @@ function openGraphHelper(options) {
   var siteName = options.site_name || config.title;
   var twitterCard = options.twitter_card || 'summary';
   var updated = options.updated !== false ? (options.updated || page.updated) : false;
+  var language = options.language || page.lang || page.language || config.language;
   var result = '';
 
   if (!Array.isArray(images)) images = [images];
@@ -95,6 +96,9 @@ function openGraphHelper(options) {
   result += og('og:site_name', siteName);
   if (description) {
     result += og('og:description', description, false);
+  }
+  if (language) {
+    result += og('og:locale', language, false);
   }
 
   images = images.map(function(path) {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -605,5 +605,5 @@ describe('open_graph', () => {
     });
 
     result.should.not.contain(meta({property: 'og:locale'}));
-  })
+  });
 });

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -554,4 +554,56 @@ describe('open_graph', () => {
 
     result.should.contain(meta({name: 'keywords', content: keywords}));
   });
+
+  it('og:locale - options.language', () => {
+    var result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    }, {language: 'es-cr'});
+
+    result.should.contain(meta({property: 'og:locale', content: 'es-cr'}));
+  });
+
+  it('og:locale - page.lang', () => {
+    var result = openGraph.call({
+      page: { lang: 'es-mx' },
+      config: hexo.config,
+      is_post: isPost
+    });
+
+    result.should.contain(meta({property: 'og:locale', content: 'es-mx'}));
+  });
+
+  it('og:locale - page.language', () => {
+    var result = openGraph.call({
+      page: { language: 'es-gt' },
+      config: hexo.config,
+      is_post: isPost
+    });
+
+    result.should.contain(meta({property: 'og:locale', content: 'es-gt'}));
+  });
+
+  it('og:locale - config.language', () => {
+    hexo.config.language = 'es-pa';
+
+    var result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    });
+
+    result.should.contain(meta({property: 'og:locale', content: 'es-pa'}));
+  });
+
+  it('og:locale - no language set', () => {
+    var result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    });
+
+    result.should.not.contain(meta({property: 'og:locale'}));
+  })
 });


### PR DESCRIPTION
This OpenGraph property is optional, but generally recommended. Since Hexo has i18n it's easy to support and will provide extra detail.

The `og:locale` property content will be set according to: (in order)

1. the `language` option to the open graph helper;
2. the page lang/language;
3. the site config.

When no language is set anywhere, the og:locale attribute is not set. In that case, the OpenGraph specification uses `en_US` as default.

``` html
<meta property="og:locale" content="zh-tw">
```

- [x] Added test cases for the changes.
- [x] Passed the CI test.