### PR TITLE
Actually allow plugins to be stored as devDependencies

### DIFF
--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -31,9 +31,10 @@ function loadModuleList(ctx) {
     // Read package.json and find dependencies
     return fs.readFile(packagePath).then(function(content) {
       var json = JSON.parse(content);
-      var deps = json.dependencies || json.devDependencies || {};
+      var deps = Object.keys(json.dependencies || {});
+      var devDeps = Object.keys(json.devDependencies || {});
 
-      return Object.keys(deps);
+      return deps.concat(devDeps);
     });
   }).filter(function(name) {
     // Ignore plugins whose name is not started with "hexo-"

--- a/test/scripts/hexo/load_plugins.js
+++ b/test/scripts/hexo/load_plugins.js
@@ -48,6 +48,7 @@ describe('Load plugins', () => {
       name: 'hexo-site',
       version: '0.0.0',
       private: true,
+      dependencies: {},
       devDependencies: {}
     };
 


### PR DESCRIPTION
Plugins should be sourced from all available options, meaning both dependencies and devDependencies.  In the current implementation (#2558), plugins are only loaded from devDependencies *if there are no dependencies*. 