### PR TITLE
Fixes: hljs option still doesn't work.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "hexo-fs": "^0.2.0",
     "hexo-i18n": "^0.2.1",
     "hexo-log": "^0.2.0",
-    "hexo-util": "^0.6.0",
+    "hexo-util": "^0.6.3",
     "js-yaml": "^3.6.1",
     "lodash": "^4.17.5",
     "minimatch": "^3.0.4",


### PR DESCRIPTION
After I update to Hexo 3.6.0, `hljs` option still doesn't work, I found the version of `hexo-util` is "^0.6.0", but `hexo-util` doesn't support `hljs` option until "0.6.3"(https://github.com/hexojs/hexo-util/releases/tag/0.6.3).
After I update the version to "0.6.3", It works.

Thank you for creating a pull request to contribute to Hexo code! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
