### PR TITLE
Fix test for nodejs v11 or higher

### DIFF
--- a/test/scripts/helpers/debug.js
+++ b/test/scripts/helpers/debug.js
@@ -21,7 +21,7 @@ describe('debug', () => {
 
   it('inspect deep object', () => {
     const obj = { baz: { thud: 'narf', dur: { foo: 'bar', baz: { bang: 'zoom' } } } };
-    debug.inspectObject(obj).should.not.eql(inspect(obj, {depth: 5}));
+    debug.inspectObject(obj, {depth: 2}).should.not.eql(inspect(obj, {depth: 5}));
     debug.inspectObject(obj, {depth: 5}).should.eql(inspect(obj, {depth: 5}));
   });
 


### PR DESCRIPTION
At node v11, the current test fails.
The initial value of the `depth` option of `util.inspect()` has changed since node v11.
[node v11: `20`](https://nodejs.org/api/util.html#util_util_inspect_object_options) [node v10: `2`](https://nodejs.org/docs/latest-v10.x/api/util.html#util_util_inspect_object_options)
Given the default value change, it is clear that the test on [this line](https://github.com/hexojs/hexo/blob/3.8.0/test/scripts/helpers/debug.js#L24) will fail on v11.

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
