### PR TITLE
Add eslint-plugin-node

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "hexo",
   "root": true,
+  "plugins": [ "node" ],
   "rules": {
     "one-var": 0,
     "operator-linebreak": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "hexo",
+  "extends": ["plugin:node/recommended", "hexo"],
   "root": true,
   "plugins": [ "node" ],
   "rules": {
@@ -13,6 +13,8 @@
       {
         "after": true
       }
-    ]
+    ],
+    "node/no-unsupported-features": 0,
+    "node/no-deprecated-api": 0
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "eslint": "^4.13.1",
     "eslint-ci": "^0.1.1",
     "eslint-config-hexo": "^2.0.0",
+    "eslint-plugin-node": "^5.2.1",
     "hexo-renderer-marked": "^0.3.0",
     "husky": "^0.14.3",
     "istanbul": "^0.4.3",


### PR DESCRIPTION
[eslint-plugin-node](https://www.npmjs.com/package/eslint-plugin-node) adds a rule specific to node.js.
This plugin detects whether inappropriate syntax / API is used for the version of package node.js.
Actually, the current Hexo does not work in Node.js: v4, and the use of deprecated API is confirmed in Node.js: v6 or v8!
In order to be able to check by automatic test, I will send this PR.
The aim of this PR is to explicitly set the supported Node.js version!