### PR TITLE
Use old language file selection when no default file exists

### DIFF
--- a/lib/plugins/filter/template_locals/i18n.js
+++ b/lib/plugins/filter/template_locals/i18n.js
@@ -30,7 +30,7 @@ function i18nLocalsFilter(locals) {
 
   page.canonical_path = page.canonical_path || locals.path;
 
-  const languages = _([].concat(lang, i18nConfigLanguages)).compact().uniq().value();
+  const languages = _([].concat(lang, i18nConfigLanguages, i18nLanguages)).compact().uniq().value();
 
   locals.__ = i18n.__(languages);
   locals._p = i18n._p(languages);

--- a/test/scripts/filters/i18n_locals.js
+++ b/test/scripts/filters/i18n_locals.js
@@ -151,4 +151,26 @@ describe('i18n locals', () => {
 
     i18n.languages = oldConfig;
   });
+
+  it('use config by default - with no set language and no default file take first available', () => {
+    var oldConfig = i18n.languages;
+    var oldSet = i18n.get('default');
+    i18n.remove('default');
+    i18n.languages = ['default'];
+
+    var locals = {
+      config: hexo.config,
+      page: {},
+      path: 'index.html'
+    };
+
+    i18nFilter(locals);
+
+    locals.page.lang.should.eql('default');
+    locals.page.canonical_path.should.eql('index.html');
+    locals.__('Home').should.eql('Zuhause');
+
+    i18n.set('default', oldSet);
+    i18n.languages = oldConfig;
+  });
 });


### PR DESCRIPTION
Issue #3108 points out that many existing themes rely on the old but incorrect way of selecting language files prior to the pull request #3069 which fixes the incorrect behaviour.

This PR makes a small change so that when no language is configured and no default language file exists then the fallback is to use the old method of selecting a language file rather than not selecting any file.

A single test has been added to confirm that the first language file added will be used as the fallback.