### PR TITLE
848 hierarchical categories

### DIFF
--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -134,26 +134,26 @@ module.exports = function(ctx) {
 
   Post.method('setCategories', function(cats) {
     // Remove empty categories, preserving hierarchies
-    cats = cats.filter(cat =>
-      Array.isArray(cat) ? true : cat != null && cat !== ''
-    ).map(cat =>
-      Array.isArray(cat) ? removeEmptyTag(cat) : cat + ''
-    );
+    cats = cats.filter(function(cat) {
+      return Array.isArray(cat) ? true : cat != null && cat !== '';
+    }).map(function(cat) {
+      return Array.isArray(cat) ? removeEmptyTag(cat) : cat + '';
+    });
 
     var PostCategory = ctx.model('PostCategory');
     var Category = ctx.model('Category');
     var id = this._id;
     var allIds = [];
     var existed = PostCategory.find({post_id: id}, {lean: true}).map(pickID);
-    var hasHierarchy = cats.filter(cat => Array.isArray(cat)).length > 0;
+    var hasHierarchy = cats.filter(Array.isArray).length > 0;
 
     // Add a hierarchy of categories
-    var addHierarchy = catHierarchy => {
+    var addHierarchy = function(catHierarchy) {
       var parentIds = [];
       if (!Array.isArray(catHierarchy)) catHierarchy = [catHierarchy];
       // Don't use "Promise.map". It doesn't run in series.
       // MUST USE "Promise.each".
-      return Promise.each(catHierarchy, (cat, i) => {
+      return Promise.each(catHierarchy, function(cat, i) {
         // Find the category by name
         var data = Category.findOne({
           name: cat,
@@ -170,7 +170,7 @@ module.exports = function(ctx) {
         var obj = {name: cat};
         if (i) obj.parent = parentIds[i - 1];
 
-        return Category.insert(obj).catch(err => {
+        return Category.insert(obj).catch(function(err) {
           // Try to find the category again. Throw the error if not found
           var data = Category.findOne({
             name: cat,
@@ -179,7 +179,7 @@ module.exports = function(ctx) {
 
           if (data) return data;
           throw err;
-        }).then(data => {
+        }).then(function(data) {
           allIds.push(data._id);
           parentIds.push(data._id);
           return data;
@@ -187,10 +187,10 @@ module.exports = function(ctx) {
       });
     };
 
-    return (hasHierarchy
-      ? Promise.each(cats, addHierarchy)
-      : Promise.resolve(addHierarchy(cats))
-    ).then(() => allIds).map(catId => {
+    return (hasHierarchy ? Promise.each(cats, addHierarchy) : Promise.resolve(addHierarchy(cats))
+    ).then(function() {
+      return allIds;
+    }).map(function(catId) {
       // Find the reference
       var ref = PostCategory.findOne({post_id: id, category_id: catId}, {lean: true});
       if (ref) return ref;
@@ -200,10 +200,12 @@ module.exports = function(ctx) {
         post_id: id,
         category_id: catId
       });
-    }).then(postCats =>
+    }).then(function(postCats) {
       // Remove old categories
-      _.difference(existed, postCats.map(pickID))
-    ).map(cat => PostCategory.removeById(cat));
+      return _.difference(existed, postCats.map(pickID));
+    }).map(function(cat) {
+      return PostCategory.removeById(cat);
+    });
   });
 
   // Remove PostTag references

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -133,62 +133,76 @@ module.exports = function(ctx) {
   });
 
   Post.method('setCategories', function(cats) {
-    cats = removeEmptyTag(cats);
-
+    // Remove empty categories, preserving hierarchies
+    cats = cats.filter(cat =>
+      Array.isArray(cat) ? true : cat != null && cat !== ''
+    ).map(cat =>
+      Array.isArray(cat) ? removeEmptyTag(cat) : cat + ''
+    );
+    
     var PostCategory = ctx.model('PostCategory');
     var Category = ctx.model('Category');
     var id = this._id;
     var arr = [];
     var existed = PostCategory.find({post_id: id}, {lean: true}).map(pickID);
+    var hasHierarchy = cats.filter(cat => Array.isArray(cat)).length > 0;
 
-    // Don't use "Promise.map". It doesn't run in series.
-    // MUST USE "Promise.each".
-    return Promise.each(cats, function(cat, i) {
-      // Find the category by name
-      var data = Category.findOne({
-        name: cat,
-        parent: i ? arr[i - 1] : {$exists: false}
-      }, {lean: true});
-
-      if (data) {
-        arr.push(data._id);
-        return data;
-      }
-
-      // Insert the category if not exist
-      var obj = {name: cat};
-      if (i) obj.parent = arr[i - 1];
-
-      return Category.insert(obj).catch(function(err) {
-        // Try to find the category again. Throw the error if not found
+    // Add a hierarchy of categories
+    var addHierarchy = function(catHierarchy) {
+      var parentIds = [];
+      if (!Array.isArray(catHierarchy)) catHierarchy = [catHierarchy];
+      // Don't use "Promise.map". It doesn't run in series.
+      // MUST USE "Promise.each".
+      return Promise.each(catHierarchy, function(cat, i) {
+        // Find the category by name
         var data = Category.findOne({
           name: cat,
-          parent: i ? arr[i - 1] : {$exists: false}
+          parent: i ? parentIds[i - 1] : {$exists: false}
         }, {lean: true});
-
-        if (data) return data;
-        throw err;
-      }).then(function(data) {
-        arr.push(data._id);
-        return data;
+  
+        if (data) {
+          arr.push(data._id);
+          parentIds.push(data._id);
+          return data;
+        }
+  
+        // Insert the category if not exist
+        var obj = {name: cat};
+        if (i) obj.parent = parentIds[i - 1];
+  
+        return Category.insert(obj).catch(function(err) {
+          // Try to find the category again. Throw the error if not found
+          var data = Category.findOne({
+            name: cat,
+            parent: i ? parentIds[i - 1] : {$exists: false}
+          }, {lean: true});
+  
+          if (data) return data;
+          throw err;
+        }).then(function(data) {
+          arr.push(data._id);
+          parentIds.push(data._id);
+          return data;
+        });
       });
-    }).map(function() {
-      // Get the index from the second argument
-      // and get the category id from arr.
-      var cat = arr[arguments[1]];
+    }
 
+    return (hasHierarchy
+      ? Promise.each(cats, addHierarchy)
+      : Promise.resolve(addHierarchy(cats))
+    ).then(() => arr).map(function(catId) {
       // Find the reference
-      var ref = PostCategory.findOne({post_id: id, category_id: cat}, {lean: true});
+      var ref = PostCategory.findOne({post_id: id, category_id: catId}, {lean: true});
       if (ref) return ref;
 
       // Insert the reference if not exist
       return PostCategory.insert({
         post_id: id,
-        category_id: cat
+        category_id: catId
       });
-    }).then(function(cats) {
+    }).then(function(postCats) {
       // Remove old categories
-      var deleted = _.difference(existed, cats.map(pickID));
+      var deleted = _.difference(existed, postCats.map(pickID));
       return deleted;
     }).map(function(cat) {
       return PostCategory.removeById(cat);

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -143,17 +143,17 @@ module.exports = function(ctx) {
     var PostCategory = ctx.model('PostCategory');
     var Category = ctx.model('Category');
     var id = this._id;
-    var arr = [];
+    var allIds = [];
     var existed = PostCategory.find({post_id: id}, {lean: true}).map(pickID);
     var hasHierarchy = cats.filter(cat => Array.isArray(cat)).length > 0;
 
     // Add a hierarchy of categories
-    var addHierarchy = function(catHierarchy) {
+    var addHierarchy = catHierarchy => {
       var parentIds = [];
       if (!Array.isArray(catHierarchy)) catHierarchy = [catHierarchy];
       // Don't use "Promise.map". It doesn't run in series.
       // MUST USE "Promise.each".
-      return Promise.each(catHierarchy, function(cat, i) {
+      return Promise.each(catHierarchy, (cat, i) => {
         // Find the category by name
         var data = Category.findOne({
           name: cat,
@@ -161,7 +161,7 @@ module.exports = function(ctx) {
         }, {lean: true});
   
         if (data) {
-          arr.push(data._id);
+          allIds.push(data._id);
           parentIds.push(data._id);
           return data;
         }
@@ -170,7 +170,7 @@ module.exports = function(ctx) {
         var obj = {name: cat};
         if (i) obj.parent = parentIds[i - 1];
   
-        return Category.insert(obj).catch(function(err) {
+        return Category.insert(obj).catch(err => {
           // Try to find the category again. Throw the error if not found
           var data = Category.findOne({
             name: cat,
@@ -179,18 +179,18 @@ module.exports = function(ctx) {
   
           if (data) return data;
           throw err;
-        }).then(function(data) {
-          arr.push(data._id);
+        }).then(data => {
+          allIds.push(data._id);
           parentIds.push(data._id);
           return data;
         });
       });
-    }
+    };
 
     return (hasHierarchy
       ? Promise.each(cats, addHierarchy)
       : Promise.resolve(addHierarchy(cats))
-    ).then(() => arr).map(function(catId) {
+    ).then(() => allIds).map(catId => {
       // Find the reference
       var ref = PostCategory.findOne({post_id: id, category_id: catId}, {lean: true});
       if (ref) return ref;
@@ -200,13 +200,10 @@ module.exports = function(ctx) {
         post_id: id,
         category_id: catId
       });
-    }).then(function(postCats) {
+    }).then(postCats =>
       // Remove old categories
-      var deleted = _.difference(existed, postCats.map(pickID));
-      return deleted;
-    }).map(function(cat) {
-      return PostCategory.removeById(cat);
-    });
+      _.difference(existed, postCats.map(pickID))
+    ).map(cat => PostCategory.removeById(cat));
   });
 
   // Remove PostTag references

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -139,7 +139,7 @@ module.exports = function(ctx) {
     ).map(cat =>
       Array.isArray(cat) ? removeEmptyTag(cat) : cat + ''
     );
-    
+
     var PostCategory = ctx.model('PostCategory');
     var Category = ctx.model('Category');
     var id = this._id;
@@ -159,24 +159,24 @@ module.exports = function(ctx) {
           name: cat,
           parent: i ? parentIds[i - 1] : {$exists: false}
         }, {lean: true});
-  
+
         if (data) {
           allIds.push(data._id);
           parentIds.push(data._id);
           return data;
         }
-  
+
         // Insert the category if not exist
         var obj = {name: cat};
         if (i) obj.parent = parentIds[i - 1];
-  
+
         return Category.insert(obj).catch(err => {
           // Try to find the category again. Throw the error if not found
           var data = Category.findOne({
             name: cat,
             parent: i ? parentIds[i - 1] : {$exists: false}
           }, {lean: true});
-  
+
           if (data) return data;
           throw err;
         }).then(data => {

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -53,7 +53,7 @@ module.exports = function(ctx) {
       var info = parseFilename(config.new_post_name, path);
       var keys = Object.keys(info);
       var key;
-
+      
       data.source = file.path;
       data.raw = content;
       data.slug = info.title;

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -53,7 +53,7 @@ module.exports = function(ctx) {
       var info = parseFilename(config.new_post_name, path);
       var keys = Object.keys(info);
       var key;
-      
+
       data.source = file.path;
       data.raw = content;
       data.slug = info.title;

--- a/test/scripts/helpers/list_categories.js
+++ b/test/scripts/helpers/list_categories.js
@@ -19,12 +19,14 @@ describe('list_categories', () => {
     {source: 'foo', slug: 'foo'},
     {source: 'bar', slug: 'bar'},
     {source: 'baz', slug: 'baz'},
-    {source: 'boo', slug: 'boo'}
+    {source: 'boo', slug: 'boo'},
+    {source: 'bat', slug: 'bat'}
   ])).then(posts => Promise.each([
     ['baz'],
     ['baz', 'bar'],
     ['foo'],
-    ['baz']
+    ['baz'],
+    ['bat', ['baz', 'bar']]
   ], (cats, i) => posts[i].setCategories(cats))).then(() => {
     hexo.locals.invalidate();
     ctx.site = hexo.locals.toObject();
@@ -37,10 +39,13 @@ describe('list_categories', () => {
     result.should.eql([
       '<ul class="category-list">',
         '<li class="category-list-item">',
-          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">3</span>',
+          '<a class="category-list-link" href="/categories/bat/">bat</a><span class="category-list-count">1</span>',
+        '</li>',
+        '<li class="category-list-item">',
+          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">4</span>',
           '<ul class="category-list-child">',
             '<li class="category-list-item">',
-              '<a class="category-list-link" href="/categories/baz/bar/">bar</a><span class="category-list-count">1</span>',
+              '<a class="category-list-link" href="/categories/baz/bar/">bar</a><span class="category-list-count">2</span>',
             '</li>',
           '</ul>',
         '</li>',
@@ -59,7 +64,10 @@ describe('list_categories', () => {
     result.should.eql([
       '<ul class="category-list">',
         '<li class="category-list-item">',
-          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">3</span>',
+          '<a class="category-list-link" href="/categories/bat/">bat</a><span class="category-list-count">1</span>',
+        '</li>',
+        '<li class="category-list-item">',
+          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">4</span>',
         '</li>',
         '<li class="category-list-item">',
           '<a class="category-list-link" href="/categories/foo/">foo</a><span class="category-list-count">1</span>',
@@ -74,8 +82,9 @@ describe('list_categories', () => {
     });
 
     result.should.eql([
-      '<a class="category-link" href="/categories/baz/">baz<span class="category-count">3</span></a>',
-      '<a class="category-link" href="/categories/baz/bar/">bar<span class="category-count">1</span></a>',
+      '<a class="category-link" href="/categories/bat/">bat<span class="category-count">1</span></a>',
+      '<a class="category-link" href="/categories/baz/">baz<span class="category-count">4</span></a>',
+      '<a class="category-link" href="/categories/baz/bar/">bar<span class="category-count">2</span></a>',
       '<a class="category-link" href="/categories/foo/">foo<span class="category-count">1</span></a>'
     ].join(', '));
   });
@@ -87,6 +96,9 @@ describe('list_categories', () => {
 
     result.should.eql([
       '<ul class="category-list">',
+        '<li class="category-list-item">',
+          '<a class="category-list-link" href="/categories/bat/">bat</a>',
+        '</li>',
         '<li class="category-list-item">',
           '<a class="category-list-link" href="/categories/baz/">baz</a>',
           '<ul class="category-list-child">',
@@ -110,10 +122,13 @@ describe('list_categories', () => {
     result.should.eql([
       '<ul class="test-list">',
         '<li class="test-list-item">',
-          '<a class="test-list-link" href="/categories/baz/">baz</a><span class="test-list-count">3</span>',
+          '<a class="test-list-link" href="/categories/bat/">bat</a><span class="test-list-count">1</span>',
+        '</li>',
+        '<li class="test-list-item">',
+          '<a class="test-list-link" href="/categories/baz/">baz</a><span class="test-list-count">4</span>',
           '<ul class="test-list-child">',
             '<li class="test-list-item">',
-              '<a class="test-list-link" href="/categories/baz/bar/">bar</a><span class="test-list-count">1</span>',
+              '<a class="test-list-link" href="/categories/baz/bar/">bar</a><span class="test-list-count">2</span>',
             '</li>',
           '</ul>',
         '</li>',
@@ -132,7 +147,10 @@ describe('list_categories', () => {
     result.should.eql([
       '<ul class="category-list">',
         '<li class="category-list-item">',
-          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">3</span>',
+          '<a class="category-list-link" href="/categories/bat/">bat</a><span class="category-list-count">1</span>',
+        '</li>',
+        '<li class="category-list-item">',
+          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">4</span>',
         '</li>',
         '<li class="category-list-item">',
           '<a class="category-list-link" href="/categories/foo/">foo</a><span class="category-list-count">1</span>',
@@ -152,10 +170,13 @@ describe('list_categories', () => {
           '<a class="category-list-link" href="/categories/foo/">foo</a><span class="category-list-count">1</span>',
         '</li>',
         '<li class="category-list-item">',
-          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">3</span>',
+          '<a class="category-list-link" href="/categories/bat/">bat</a><span class="category-list-count">1</span>',
+        '</li>',
+        '<li class="category-list-item">',
+          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">4</span>',
           '<ul class="category-list-child">',
             '<li class="category-list-item">',
-              '<a class="category-list-link" href="/categories/baz/bar/">bar</a><span class="category-list-count">1</span>',
+              '<a class="category-list-link" href="/categories/baz/bar/">bar</a><span class="category-list-count">2</span>',
             '</li>',
           '</ul>',
         '</li>',
@@ -174,12 +195,15 @@ describe('list_categories', () => {
           '<a class="category-list-link" href="/categories/foo/">foo</a><span class="category-list-count">1</span>',
         '</li>',
         '<li class="category-list-item">',
-          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">3</span>',
+          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">4</span>',
           '<ul class="category-list-child">',
             '<li class="category-list-item">',
-              '<a class="category-list-link" href="/categories/baz/bar/">bar</a><span class="category-list-count">1</span>',
+              '<a class="category-list-link" href="/categories/baz/bar/">bar</a><span class="category-list-count">2</span>',
             '</li>',
           '</ul>',
+        '</li>',
+        '<li class="category-list-item">',
+          '<a class="category-list-link" href="/categories/bat/">bat</a><span class="category-list-count">1</span>',
         '</li>',
       '</ul>'
     ].join(''));
@@ -195,10 +219,13 @@ describe('list_categories', () => {
     result.should.eql([
       '<ul class="category-list">',
         '<li class="category-list-item">',
-          '<a class="category-list-link" href="/categories/baz/">BAZ</a><span class="category-list-count">3</span>',
+          '<a class="category-list-link" href="/categories/bat/">BAT</a><span class="category-list-count">1</span>',
+        '</li>',
+        '<li class="category-list-item">',
+          '<a class="category-list-link" href="/categories/baz/">BAZ</a><span class="category-list-count">4</span>',
           '<ul class="category-list-child">',
             '<li class="category-list-item">',
-              '<a class="category-list-link" href="/categories/baz/bar/">BAR</a><span class="category-list-count">1</span>',
+              '<a class="category-list-link" href="/categories/baz/bar/">BAR</a><span class="category-list-count">2</span>',
             '</li>',
           '</ul>',
         '</li>',
@@ -209,15 +236,30 @@ describe('list_categories', () => {
     ].join(''));
   });
 
-  it('separator', () => {
+  it('separator (blank)', () => {
     var result = listCategories({
       style: false,
       separator: ''
     });
 
     result.should.eql([
-      '<a class="category-link" href="/categories/baz/">baz<span class="category-count">3</span></a>',
-      '<a class="category-link" href="/categories/baz/bar/">bar<span class="category-count">1</span></a>',
+      '<a class="category-link" href="/categories/bat/">bat<span class="category-count">1</span></a>',
+      '<a class="category-link" href="/categories/baz/">baz<span class="category-count">4</span></a>',
+      '<a class="category-link" href="/categories/baz/bar/">bar<span class="category-count">2</span></a>',
+      '<a class="category-link" href="/categories/foo/">foo<span class="category-count">1</span></a>'
+    ].join(''));
+  });
+
+  it('separator (non-blank)', () => {
+    var result = listCategories({
+      style: false,
+      separator: '|'
+    });
+
+    result.should.eql([
+      '<a class="category-link" href="/categories/bat/">bat<span class="category-count">1</span></a>|',
+      '<a class="category-link" href="/categories/baz/">baz<span class="category-count">4</span></a>|',
+      '<a class="category-link" href="/categories/baz/bar/">bar<span class="category-count">2</span></a>|',
       '<a class="category-link" href="/categories/foo/">foo<span class="category-count">1</span></a>'
     ].join(''));
   });
@@ -229,11 +271,14 @@ describe('list_categories', () => {
 
     result.should.eql([
       '<ul class="category-list">',
+        '<li class="category-list-item">',
+          '<a class="category-list-link" href="/categories/bat/">bat</a><span class="category-list-count">1</span>',
+        '</li>',
         '<li class="category-list-item has-children">',
-          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">3</span>',
+          '<a class="category-list-link" href="/categories/baz/">baz</a><span class="category-list-count">4</span>',
           '<ul class="category-list-child">',
             '<li class="category-list-item">',
-              '<a class="category-list-link" href="/categories/baz/bar/">bar</a><span class="category-list-count">1</span>',
+              '<a class="category-list-link" href="/categories/baz/bar/">bar</a><span class="category-list-count">2</span>',
             '</li>',
           '</ul>',
         '</li>',
@@ -252,10 +297,13 @@ describe('list_categories', () => {
     result.should.eql([
       '<ul class="category-list">',
         '<li class="category-list-item">',
-          '<a class="category-list-link current" href="/categories/baz/">baz</a><span class="category-list-count">3</span>',
+          '<a class="category-list-link" href="/categories/bat/">bat</a><span class="category-list-count">1</span>',
+        '</li>',
+        '<li class="category-list-item">',
+          '<a class="category-list-link current" href="/categories/baz/">baz</a><span class="category-list-count">4</span>',
           '<ul class="category-list-child">',
             '<li class="category-list-item">',
-              '<a class="category-list-link current" href="/categories/baz/bar/">bar</a><span class="category-list-count">1</span>',
+              '<a class="category-list-link current" href="/categories/baz/bar/">bar</a><span class="category-list-count">2</span>',
             '</li>',
           '</ul>',
         '</li>',

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -127,7 +127,7 @@ describe('Post', () => {
   }).then(post => post.setCategories(['foo', 'bar', 'baz'])
     .thenReturn(Post.findById(post._id))).then(post => {
     var cats = post.categories;
-    
+
     // Make sure the order of categories is correct
     cats.map((cat, i) => {
       // Make sure the parent reference is correct
@@ -326,11 +326,11 @@ describe('Post', () => {
     // Category 1 should be foo, no parent
     cats[0].name.should.eql('foo');
     should.not.exist(cats[0].parent);
-    
+
     // Category 2 should be bar, foo as parent
     cats[1].name.should.eql('bar');
     cats[1].parent.should.eql(cats[0]._id);
-    
+
     // Category 3 should be baz, no parent
     cats[2].name.should.eql('baz');
     should.not.exist(cats[2].parent);

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -127,7 +127,7 @@ describe('Post', () => {
   }).then(post => post.setCategories(['foo', 'bar', 'baz'])
     .thenReturn(Post.findById(post._id))).then(post => {
     var cats = post.categories;
-
+    
     // Make sure the order of categories is correct
     cats.map((cat, i) => {
       // Make sure the parent reference is correct
@@ -139,6 +139,31 @@ describe('Post', () => {
 
       return cat.name;
     }).should.eql(['foo', 'bar', 'baz']);
+
+    return Post.removeById(post._id);
+  }));
+
+  it('categories (multi hierarchy) - virtual', () => Post.insert({
+    source: 'foo.md',
+    slug: 'bar'
+  }).then(post => post.setCategories([['foo', '', 'bar'], '', 'baz'])
+    .thenReturn(Post.findById(post._id))).then(post => {
+    var cats = post.categories.toArray();
+
+    // There should have been 3 categories set; blanks eliminated
+    cats.should.have.lengthOf(3);
+
+    // Category 1 should be foo, no parent
+    cats[0].name.should.eql('foo');
+    should.not.exist(cats[0].parent);
+    
+    // Category 2 should be bar, foo as parent
+    cats[1].name.should.eql('bar');
+    cats[1].parent.should.eql(cats[0]._id);
+    
+    // Category 3 should be baz, no parent
+    cats[2].name.should.eql('baz');
+    should.not.exist(cats[2].parent);
 
     return Post.removeById(post._id);
   }));

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -143,31 +143,6 @@ describe('Post', () => {
     return Post.removeById(post._id);
   }));
 
-  it('categories (multi hierarchy) - virtual', () => Post.insert({
-    source: 'foo.md',
-    slug: 'bar'
-  }).then(post => post.setCategories([['foo', '', 'bar'], '', 'baz'])
-    .thenReturn(Post.findById(post._id))).then(post => {
-    var cats = post.categories.toArray();
-
-    // There should have been 3 categories set; blanks eliminated
-    cats.should.have.lengthOf(3);
-
-    // Category 1 should be foo, no parent
-    cats[0].name.should.eql('foo');
-    should.not.exist(cats[0].parent);
-    
-    // Category 2 should be bar, foo as parent
-    cats[1].name.should.eql('bar');
-    cats[1].parent.should.eql(cats[0]._id);
-    
-    // Category 3 should be baz, no parent
-    cats[2].name.should.eql('baz');
-    should.not.exist(cats[2].parent);
-
-    return Post.removeById(post._id);
-  }));
-
   it('setTags() - old tags should be removed', () => {
     var id;
 
@@ -337,6 +312,31 @@ describe('Post', () => {
       post.categories.map(cat => cat.name).should.eql(['foo', 'bar']);
     }).finally(() => Post.removeById(id));
   });
+
+  it('setCategories() - multiple hierarchies', () => Post.insert({
+    source: 'foo.md',
+    slug: 'bar'
+  }).then(post => post.setCategories([['foo', '', 'bar'], '', 'baz'])
+    .thenReturn(Post.findById(post._id))).then(post => {
+    var cats = post.categories.toArray();
+
+    // There should have been 3 categories set; blanks eliminated
+    cats.should.have.lengthOf(3);
+
+    // Category 1 should be foo, no parent
+    cats[0].name.should.eql('foo');
+    should.not.exist(cats[0].parent);
+    
+    // Category 2 should be bar, foo as parent
+    cats[1].name.should.eql('bar');
+    cats[1].parent.should.eql(cats[0]._id);
+    
+    // Category 3 should be baz, no parent
+    cats[2].name.should.eql('baz');
+    should.not.exist(cats[2].parent);
+
+    return Post.removeById(post._id);
+  }));
 
   it('remove PostTag references when a post is removed', () => Post.insert({
     source: 'foo.md',

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -338,6 +338,19 @@ describe('Post', () => {
     return Post.removeById(post._id);
   }));
 
+  it('setCategories() - multiple hierarchies (dedupes repeated parent)', () => Post.insert({
+    source: 'foo.md',
+    slug: 'bar'
+  }).then(post => post.setCategories([['foo', 'bar'], ['foo', 'baz']])
+    .thenReturn(Post.findById(post._id))).then(post => {
+    var cats = post.categories.toArray();
+
+    // There should have been 3 categories set (foo is dupe)
+    cats.should.have.lengthOf(3);
+
+    return Post.removeById(post._id);
+  }));
+
   it('remove PostTag references when a post is removed', () => Post.insert({
     source: 'foo.md',
     slug: 'bar'

--- a/test/scripts/processors/post.js
+++ b/test/scripts/processors/post.js
@@ -663,6 +663,31 @@ describe('post', () => {
     }).finally(() => fs.unlink(file.source));
   });
 
+  it('post - categories (multiple hierarchies)', () => {
+    var body = [
+      'title: "Hello world"',
+      'categories:',
+      '- foo',
+      '- [bar, baz]',
+      '---'
+    ].join('\n');
+
+    var file = newFile({
+      path: 'foo.html',
+      published: true,
+      type: 'create',
+      renderable: true
+    });
+
+    return fs.writeFile(file.source, body).then(() => process(file)).then(() => {
+      var post = Post.findOne({source: file.path});
+
+      post.categories.map(item => item.name).should.eql(['foo', 'bar', 'baz']);
+
+      return post.remove();
+    }).finally(() => fs.unlink(file.source));
+  });
+
   it('post - tag is an alias for tags', () => {
     var body = [
       'title: "Hello world"',


### PR DESCRIPTION
This implements the ability to have multiple category hierarchies attached to a single post (#848).

By default, everything works the way it currently does; a list of categories will be assembled for a single category hierarchy. The change implemented here is that, if a category is a list, `setCategories()` will switch into multiple category mode, and each top-level item in the list will be a category hierarchy itself.

```yaml
categories:
- Example 1
- Example 2
- [Example 3, Subexample 3.1]
```
This will result in four different categories assigned to the post, with three different hierarchies (`example-1`, `example-2`, and `example-3/subexample-3.1`). The category generator already created index pages for intermediate categories, so `[url]/category/example-3/` is a good URL, and would contain this post.

I have just forked/cloned the `site` repo, and will get the documentation for this change there.  Additionally, I plan to look at the WordPress export format; if it exports the categories in their hierarchy, I'll see if I can PR a change to that migrator to bring the hierarchies over intact.

- [x] Add test cases for the changes.
- [x] Passed the CI test.
