### PR TITLE
Fix typos in plain.js

### DIFF
--- a/lib/plugins/renderer/plain.js
+++ b/lib/plugins/renderer/plain.js
@@ -1,7 +1,7 @@
 'use strict';
 
-function planRenderer(data) {
+function plainRenderer(data) {
   return data.text;
 }
 
-module.exports = planRenderer;
+module.exports = plainRenderer;


### PR DESCRIPTION
Just some typo fixes in `lib/plugins/renderer/plain.js`.

- [x] Add test cases for the changes.
- [x] Passed the CI test.
