### PR TITLE
Reuse img in asset img

### DIFF
--- a/lib/plugins/tag/asset_img.js
+++ b/lib/plugins/tag/asset_img.js
@@ -1,28 +1,34 @@
 'use strict';
 
 var url = require('url');
+var img = require('./img');
 
 /**
  * Asset image tag
  *
  * Syntax:
- *   {% asset_img slug [title]%}
+ *   {% asset_img [class names] slug [width] [height] [title text [alt text]]%}
  */
 module.exports = function(ctx) {
   var PostAsset = ctx.model('PostAsset');
 
   return function assetImgTag(args) {
-    var slug = args.shift();
-    if (!slug) return;
+    var asset;
+    var item = '';
+    var i = 0;
+    var len = args.length;
+    
+    // Find image URL
+    for (; i < len; i++) {
+      item = args[i];
+      asset = PostAsset.findOne({post: this._id, slug: item});
+      if (asset) break;
+    }
 
-    var asset = PostAsset.findOne({post: this._id, slug: slug});
     if (!asset) return;
+    
+    args[i] = url.resolve(ctx.config.root, asset.path);
 
-    // if title is not assigned, set it ''
-    var title = args.length ? args.join(' ') : '';
-    // alt always exist
-    var alt = title || asset.slug;
-
-    return '<img src="' + url.resolve(ctx.config.root, asset.path) + '" alt="' + alt + '" title="' + title + '">';
+    return img(ctx)(args);
   };
 };

--- a/lib/plugins/tag/asset_img.js
+++ b/lib/plugins/tag/asset_img.js
@@ -17,7 +17,7 @@ module.exports = function(ctx) {
     var item = '';
     var i = 0;
     var len = args.length;
-    
+
     // Find image URL
     for (; i < len; i++) {
       item = args[i];
@@ -26,7 +26,7 @@ module.exports = function(ctx) {
     }
 
     if (!asset) return;
-    
+
     args[i] = url.resolve(ctx.config.root, asset.path);
 
     return img(ctx)(args);

--- a/test/scripts/tags/asset_img.js
+++ b/test/scripts/tags/asset_img.js
@@ -36,18 +36,28 @@ describe('asset_img', () => {
   }));
 
   it('default', () => {
-    assetImg('bar').should.eql('<img src="/foo/bar" alt="bar" title="">');
+    assetImg('bar').should.eql('<img src="/foo/bar">');
   });
 
   it('default', () => {
-    assetImg('bar title').should.eql('<img src="/foo/bar" alt="title" title="title">');
+    assetImg('bar title').should.eql('<img src="/foo/bar" title="title">');
   });
 
   it('with space', () => {
     // {% asset_img "spaced asset" "spaced title" %}
     assetImgTag.call(post, ['spaced asset', 'spaced title'])
-      .should.eql('<img src="/foo/spaced%20asset" alt="spaced title" title="spaced title">');
+      .should.eql('<img src="/foo/spaced%20asset" title="spaced title">');
   });
+  
+  it('with alt and title', () => {
+    assetImgTag.call(post, ['bar', '"title"', '"alt"'])
+      .should.eql('<img src="/foo/bar" title="title" alt="alt">');
+  });
+  
+    it('with width height alt and title', () => {
+      assetImgTag.call(post, ['bar', '100', '200', '"title"', '"alt"'])
+        .should.eql('<img src="/foo/bar" width="100" height="200" title="title" alt="alt">');
+    });
 
   it('no slug', () => {
     should.not.exist(assetImg(''));

--- a/test/scripts/tags/asset_img.js
+++ b/test/scripts/tags/asset_img.js
@@ -48,16 +48,16 @@ describe('asset_img', () => {
     assetImgTag.call(post, ['spaced asset', 'spaced title'])
       .should.eql('<img src="/foo/spaced%20asset" title="spaced title">');
   });
-  
+
   it('with alt and title', () => {
     assetImgTag.call(post, ['bar', '"title"', '"alt"'])
       .should.eql('<img src="/foo/bar" title="title" alt="alt">');
   });
-  
-    it('with width height alt and title', () => {
-      assetImgTag.call(post, ['bar', '100', '200', '"title"', '"alt"'])
-        .should.eql('<img src="/foo/bar" width="100" height="200" title="title" alt="alt">');
-    });
+
+  it('with width height alt and title', () => {
+    assetImgTag.call(post, ['bar', '100', '200', '"title"', '"alt"'])
+      .should.eql('<img src="/foo/bar" width="100" height="200" title="title" alt="alt">');
+  });
 
   it('no slug', () => {
     should.not.exist(assetImg(''));


### PR DESCRIPTION
This change reuses `img` plugin within the `asset_img`. Thanks to this, we can use more flexible syntax:

`{% asset_img [class names] slug [width] [height] [title text [alt text]]%}`

If Google Translate is right, this PR is related to #2275.
