### PR TITLE
fix bug: remove dupliated root path when using asset_img tag

### DIFF
--- a/lib/plugins/tag/asset_img.js
+++ b/lib/plugins/tag/asset_img.js
@@ -27,7 +27,7 @@ module.exports = function(ctx) {
 
     if (!asset) return;
 
-    args[i] = url.resolve(ctx.config.root, asset.path);
+    args[i] = url.resolve('/', asset.path);
 
     return img(ctx)(args);
   };

--- a/test/scripts/tags/asset_img.js
+++ b/test/scripts/tags/asset_img.js
@@ -66,4 +66,9 @@ describe('asset_img', () => {
   it('asset not found', () => {
     should.not.exist(assetImg('boo'));
   });
+
+  it('with root path', ()=> {
+    hexo.config.root = '/root/';
+    assetImg('bar').should.eql('<img src="/root/foo/bar">');
+  });
 });


### PR DESCRIPTION
solving #2123

- plugin img tag resolve root path twice 

on `lib/plugin/tag/asset_img.js`

```
  args[i] = url.resolve(ctx.config.root, asset.path);  << first 
```
and on `lib/plugin/tag/img.js`

```
  function makeUrl(path) {
    if (path[0] === '#' || path.substring(0, 2) === '//') {
      return path;
    }

    var data = url.parse(path);

    if (data && data.protocol) {
      return path;
    }

    path = config.root + path;

    return path.replace(/\/{2,}/g, '/'); << second
  }
```

I think there is no reason to prefix root config twice.





