### PR TITLE
Drop node.js v9 and support v10 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ environment:
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "8"
-    - nodejs_version: "9"
+    - nodejs_version: "10"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Node.js v9 is already EOL.
Drop v9 and support v10 on AppVeyor.

- [x] Add test cases for the changes.
- [x] Passed the CI test.
