### PR TITLE
Fixed #2954

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -31,6 +31,7 @@ function og(name, content, escape) {
 }
 
 function removeScripts(content) {
+    if (!content) return content;
     return content.replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;')
     .replace(/\n/g, ' ')

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -31,8 +31,8 @@ function og(name, content, escape) {
 }
 
 function removeScripts(content) {
-    if (!content || !content.match(/<script>(.*?)<\/script>/g)) return content;
-    return content.replace(/"/g, '&quot;')
+  if (!content || !content.match(/<script>(.*?)<\/script>/g)) return content;
+  return content.replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;')
     .replace(/\n/g, ' ')
     .replace(/<script>(.*?)<\/script>/g, '');

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -32,10 +32,7 @@ function og(name, content, escape) {
 
 function removeScripts(content) {
   if (!content || !content.match(/<script>(.*?)<\/script>/g)) return content;
-  return content.replace(/"/g, '&quot;')
-    .replace(/'/g, '&apos;')
-    .replace(/\n/g, ' ')
-    .replace(/<script>(.*?)<\/script>/g, '');
+  return content.replace(/\n/g, ' ').replace(/<script>(.*?)<\/script>/g, '');
 }
 
 function openGraphHelper(options) {

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -31,7 +31,7 @@ function og(name, content, escape) {
 }
 
 function removeScripts(content) {
-    if (!content) return content;
+    if (!content || !content.match(/<script>(.*?)<\/script>/g)) return content;
     return content.replace(/"/g, '&quot;')
     .replace(/'/g, '&apos;')
     .replace(/\n/g, ' ')
@@ -45,7 +45,8 @@ function openGraphHelper(options) {
 
   var page = this.page;
   var config = this.config;
-  var content = removeScripts(page.content);
+  var content = page.content;
+  content = removeScripts(content);
   var images = options.image || options.images || page.photos || [];
   var description = options.description || page.description || page.excerpt || config.description || content;
   var keywords = page.keywords || (page.tags && page.tags.length ? page.tags : undefined) || config.keywords;

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -30,6 +30,13 @@ function og(name, content, escape) {
   }) + '\n';
 }
 
+function removeScripts(content) {
+    return content.replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+    .replace(/\n/g, ' ')
+    .replace(/<script>(.*?)<\/script>/g, '');
+}
+
 function openGraphHelper(options) {
   options = options || {};
 
@@ -37,7 +44,7 @@ function openGraphHelper(options) {
 
   var page = this.page;
   var config = this.config;
-  var content = page.content;
+  var content = removeScripts(page.content);
   var images = options.image || options.images || page.photos || [];
   var description = options.description || page.description || page.excerpt || config.description || content;
   var keywords = page.keywords || (page.tags && page.tags.length ? page.tags : undefined) || config.keywords;

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -39,7 +39,7 @@ function openGraphHelper(options) {
   var config = this.config;
   var content = page.content;
   var images = options.image || options.images || page.photos || [];
-  var description = options.description || page.description || page.excerpt || content || config.description;
+  var description = options.description || page.description || page.excerpt || config.description || content;
   var keywords = page.keywords || (page.tags && page.tags.length ? page.tags : undefined) || config.keywords;
   var title = options.title || page.title || config.title;
   var type = options.type || (this.is_post() ? 'article' : 'website');

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "hexo-renderer-marked": "^0.3.0",
     "istanbul": "^0.4.3",
     "jscs-preset-hexo": "^1.0.1",
-    "mocha": "^4.1.0",
+    "mocha": "^4.0.1",
     "rewire": "^3.0.2",
     "sinon": "^4.1.2"
   }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "hexo-renderer-marked": "^0.3.0",
     "istanbul": "^0.4.3",
     "jscs-preset-hexo": "^1.0.1",
-    "mocha": "^4.0.1",
+    "mocha": "^4.1.0",
     "rewire": "^3.0.2",
     "sinon": "^4.1.2"
   }

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -608,4 +608,45 @@ describe('open_graph', () => {
 
     result.should.not.contain(meta({property: 'og:locale'}));
   });
+
+
+  it('description - content with script', () => {
+    var ctx = {
+      page: {content: 'content1.<script>var a = "a";</script> content2.'},
+      config: hexo.config,
+      is_post: isPost
+    };
+
+    var result = openGraph.call(ctx);
+
+    result.should.contain(meta({name: 'description', content: 'content1. content2.'}));
+    result.should.contain(meta({property: 'og:description', content: 'content1. content2.'}));
+  });
+
+  it('description - only script', () => {
+    var ctx = {
+      page: {content: '<script>var a = "a";</script>'},
+      config: hexo.config,
+      is_post: isPost
+    };
+
+    var result = openGraph.call(ctx);
+
+    result.should.contain(meta({name: 'description', content: hexo.config.description}));
+    result.should.contain(meta({property: 'og:description', content: hexo.config.description}));
+  });
+
+  it('description - two scripts', () => {
+    var ctx = {
+      page: {content: '<script>var a = "a";</script><script>var b = 4;</script>'},
+      config: hexo.config,
+      is_post: isPost
+    };
+
+    var result = openGraph.call(ctx);
+
+    result.should.contain(meta({name: 'description', content: hexo.config.description}));
+    result.should.contain(meta({property: 'og:description', content: hexo.config.description}));
+  });
+
 });

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -629,7 +629,7 @@ describe('open_graph', () => {
       config: hexo.config,
       is_post: isPost
     };
-    hexo.config.description = "test";
+    hexo.config.description = 'test';
     var result = openGraph.call(ctx);
 
     result.should.contain(meta({name: 'description', content: hexo.config.description}));
@@ -642,7 +642,7 @@ describe('open_graph', () => {
       config: hexo.config,
       is_post: isPost
     };
-    hexo.config.description = "test";
+    hexo.config.description = 'test';
     var result = openGraph.call(ctx);
 
     result.should.contain(meta({name: 'description', content: hexo.config.description}));

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -629,7 +629,7 @@ describe('open_graph', () => {
       config: hexo.config,
       is_post: isPost
     };
-
+    hexo.config.description = "test";
     var result = openGraph.call(ctx);
 
     result.should.contain(meta({name: 'description', content: hexo.config.description}));
@@ -642,7 +642,7 @@ describe('open_graph', () => {
       config: hexo.config,
       is_post: isPost
     };
-
+    hexo.config.description = "test";
     var result = openGraph.call(ctx);
 
     result.should.contain(meta({name: 'description', content: hexo.config.description}));


### PR DESCRIPTION
Fixed: #2954
Fix method:
Remove all script tags in page.content and store the result to a content variable before proceeding.

This will still result in an "undefine" string in the description, which should be solved by hexo-disqus-proxy.

- [x] Add test cases for the changes.
- [x] Passed the CI test.

  
  