### PR TITLE
Use default language when no language set

### DIFF
--- a/lib/plugins/filter/template_locals/i18n.js
+++ b/lib/plugins/filter/template_locals/i18n.js
@@ -21,7 +21,8 @@ function i18nLocalsFilter(locals) {
       lang = data.lang;
       page.canonical_path = data.path;
     } else {
-      lang = getFirstLanguage(i18nConfigLanguages);
+      // i18n.languages is always an array with at least one argument ('default')
+      lang = i18nConfigLanguages[0];
     }
 
     page.lang = lang;
@@ -36,11 +37,3 @@ function i18nLocalsFilter(locals) {
 }
 
 module.exports = i18nLocalsFilter;
-
-function getFirstLanguage(lang) {
-  if (Array.isArray(lang)) {
-    return lang[0];
-  }
-
-  return lang;
-}

--- a/lib/plugins/filter/template_locals/i18n.js
+++ b/lib/plugins/filter/template_locals/i18n.js
@@ -11,6 +11,7 @@ function i18nLocalsFilter(locals) {
   const page = locals.page;
   let lang = page.lang || page.language;
   const i18nLanguages = i18n.list();
+  const i18nConfigLanguages = i18n.languages;
 
   if (!lang) {
     const pattern = new Pattern(`${i18nDir}/*path`);
@@ -20,7 +21,7 @@ function i18nLocalsFilter(locals) {
       lang = data.lang;
       page.canonical_path = data.path;
     } else {
-      lang = getFirstLanguage(config.language);
+      lang = getFirstLanguage(i18nConfigLanguages);
     }
 
     page.lang = lang;
@@ -28,7 +29,7 @@ function i18nLocalsFilter(locals) {
 
   page.canonical_path = page.canonical_path || locals.path;
 
-  const languages = _([].concat(lang, i18nLanguages)).compact().uniq().value();
+  const languages = _([].concat(lang, i18nConfigLanguages)).compact().uniq().value();
 
   locals.__ = i18n.__(languages);
   locals._p = i18n._p(languages);

--- a/test/scripts/filters/i18n_locals.js
+++ b/test/scripts/filters/i18n_locals.js
@@ -8,9 +8,17 @@ describe('i18n locals', () => {
   var i18n = theme.i18n;
 
   // Default language
-  hexo.config.language = 'en';
+  i18n.languages = ['en', 'default'];
 
   // Fixtures
+  i18n.set('de', {
+    Home: 'Zuhause'
+  });
+
+  i18n.set('default', {
+    Home: 'Default Home'
+  });
+
   i18n.set('en', {
     Home: 'Home'
   });
@@ -88,8 +96,8 @@ describe('i18n locals', () => {
   });
 
   it('use config by default - with multiple languages, first language should be used', () => {
-    var oldConfig = hexo.config.language;
-    hexo.config.language = ['zh-tw', 'en'];
+    var oldConfig = i18n.languages;
+    i18n.languages = ['zh-tw', 'en', 'default'];
 
     var locals = {
       config: hexo.config,
@@ -103,6 +111,44 @@ describe('i18n locals', () => {
     locals.page.canonical_path.should.eql('index.html');
     locals.__('Home').should.eql('首頁');
 
-    hexo.config.language = oldConfig;
+    i18n.languages = oldConfig;
+  });
+
+  it('use config by default - with no languages, default language should be used', () => {
+    var oldConfig = i18n.language;
+    i18n.languages = ['default'];
+
+    var locals = {
+      config: hexo.config,
+      page: {},
+      path: 'index.html'
+    };
+
+    i18nFilter(locals);
+
+    locals.page.lang.should.eql('default');
+    locals.page.canonical_path.should.eql('index.html');
+    locals.__('Home').should.eql('Default Home');
+
+    i18n.languages = oldConfig;
+  });
+
+  it('use config by default - with unknown language, default language should be used', () => {
+    var oldConfig = i18n.languages;
+    i18n.languages = ['fr', 'default'];
+
+    var locals = {
+      config: hexo.config,
+      page: {},
+      path: 'index.html'
+    };
+
+    i18nFilter(locals);
+
+    locals.page.lang.should.eql('fr');
+    locals.page.canonical_path.should.eql('index.html');
+    locals.__('Home').should.eql('Default Home');
+
+    i18n.languages = oldConfig;
   });
 });


### PR DESCRIPTION
Use default language when no language set, or there is no translation for specified language

If no language is set in _config, or the theme has no language file for the one set, then the translation data is chosen in indeterminate manner as it is taken from a list of all available translations returned by hexo.theme.i18n#list().

The changes to lib/plugins/filter/template_locals/i18n.js use i18n.languages in preference to config.language and i18n.list() as this provides an array of configured languages with 'default' on the end.  This ensures that if no language is set or the language cannot be found then then default translation will be used.

The changes to test/scripts/filters/i18n_locals.js set i18n.languages rather than config.language as the original test code did not set the 'default' language correctly.

Added two tests
+ use config by default - with no languages, default language should be used
+ use config by default - with unknown language, default language should be used

Both of the new tests fail on the current release but pass with the changes in the pull request.

This is a fix for #1125 