### PR TITLE
Rel external switched to noopener

### DIFF
--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -30,7 +30,7 @@ function externalLinkFilter(data) {
 
     $(this)
       .attr('target', '_blank')
-      .attr('rel', 'external');
+      .attr('rel', 'noopener');
   });
 
   data.content = $.html();

--- a/lib/plugins/helper/link_to.js
+++ b/lib/plugins/helper/link_to.js
@@ -23,7 +23,7 @@ function linkToHelper(path, text, options) {
 
   if (attrs.external) {
     attrs.target = '_blank';
-    attrs.rel = 'external noopener';
+    attrs.rel = 'noopener';
     attrs.external = null;
   }
 

--- a/test/scripts/filters/external_link.js
+++ b/test/scripts/filters/external_link.js
@@ -43,7 +43,7 @@ describe('External link', () => {
     data.content.should.eql([
       '# External link test',
       '1. External link',
-      '<a href="http://hexo.io/" target="_blank" rel="external">Hexo</a>',
+      '<a href="http://hexo.io/" target="_blank" rel="noopener">Hexo</a>',
       '2. Internal link',
       '<a href="/archives/foo.html">Link</a>',
       '3. Ignore links have "target" attribute',

--- a/test/scripts/helpers/link_to.js
+++ b/test/scripts/helpers/link_to.js
@@ -22,12 +22,12 @@ describe('link_to', () => {
 
   it('external (boolean)', () => {
     linkTo('http://hexo.io/', 'Hexo', true)
-      .should.eql('<a href="http://hexo.io/" title="Hexo" target="_blank" rel="external noopener">Hexo</a>');
+      .should.eql('<a href="http://hexo.io/" title="Hexo" target="_blank" rel="noopener">Hexo</a>');
   });
 
   it('external (object)', () => {
     linkTo('http://hexo.io/', 'Hexo', {external: true})
-      .should.eql('<a href="http://hexo.io/" title="Hexo" target="_blank" rel="external noopener">Hexo</a>');
+      .should.eql('<a href="http://hexo.io/" title="Hexo" target="_blank" rel="noopener">Hexo</a>');
   });
 
   it('class (string)', () => {


### PR DESCRIPTION
Rel "external" switched to "noopener" for security best practices.
See https://developers.google.com/web/tools/lighthouse/audits/noopener (and other related documentation) for more info on this threat.

- [V] Add test cases for the changes.
- [V] Passed the CI test.
