### PR TITLE
Fix a bug then pages display more reasonable.

### DIFF
--- a/lib/plugins/helper/paginator.js
+++ b/lib/plugins/helper/paginator.js
@@ -56,8 +56,8 @@ function paginatorHelper(options) {
     // It's too complicated. May need refactor.
     var leftEnd = current <= endSize ? current - 1 : endSize;
     var rightEnd = total - current <= endSize ? current + 1 : total - endSize + 1;
-    var leftMid = current - midSize <= endSize ? current - midSize + endSize : current - midSize;
-    var rightMid = current + midSize + endSize > total ? current + midSize - endSize : current + midSize;
+    var leftMid = current - midSize <= endSize ? leftEnd + 1 : current - midSize;
+    var rightMid = current + midSize + endSize > total ? rightEnd - 1 : current + midSize;
     var spaceHtml = '<span class="space">' + space + '</span>';
 
     // Display pages on the left edge


### PR DESCRIPTION
When I use `paginator` function like this:
`paginator({
    space: "",
    end_size: 0,
    mid_size: 2,
    prev_text: " ",
    next_text: " "
})`, then in `/page/2`, the page nums in `nav` tag whose class name is `page-nav` will be 2, 3, 4.
I think the corrent display should be 1, 2, 3, 4.

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
