### PR TITLE
test: remove \u180e on excerpt test case

### DIFF
--- a/test/scripts/filters/excerpt.js
+++ b/test/scripts/filters/excerpt.js
@@ -29,7 +29,7 @@ describe('Excerpt', () => {
     function _moreCases() {
       var template = '<!--{{lead}}more{{tail}}-->';
       // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Special_characters_meaning_in_regular_expressions
-      var spaces = ' \f\n\r\t\v\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000\ufeff';
+      var spaces = ' \f\n\r\t\v\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000\ufeff';
       var cases = [];
       var more;
       var lead;


### PR DESCRIPTION
MVS is removed from whitespace since Unicode 8.0.0, see http://www.unicode.org/L2/L2013/13004-vowel-sep-change.pdf

ES2016 uses Unicode 8.0.0 thus the test fails on node.js 8.4.0

Thank you for creating a pull request to contribute to Hexo code! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- [-] Add test cases for the changes.
- [x] Passed the CI test.

Blocks #2728.