### PR TITLE
Change plugins loading order

### DIFF
--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -8,10 +8,9 @@ var chalk = require('chalk');
 module.exports = function(ctx) {
   if (!ctx.env.init || ctx.env.safe) return;
 
-  return Promise.all([
-    loadModules(ctx),
-    loadScripts(ctx)
-  ]);
+  return loadModules(ctx).then(function () {
+    return loadScripts(ctx);
+  });
 };
 
 function loadModuleList(ctx) {
@@ -68,8 +67,8 @@ function loadScripts(ctx) {
   }
 
   return Promise.filter([
-    ctx.script_dir,
-    ctx.theme_script_dir
+    ctx.theme_script_dir,
+    ctx.script_dir
   ], function(scriptDir) {
     // Ignore the directory if it does not exist
     return scriptDir ? fs.exists(scriptDir) : false;

--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -8,7 +8,7 @@ var chalk = require('chalk');
 module.exports = function(ctx) {
   if (!ctx.env.init || ctx.env.safe) return;
 
-  return loadModules(ctx).then(function () {
+  return loadModules(ctx).then(function() {
     return loadScripts(ctx);
   });
 };


### PR DESCRIPTION
Intuition says local changes should have precedence over external ones, so this enforces the following load order:

external modules -> theme scripts -> local scripts

This way, any changes made locally will surely be applied.

The motivation was a long time trying to debug something I've overwritten in a local script that wasn't running.