### PR TITLE
Revert "hotfix(file): cast dev to uint32"

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,15 +5,15 @@ init:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "6"
-    - nodejs_version: "8"
+    - nodejs_version: "6.12.2"
+    - nodejs_version: "8.9.3"
 
 matrix:
   fast_finish: true
 
 # Install scripts. (runs after repo cloning)
 install:
-  - ps: Install-Product node $env:nodejs_version
+  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
   - npm install -g npm
   - npm install
 

--- a/test/scripts/box/file.js
+++ b/test/scripts/box/file.js
@@ -73,8 +73,6 @@ describe('File', () => {
     file.stat((err, fileStats) => {
       if (err) return callback(err);
 
-      //todo: cast dev to uint32 until https://github.com/nodejs/node/issues/16496 is resolved
-      fileStats.dev = (new Uint32Array([fileStats.dev]))[0];
       fileStats.should.eql(fs.statSync(file.source));
       callback();
     });


### PR DESCRIPTION
This reverts commit a2184229232a9893179b43475f344c556ec4d956.

Since https://github.com/nodejs/node/pull/16705 is merged, the hotfix is unecessary.

# Conflicts:
#	test/scripts/box/file.js

- [x] Passed the CI test.

# Todo
- [ ] Hold this PR until appveyor update node.js to 6.12.1