### PR TITLE
added command line option `output` to write db.json and _multiconfig.…

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -31,8 +31,6 @@ const sep = pathFn.sep;
 const dbVersion = 1;
 
 function Hexo(base = process.cwd(), args = {}) {
-  const mcp = multiConfigPath(this);
-
   EventEmitter.call(this);
 
   this.base_dir = base + sep;
@@ -82,12 +80,20 @@ function Hexo(base = process.cwd(), args = {}) {
 
   this._isGenerating = false;
 
+  // If `output` is provided, use that as the
+  // root for saving the db. Otherwise default to `base`.
+  const dbPath = args.output || base;
+
+  this.log.d(`Writing database to ${dbPath}/db.json`);
+
   this.database = new Database({
     version: dbVersion,
-    path: pathFn.join(base, 'db.json')
+    path: pathFn.join(dbPath, 'db.json')
   });
 
-  this.config_path = args.config ? mcp(base, args.config) :
+  const mcp = multiConfigPath(this);
+
+  this.config_path = args.config ? mcp(base, args.config, args.output) :
     pathFn.join(base, '_config.yml');
 
   registerModels(this);

--- a/lib/hexo/multi_config_path.js
+++ b/lib/hexo/multi_config_path.js
@@ -5,7 +5,7 @@ const fs = require('hexo-fs');
 const _ = require('lodash');
 const yml = require('js-yaml');
 
-module.exports = ctx => function multiConfigPath(base, configPaths) {
+module.exports = ctx => function multiConfigPath(base, configPaths, outputDir) {
   const log = ctx.log;
 
   const defaultPath = pathFn.join(base, '_config.yml');
@@ -63,7 +63,11 @@ module.exports = ctx => function multiConfigPath(base, configPaths) {
 
   log.i('Config based on', count, 'files');
 
-  const outputPath = pathFn.join(base, '_multiconfig.yml');
+  const multiconfigRoot = outputDir || base;
+  const outputPath = pathFn.join(multiconfigRoot, '_multiconfig.yml');
+
+  log.d(`Writing _multiconfig.yml to ${outputPath}`);
+
   fs.writeFileSync(outputPath, yml.dump(combinedConfig));
 
   // write file and return path

--- a/test/scripts/hexo/multi_config_path.js
+++ b/test/scripts/hexo/multi_config_path.js
@@ -14,6 +14,22 @@ describe('config flag handling', () => {
 
   function ConsoleReader() {
     this.reader = [];
+    this.d = function(...args) {
+      var type = 'debug';
+      var message = '';
+      for (var i = 0; i < args.length;) {
+        message += args[i];
+        if (++i < args.length) {
+          message += ' ';
+        }
+      }
+
+      this.reader.push({
+        type,
+        msg: message
+      });
+    }.bind(this);
+
     this.i = function(...args) {
       var type = 'info';
       var message = '';
@@ -145,15 +161,15 @@ describe('config flag handling', () => {
 
     hexo.log.reader[0].type.should.eql('info');
     hexo.log.reader[0].msg.should.eql('Config based on 2 files');
-    hexo.log.reader[3].type.should.eql('warning');
-    hexo.log.reader[3].msg.should.eql('Config file notafile.yml not found.');
-    hexo.log.reader[4].type.should.eql('info');
-    hexo.log.reader[4].msg.should.eql('Config based on 1 files');
+    hexo.log.reader[6].type.should.eql('warning');
+    hexo.log.reader[6].msg.should.eql('Config file notafile.yml not found.');
+    hexo.log.reader[7].type.should.eql('info');
+    hexo.log.reader[7].msg.should.eql('Config based on 1 files');
     // because who cares about grammar anyway?
 
     mcp(base, 'notafile.yml,alsonotafile.json').should.not.eql(combinedPath);
-    hexo.log.reader[7].type.should.eql('error');
-    hexo.log.reader[7].msg.should.eql('No config files found.'
+    hexo.log.reader[11].type.should.eql('error');
+    hexo.log.reader[11].msg.should.eql('No config files found.'
                                      + ' Using _config.yml.');
   });
 
@@ -204,5 +220,29 @@ describe('config flag handling', () => {
     config.author.should.eql('foo');
     config.favorites.food.should.eql('sushi');
     config.type.should.eql('dinosaur');
+  });
+
+  it('write multiconfig to specified path', () => {
+    let outputPath = '/tmp';
+    let combinedPath = pathFn.join(outputPath, '_multiconfig.yml');
+
+    mcp(base, 'test1.yml', outputPath).should.not.eql(combinedPath);
+    mcp(base, 'test1.yml,test2.yml', outputPath).should.eql(combinedPath);
+    mcp(base, 'test1.yml,test1.json', outputPath).should.eql(combinedPath);
+    mcp(base, 'test1.json,test2.json', outputPath).should.eql(combinedPath);
+    mcp(base, 'notafile.yml,test1.json', outputPath).should.eql(combinedPath);
+    mcp(base, 'notafile.yml,alsonotafile.json', outputPath).should.not.eql(combinedPath);
+
+    hexo.log.reader[1].type.should.eql('debug');
+    hexo.log.reader[1].msg.should.eql('Writing _multiconfig.yml to /tmp/_multiconfig.yml');
+    hexo.log.reader[2].type.should.eql('info');
+    hexo.log.reader[2].msg.should.eql('Config based on 2 files');
+    hexo.log.reader[6].type.should.eql('warning');
+    hexo.log.reader[6].msg.should.eql('Config file notafile.yml not found.');
+    hexo.log.reader[7].type.should.eql('info');
+    hexo.log.reader[7].msg.should.eql('Config based on 1 files');
+    hexo.log.reader[11].type.should.eql('error');
+    hexo.log.reader[11].msg.should.eql('No config files found.'
+                                     + ' Using _config.yml.');
   });
 });


### PR DESCRIPTION
I'm working with a read-only file system and I need a way to direct the output to a different path.

I added command line option `output` to write db.json and _multiconfig.yml to a path provided

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
