### PR TITLE
Revert "Limit meta description length to 160 characters"

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -75,7 +75,7 @@ function openGraphHelper(options) {
   }
 
   if (description) {
-    result += meta('description', description.substring(0, 160), false); // Truncate meta description to 160 characters - SEO Best practice - See https://github.com/hexojs/hexo/issues/2809
+    result += meta('description', description, false);
   }
 
   if (keywords) {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -240,19 +240,6 @@ describe('open_graph', () => {
     result.should.contain(meta({property: 'og:site_name', content: 'foo'}));
   });
 
-  it('description - truncate meta description to 160 characters', () => {
-    var ctx = {
-      // 160 `a`s followed by some `b`s
-      page: {description: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbb'},
-      config: hexo.config,
-      is_post: isPost
-    };
-
-    var result = openGraph.call(ctx);
-
-    result.match('<meta name="description"[^>]+content="([^")]*)"')[1].length.should.be.at.most(160);
-  });
-
   it('description - page', () => {
     var ctx = {
       page: {description: 'test'},


### PR DESCRIPTION
Reverts hexojs/hexo#2810
As discussed in #2809, the user should be able to decide how to use the meta description.