### PR TITLE
Limit meta description length to 160 characters

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -75,7 +75,7 @@ function openGraphHelper(options) {
   }
 
   if (description) {
-    result += meta('description', description.substring(0, 160), false);
+    result += meta('description', description.substring(0, 160), false); // Truncate meta description to 160 characters - SEO Best practice - See https://github.com/hexojs/hexo/issues/2809
   }
 
   if (keywords) {

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -75,7 +75,7 @@ function openGraphHelper(options) {
   }
 
   if (description) {
-    result += meta('description', description, false);
+    result += meta('description', description.substring(0, 160), false);
   }
 
   if (keywords) {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -1,5 +1,6 @@
 var moment = require('moment');
 var should = require('chai').should(); // eslint-disable-line
+var expect = require('chai').expect;
 
 describe('open_graph', () => {
   var Hexo = require('../../../lib/hexo');
@@ -238,6 +239,19 @@ describe('open_graph', () => {
     }, {site_name: 'foo'});
 
     result.should.contain(meta({property: 'og:site_name', content: 'foo'}));
+  });
+
+  it('description - truncate meta description to 160 characters', () => {
+    var ctx = {
+      // 160 `a`s followed by some `b`s
+      page: {description: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbb'},
+      config: hexo.config,
+      is_post: isPost
+    };
+
+    var result = openGraph.call(ctx);
+
+    expect(result.match('<meta name="description"[^>]+content="([^")]*)"')[1].length).to.be.at.most(160);
   });
 
   it('description - page', () => {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -1,6 +1,5 @@
 var moment = require('moment');
 var should = require('chai').should(); // eslint-disable-line
-var expect = require('chai').expect;
 
 describe('open_graph', () => {
   var Hexo = require('../../../lib/hexo');

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -251,7 +251,7 @@ describe('open_graph', () => {
 
     var result = openGraph.call(ctx);
 
-    expect(result.match('<meta name="description"[^>]+content="([^")]*)"')[1].length).to.be.at.most(160);
+    result.match('<meta name="description"[^>]+content="([^")]*)"')[1].length.should.be.at.most(160);
   });
 
   it('description - page', () => {


### PR DESCRIPTION
Fixes https://github.com/hexojs/hexo/issues/2809.

Leaves other Open Graph meta tags @ 200 characters

- [x] Add test cases for the changes.
- [ ] Passed the CI test.