### PR TITLE
Actually allow plugins to be stored as devDependencies

### DIFF
--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -31,9 +31,10 @@ function loadModuleList(ctx) {
     // Read package.json and find dependencies
     return fs.readFile(packagePath).then(function(content) {
       var json = JSON.parse(content);
-      var deps = json.dependencies || json.devDependencies || {};
+      var deps = Object.keys(json.dependencies || {});
+      var devDeps = Object.keys(json.devDependencies || {});
 
-      return Object.keys(deps);
+      return deps.concat(devDeps);
     });
   }).filter(function(name) {
     // Ignore plugins whose name is not started with "hexo-"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.9.0",
+  "version": "3.10.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "3.3.8",
+  "version": "3.4.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {
@@ -28,7 +28,7 @@
   "author": "Tommy Chen <tommy351@gmail.com> (http://zespia.tw)",
   "maintainers": [
     "Abner Chou <hi@abnerchou.me> (http://abnerchou.me)"
-    ],
+  ],
   "license": "MIT",
   "dependencies": {
     "abbrev": "^1.0.7",

--- a/test/scripts/hexo/load_plugins.js
+++ b/test/scripts/hexo/load_plugins.js
@@ -48,6 +48,7 @@ describe('Load plugins', () => {
       name: 'hexo-site',
       version: '0.0.0',
       private: true,
+      dependencies: {},
       devDependencies: {}
     };
 


### PR DESCRIPTION
Plugins should be sourced from all available options, meaning both dependencies and devDependencies.  In the current implementation (#2558), plugins are only loaded from devDependencies *if there are no dependencies*. 
