### PR TITLE
Only one label can be used for marking

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -13,10 +13,7 @@ exemptLabels:
   - feature-request
   - enhancement
 # Label to use when marking as stale
-staleLabel:
-  - wontfix
-  - duplicate
-  - invalid
+staleLabel: wontfix
 # Comment to post when marking as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because lack of


### PR DESCRIPTION
:wave: thanks for using the @probot stale app. I noticed some errors in our logs coming from this app, caused by multiple labels being used for the `staleLabel`. This is the label the app applies when an issue meets the stale criteria, so it only accepts one.