### PR TITLE
change Buffer API

### DIFF
--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -201,7 +201,7 @@ function CacheStream() {
 require('util').inherits(CacheStream, Transform);
 
 CacheStream.prototype._transform = function(chunk, enc, callback) {
-  var buf = chunk instanceof Buffer ? chunk : new Buffer(chunk, enc);
+  var buf = chunk instanceof Buffer ? chunk : Buffer.from(chunk, enc);
 
   this._cache.push(buf);
   this.push(buf);


### PR DESCRIPTION
[`new Buffer()` is Deprecated API from node.js v6 or later.](https://nodejs.org/dist/latest-v6.x/docs/api/buffer.html#buffer_new_buffer_string_encoding)
[`Buffer.from()` is also implemented in Node.js v4 LTS.](https://nodejs.org/docs/latest-v4.x/api/buffer.html#buffer_class_method_buffer_from_str_encoding)
see https://nodejs.org/docs/latest-v4.x/api/buffer.html#buffer_new_buffer_array

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
