### PR TITLE
chore(package): add lint-staged eslint autofix

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,7 @@
+{
+  "linters": {
+    "*.js": [
+      "git-exec-and-restage eslint --fix --"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   "scripts": {
     "eslint": "eslint-ci .",
     "test": "mocha test/index.js",
-    "test-cov": "istanbul cover --print both _mocha -- test/index.js"
+    "test-cov": "istanbul cover --print both _mocha -- test/index.js",
+    "precommit": "lint-staged",
+    "lint-staged": "lint-staged"
   },
   "directories": {
     "lib": "./lib",
@@ -58,14 +60,17 @@
     "warehouse": "^2.2.0"
   },
   "devDependencies": {
+    "@easyops/git-exec-and-restage": "^1.0.4",
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^4.13.1",
     "eslint-ci": "^0.1.1",
     "eslint-config-hexo": "^2.0.0",
     "hexo-renderer-marked": "^0.3.0",
+    "husky": "^0.14.3",
     "istanbul": "^0.4.3",
     "jscs-preset-hexo": "^1.0.1",
+    "lint-staged": "^6.0.0",
     "mocha": "^4.0.1",
     "rewire": "^3.0.2",
     "sinon": "^4.1.2"


### PR DESCRIPTION
This PR introduces pre-commit hook to run eslint autofix on staged .js files. Most of time you will not waste your time adding whitespace or commas after you draft a PR and the travis fails due to style issues. No more, it is frustrating and tedious. We really treasure your time.

In this time you simply draft your ideas and let `eslint` fix most style issues for you on commit, you just sit and don't have to run `eslint` after you revise files.

`git-exec-and-restage` is less popular but it proves pretty handy over half a year coporate trial. Basically `git-exec-and-restage` will only run `git add` on fully staged file. It runs linter on partially staged file and it depends on you to commit the style changes of specific hunks later.
  