### PR TITLE
Configs are now expanded for hexo-util/highlight to make it easier to…

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -18,7 +18,7 @@ function backtickCodeBlock(data) {
     var content = arguments[4];
 
     var options = {
-      ...config,
+      hljs: config.hljs,
       autoDetect: config.auto_detect,
       gutter: config.line_number,
       tab: config.tab_replace

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -11,7 +11,6 @@ var rLangCaption = /([^\s]+)\s*(.+)?/;
 function backtickCodeBlock(data) {
   var config = this.config.highlight || {};
   if (!config.enable) return;
-
   data.content = data.content.replace(rBacktick, function() {
     var start = arguments[1];
     var end = arguments[5];
@@ -19,6 +18,7 @@ function backtickCodeBlock(data) {
     var content = arguments[4];
 
     var options = {
+      ...config,
       autoDetect: config.auto_detect,
       gutter: config.line_number,
       tab: config.tab_replace

--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -111,11 +111,11 @@ module.exports = function(ctx) {
     content = stripIndent(content);
 
     content = highlight(content, {
-      ...config,
       lang: lang,
       firstLine: first_line,
       caption: caption,
       gutter: line_number,
+      hljs: config.hljs,
       mark: mark,
       tab: config.tab_replace,
       autoDetect: config.auto_detect

--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -111,6 +111,7 @@ module.exports = function(ctx) {
     content = stripIndent(content);
 
     content = highlight(content, {
+      ...config,
       lang: lang,
       firstLine: first_line,
       caption: caption,


### PR DESCRIPTION
This is part of the code necessary to address #2145.

It simply expands `config.highlight` inside of the `options` object that is passed to `hexo-util/highlight`.

I went this route to make sure that the plugin remains backward compatible for themes and people who have already styled based on the current highlight engine.

This is a quick proof of concept, and if everything is fine, I will update the documentation accordingly.

The other part of the PR will be in [`@hexojs/hexo-util`](https://github.com/hexojs/hexo-util)

The matching PR to support the added `highlight.hljs` setting is located at [`hexo-util/#30`](https://github.com/hexojs/hexo-util/pull/30)

- [x] Add test cases for the changes.
- [x] Passed the CI test.
