### PR TITLE
update build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ cache:
 node_js:
   - "6"
   - "8"
+  - "10"
   - "node"
 
 script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,16 +10,20 @@ image:
 environment:
   matrix:
     - nodejs_version: "6"
+      stack: node 6
     - nodejs_version: "8"
-    - nodejs_version: "10"
+      stack: node 8
+    # - nodejs_version: "10"
+    #   stack: node 10
     # - nodejs_version: "11"
+    #   stack: node 11
 
 matrix:
   fast_finish: true
 
 # Install scripts. (runs after repo cloning)
-install:
-  - ps: Install-Product node $env:nodejs_version
+# install:
+  # - ps: Install-Product node $env:nodejs_version
   
 before_test:
   - npm install --build-from-source

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ install:
   - ps: Install-Product node $env:nodejs_version
   
 before_test:
-  - npm install --build-from-source
+  - npm install
 
 cache:
   - node_modules -> package.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,9 @@ matrix:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
-  - npm install -g npm
-  - npm install
+
+build_script:
+  - npm install --build-from-source
 
 cache:
   - node_modules -> package.json

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,28 +4,21 @@ init:
 
 image:
 - Visual Studio 2017
-- Ubuntu1804
-
-stack:
-- node 6
-- node 8
 
 # Test against these versions of Node.js.
 environment:
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "8"
-    # - nodejs_version: "10"
-    #   stack: node 10
-    # - nodejs_version: "11"
-    #   stack: node 11
-
+    - nodejs_version: "10"
+    - nodejs_version: "11"
+    
 matrix:
   fast_finish: true
 
 # Install scripts. (runs after repo cloning)
-# install:
-  # - ps: Install-Product node $env:nodejs_version
+install:
+  - ps: Install-Product node $env:nodejs_version
   
 before_test:
   - npm install --build-from-source

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ image:
 environment:
   matrix:
     - nodejs_version: "6"
-    - nodejs_version: "8"
-    - nodejs_version: "10"
+    # - nodejs_version: "8"
+    # - nodejs_version: "10"
     - nodejs_version: "11"
 
 matrix:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ matrix:
 install:
   - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
 
-build_script:
+before_test:
   - npm install --build-from-source
 
 cache:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,8 @@ matrix:
 
 # Install scripts. (runs after repo cloning)
 install:
-  - ps: Update-NodeJsInstallation (Get-NodeJsLatestBuild $env:nodejs_version)
-
+  - ps: Install-Product node $env:nodejs_version
+  
 before_test:
   - npm install --build-from-source
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,13 +6,15 @@ image:
 - Visual Studio 2017
 - Ubuntu1804
 
+stack:
+- node 6
+- node 8
+
 # Test against these versions of Node.js.
 environment:
   matrix:
     - nodejs_version: "6"
-      stack: node 6
     - nodejs_version: "8"
-      stack: node 8
     # - nodejs_version: "10"
     #   stack: node 10
     # - nodejs_version: "11"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,17 @@
 init:
   - git config --global core.autocrlf input
 
+image:
+- Visual Studio 2017
+- Ubuntu1804
+
 # Test against these versions of Node.js.
 environment:
   matrix:
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "11"
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,9 +10,9 @@ image:
 environment:
   matrix:
     - nodejs_version: "6"
-    # - nodejs_version: "8"
-    # - nodejs_version: "10"
-    - nodejs_version: "11"
+    - nodejs_version: "8"
+    - nodejs_version: "10"
+    # - nodejs_version: "11"
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This PR adds nodejs 10 as well as 11
node 10 will become the next lts
node 9 was an intermediate release

and add tests on linux for appveyor

See https://www.appveyor.com/docs/getting-started-with-appveyor-for-linux/#running-windows-and-linux-builds-side-by-side

and 

https://github.com/nodejs/Release#release-schedule