### PR TITLE
chore(travis): update dist to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ after_script:
   - npm install coveralls
   - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
 
-dist: precise
+dist: trusty


### PR DESCRIPTION
Update dist of travis to `trusty`. Better boot time according to https://docs.travis-ci.com/user/reference/overview/

- [x] Passed the CI test.
