### PR TITLE
feat(config): use yml.load to support custom js types

### DIFF
--- a/lib/hexo/multi_config_path.js
+++ b/lib/hexo/multi_config_path.js
@@ -47,7 +47,7 @@ module.exports = function(ctx) {
       var ext = pathFn.extname(paths[i]).toLowerCase();
 
       if (ext === '.yml') {
-        deepAssign(combinedConfig, yml.safeLoad(file));
+        deepAssign(combinedConfig, yml.load(file));
         count++;
       } else if (ext === '.json') {
         deepAssign(combinedConfig, yml.safeLoad(file, {json: true}));

--- a/lib/plugins/console/config.js
+++ b/lib/plugins/console/config.js
@@ -37,7 +37,7 @@ function configConsole(args) {
     if (extname === '.json') {
       result = JSON.stringify(config);
     } else {
-      result = yaml.safeDump(config);
+      result = yaml.dump(config);
     }
 
     return fs.writeFile(configPath, result);

--- a/test/scripts/console/config.js
+++ b/test/scripts/console/config.js
@@ -63,7 +63,7 @@ describe('config', () => {
   function writeConfig() {
     var args = _.toArray(arguments);
 
-    return config({_: args}).then(() => fs.readFile(hexo.config_path)).then(content => yaml.safeLoad(content));
+    return config({_: args}).then(() => fs.readFile(hexo.config_path)).then(content => yaml.load(content));
   }
 
   it('write config', () => writeConfig('title', 'My Blog').then(config => {
@@ -84,6 +84,10 @@ describe('config', () => {
 
   it('write config: null', () => writeConfig('language', 'null').then(config => {
     should.not.exist(config.language);
+  }));
+
+  it('write config: regex', () => writeConfig('include', /^pattern$/gim).then(config => {
+    config.include.should.eql(/^pattern$/gim);
   }));
 
   it('write config: json', () => {


### PR DESCRIPTION
The `safeLoad` method is recommended for untrusted data. However, hexo uses `js-yaml` to parse config files handwritten by SAs. These config files should be treated as trusted data and thus we can use `load` method for flexibility. The `load` method uses `DEFAULT_FULL_SCHEMA` to support !!js/regexp or !!js/function types.

This commit does not introduce breaking change as `DEFAULT_FULL_SCHEMA` is a superset of `DEFAULT_SAFE_SCHEMA`, which is defaults of `safeLoad`.

Thank you for creating a pull request to contribute to Hexo code! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- [x] Add test cases for the changes.
- [x] Passed the CI test.
