### PR TITLE
fix a bug that post.permalink error when config.relative_link is true

### DIFF
--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -58,6 +58,7 @@ module.exports = function(ctx) {
     var self = _.assign({}, ctx.extend.helper.list(), ctx);
     var config = ctx.config;
     var partial_url = self.url_for(this.path);
+    if (config.relative_link) partial_url = '/' + partial_url;
     return config.url + _.replace(partial_url, config.root, '/');
   });
 

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -82,7 +82,7 @@ describe('Post', () => {
       return Post.removeById(data._id);
     });
   });
-  
+
   it('permalink - virtual - when set relative_link', () => {
     hexo.config.root = '/';
     hexo.config.relative_link = true;
@@ -106,7 +106,7 @@ describe('Post', () => {
       return Post.removeById(data._id);
     });
   });
-  
+
   it('permalink_root_prefix - virtual - when set relative_link', () => {
     hexo.config.url = 'http://yoursite.com/root';
     hexo.config.root = '/root/';

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -82,6 +82,18 @@ describe('Post', () => {
       return Post.removeById(data._id);
     });
   });
+  
+  it('permalink - virtual - when set relative_link', () => {
+    hexo.config.root = '/';
+    hexo.config.relative_link = true;
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bar'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path);
+      return Post.removeById(data._id);
+    });
+  });
 
   it('permalink_root_prefix - virtual', () => {
     hexo.config.url = 'http://yoursite.com/root';
@@ -91,6 +103,19 @@ describe('Post', () => {
       slug: 'bar'
     }).then(data => {
       data.permalink.should.eql('http://yoursite.com/root/' + data.path);
+      return Post.removeById(data._id);
+    });
+  });
+  
+  it('permalink_root_prefix - virtual - when set relative_link', () => {
+    hexo.config.url = 'http://yoursite.com/root';
+    hexo.config.root = '/root/';
+    hexo.config.relative_link = true;
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bar'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path);
       return Post.removeById(data._id);
     });
   });


### PR DESCRIPTION
When set `relative_link` to `true` in `config.yml`, the `post.permalink` will incrrect.

For example:
When `config.url` is `http://yoursite.com/` and the post's path is `2017/09/a-post` ,the result will `http://yoursite.com2017/09/a-post` . It misses a separator `/` after the site url.

This pull request aims to repair this problem.

- [x] Add test cases for the changes.
- [ ]  Passed the CI test.