### PR TITLE
include_code – add hljs option

### DIFF
--- a/lib/plugins/tag/include_code.js
+++ b/lib/plugins/tag/include_code.js
@@ -70,6 +70,7 @@ module.exports = function(ctx) {
         lang: lang,
         caption: caption,
         gutter: config.line_number,
+        hljs: config.hljs,
         tab: config.tab_replace
       });
     });


### PR DESCRIPTION
This PR is to align `include_code` with `code` options

- [ ] Add test cases for the changes <= no tests were defined for `code`
- [x] Passed the CI test.
