### PR TITLE
Add after_clean filter

### DIFF
--- a/lib/plugins/console/clean.js
+++ b/lib/plugins/console/clean.js
@@ -6,7 +6,8 @@ const fs = require('hexo-fs');
 function cleanConsole(args) {
   return Promise.all([
     deleteDatabase(this),
-    deletePublicDir(this)
+    deletePublicDir(this),
+    this.execFilter('after_clean', null, {context: this})
   ]);
 }
 

--- a/test/scripts/console/clean.js
+++ b/test/scripts/console/clean.js
@@ -3,8 +3,12 @@ var fs = require('hexo-fs');
 
 describe('clean', () => {
   var Hexo = require('../../../lib/hexo');
-  var hexo = new Hexo(__dirname, {silent: true});
-  var clean = require('../../../lib/plugins/console/clean').bind(hexo);
+  var hexo, clean;
+
+  beforeEach(() => {
+    hexo = new Hexo(__dirname, {silent: true});
+    clean = require('../../../lib/plugins/console/clean').bind(hexo);
+  });
 
   it('delete database', () => {
     var dbPath = hexo.database.options.path;
@@ -18,6 +22,18 @@ describe('clean', () => {
     var publicDir = hexo.public_dir;
 
     return fs.mkdirs(publicDir).then(() => clean()).then(() => fs.exists(publicDir)).then(exist => {
+      exist.should.be.false;
+    });
+  });
+
+  it('execute corresponding filter', () => {
+    var extraDbPath = hexo.database.options.path + '.tmp';
+
+    hexo.extend.filter.register('after_clean', () => {
+      return fs.unlink(extraDbPath);
+    });
+
+    return fs.writeFile(extraDbPath, '').then(() => clean()).then(() => fs.exists(extraDbPath)).then(exist => {
       exist.should.be.false;
     });
   });


### PR DESCRIPTION
Related to #2436 

It allows injecting code to the `hexo clean` command to
let plugin developers perform additional clean up.


- [x] Add test cases for the changes.
- [x] Passed the CI test.
