### PR TITLE
Spread function: Hexo built-in plugin blockquote

### DIFF
--- a/lib/plugins/tag/blockquote.js
+++ b/lib/plugins/tag/blockquote.js
@@ -7,7 +7,6 @@ const titlecase = require('titlecase');
 const rFullCiteWithTitle = /(\S.*)\s+(https?:\/\/)(\S+)\s+(.+)/i;
 const rFullCite = /(\S.*)\s+(https?:\/\/)(\S+)/i;
 const rAuthorTitle = /([^,]+),\s*([^,]+)/;
-const rAuthor = /(.+)/;
 
 /**
  * @param {string[]} args
@@ -35,9 +34,8 @@ const parseFooter = (args, ctx) => {
       match = str.match(rAuthorTitle);
       author = match[1];
       title = ctx.config.titlecase ? titlecase(match[2]) : match[2];
-    } else if (rAuthor.test(str)) {
-      match = str.match(rAuthor);
-      author = match[1];
+    } else {
+      author = str;
     }
 
     if (author) footer += `<strong>${author}</strong>`;

--- a/lib/plugins/tag/blockquote.js
+++ b/lib/plugins/tag/blockquote.js
@@ -10,21 +10,15 @@ const rAuthorTitle = /([^,]+),\s*([^,]+)/;
 const rAuthor = /(.+)/;
 
 /**
-* Blockquote tag
-*
-* Syntax:
-*   {% blockquote [author[, source]] [link] [source_link_title] %}
-*   Quote string
-*   {% endblockquote %}
-*/
-
-module.exports = ctx => function blockquoteTag(args, content) {
+ * @param {string[]} args
+ * @param {Hexo} ctx
+ */
+const parseFooter = (args, ctx) => {
   const str = args.join(' ');
   let author = '';
   let source = '';
   let title = '';
   let footer = '';
-  let result = '';
   let match;
 
   if (str) {
@@ -55,6 +49,22 @@ module.exports = ctx => function blockquoteTag(args, content) {
       footer += `<cite>${title}</cite>`;
     }
   }
+
+  return footer;
+};
+
+/**
+* Blockquote tag
+*
+* Syntax:
+*   {% blockquote [author[, source]] [link] [source_link_title] %}
+*   Quote string
+*   {% endblockquote %}
+*/
+
+module.exports = ctx => function blockquoteTag(args, content) {
+  let result = '';
+  const footer = parseFooter(args, ctx);
 
   result += '<blockquote>';
   result += ctx.render.renderSync({text: content, engine: 'markdown'});

--- a/lib/plugins/tag/blockquote.js
+++ b/lib/plugins/tag/blockquote.js
@@ -22,14 +22,14 @@ const parseFooter = (args, ctx) => {
   let footer = '';
   let match;
 
-  if ((match = str.match(rFullCiteWithTitle))) {
+  if ((match = rFullCiteWithTitle.exec(str))) {
     author = match[1];
     source = match[2] + match[3];
     title = ctx.config.titlecase ? titlecase(match[4]) : match[4];
-  } else if ((match = str.match(rFullCite))) {
+  } else if ((match = rFullCite.exec(str))) {
     author = match[1];
     source = match[2] + match[3];
-  } else if ((match = str.match(rAuthorTitle))) {
+  } else if ((match = rAuthorTitle.exec(str))) {
     author = match[1];
     title = ctx.config.titlecase ? titlecase(match[2]) : match[2];
   } else {

--- a/lib/plugins/tag/blockquote.js
+++ b/lib/plugins/tag/blockquote.js
@@ -4,8 +4,8 @@
 
 const titlecase = require('titlecase');
 
-const rFullCiteWithTitle = /(\S.*)\s+(https?:\/\/)(\S+)\s+(.+)/i;
-const rFullCite = /(\S.*)\s+(https?:\/\/)(\S+)/i;
+const rFullCiteWithTitle = /(\S.*)\s+(https?:\/\/\S+)\s+(.+)/i;
+const rFullCite = /(\S.*)\s+(https?:\/\/\S+)/i;
 const rAuthorTitle = /([^,]+),\s*([^,]+)/;
 
 /**
@@ -23,11 +23,11 @@ const parseFooter = (args, ctx) => {
 
   if ((match = rFullCiteWithTitle.exec(str))) {
     author = match[1];
-    source = match[2] + match[3];
-    title = ctx.config.titlecase ? titlecase(match[4]) : match[4];
+    source = match[2];
+    title = ctx.config.titlecase ? titlecase(match[3]) : match[3];
   } else if ((match = rFullCite.exec(str))) {
     author = match[1];
-    source = match[2] + match[3];
+    source = match[2];
   } else if ((match = rAuthorTitle.exec(str))) {
     author = match[1];
     title = ctx.config.titlecase ? titlecase(match[2]) : match[2];

--- a/lib/plugins/tag/blockquote.js
+++ b/lib/plugins/tag/blockquote.js
@@ -22,17 +22,14 @@ const parseFooter = (args, ctx) => {
   let footer = '';
   let match;
 
-  if (rFullCiteWithTitle.test(str)) {
-    match = str.match(rFullCiteWithTitle);
+  if ((match = str.match(rFullCiteWithTitle))) {
     author = match[1];
     source = match[2] + match[3];
     title = ctx.config.titlecase ? titlecase(match[4]) : match[4];
-  } else if (rFullCite.test(str)) {
-    match = str.match(rFullCite);
+  } else if ((match = str.match(rFullCite))) {
     author = match[1];
     source = match[2] + match[3];
-  } else if (rAuthorTitle.test(str)) {
-    match = str.match(rAuthorTitle);
+  } else if ((match = str.match(rAuthorTitle))) {
     author = match[1];
     title = ctx.config.titlecase ? titlecase(match[2]) : match[2];
   } else {

--- a/lib/plugins/tag/blockquote.js
+++ b/lib/plugins/tag/blockquote.js
@@ -19,7 +19,6 @@ const parseFooter = (args, ctx) => {
   let author = '';
   let source = '';
   let title = '';
-  let footer = '';
   let match;
 
   if ((match = rFullCiteWithTitle.exec(str))) {
@@ -36,6 +35,7 @@ const parseFooter = (args, ctx) => {
     author = str;
   }
 
+  let footer = '';
   if (author) footer += `<strong>${author}</strong>`;
 
   if (source) {
@@ -58,10 +58,9 @@ const parseFooter = (args, ctx) => {
 */
 
 module.exports = ctx => function blockquoteTag(args, content) {
-  let result = '';
   const footer = parseFooter(args, ctx);
 
-  result += '<blockquote>';
+  let result = '<blockquote>';
   result += ctx.render.renderSync({text: content, engine: 'markdown'});
   if (footer) result += `<footer>${footer}</footer>`;
   result += '</blockquote>';

--- a/lib/plugins/tag/blockquote.js
+++ b/lib/plugins/tag/blockquote.js
@@ -14,38 +14,38 @@ const rAuthorTitle = /([^,]+),\s*([^,]+)/;
  */
 const parseFooter = (args, ctx) => {
   const str = args.join(' ');
+  if (!str) return '';
+
   let author = '';
   let source = '';
   let title = '';
   let footer = '';
   let match;
 
-  if (str) {
-    if (rFullCiteWithTitle.test(str)) {
-      match = str.match(rFullCiteWithTitle);
-      author = match[1];
-      source = match[2] + match[3];
-      title = ctx.config.titlecase ? titlecase(match[4]) : match[4];
-    } else if (rFullCite.test(str)) {
-      match = str.match(rFullCite);
-      author = match[1];
-      source = match[2] + match[3];
-    } else if (rAuthorTitle.test(str)) {
-      match = str.match(rAuthorTitle);
-      author = match[1];
-      title = ctx.config.titlecase ? titlecase(match[2]) : match[2];
-    } else {
-      author = str;
-    }
+  if (rFullCiteWithTitle.test(str)) {
+    match = str.match(rFullCiteWithTitle);
+    author = match[1];
+    source = match[2] + match[3];
+    title = ctx.config.titlecase ? titlecase(match[4]) : match[4];
+  } else if (rFullCite.test(str)) {
+    match = str.match(rFullCite);
+    author = match[1];
+    source = match[2] + match[3];
+  } else if (rAuthorTitle.test(str)) {
+    match = str.match(rAuthorTitle);
+    author = match[1];
+    title = ctx.config.titlecase ? titlecase(match[2]) : match[2];
+  } else {
+    author = str;
+  }
 
-    if (author) footer += `<strong>${author}</strong>`;
+  if (author) footer += `<strong>${author}</strong>`;
 
-    if (source) {
-      const link = source.replace(/^https?:\/\/|\/(index.html?)?$/g, '');
-      footer += `<cite><a href="${source}">${title ? title : link}</a></cite>`;
-    } else if (title) {
-      footer += `<cite>${title}</cite>`;
-    }
+  if (source) {
+    const link = source.replace(/^https?:\/\/|\/(index.html?)?$/g, '');
+    footer += `<cite><a href="${source}">${title ? title : link}</a></cite>`;
+  } else if (title) {
+    footer += `<cite>${title}</cite>`;
   }
 
   return footer;


### PR DESCRIPTION
The blockquote built-in plugin is too large as a single function.
Also, most of the code concerns only footer output.
Therefore, we will create a new `parseFooter()` to reduce complexity.

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.