### PR TITLE
fix: compatibility with cheerio 1.0.0+ (#3313)

### DIFF
--- a/lib/plugins/filter/meta_generator.js
+++ b/lib/plugins/filter/meta_generator.js
@@ -7,7 +7,7 @@ function hexoMetaGeneratorInject(data) {
   if (!cheerio) cheerio = require('cheerio');
   const $ = cheerio.load(data, {decodeEntities: false});
 
-  if (!($('meta[name="generator"]').length > 0)) {
+  if (!($('meta[name="generator"]').length > 0) && $('head').contents().length > 0) {
     $('head').prepend(hexoGeneratorTag.replace('%s', this.version));
 
     return $.html();

--- a/test/scripts/filters/index.js
+++ b/test/scripts/filters/index.js
@@ -5,6 +5,7 @@ describe('Filters', () => {
   require('./excerpt');
   require('./external_link');
   require('./i18n_locals');
+  require('./meta_generator');
   require('./new_post_path');
   require('./post_permalink');
   require('./render_post');

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -1,14 +1,12 @@
 'use strict';
 
-const should = require('chai').should(); // eslint-disable-line
-
-describe('Meta Generator', function() {
+describe('Meta Generator', () => {
   const Hexo = require('../../../lib/hexo');
   const hexo = new Hexo();
   const metaGenerator = require('../../../lib/plugins/filter/meta_generator').bind(hexo);
   const cheerio = require('cheerio');
 
-  it('default', function() {
+  it('default', () => {
     const content = '<head><link></head>';
     const result = metaGenerator(content);
 
@@ -16,7 +14,7 @@ describe('Meta Generator', function() {
     $('meta[name="generator"]').length.should.eql(1);
   });
 
-  it('empty <head>', function() {
+  it('empty <head>', () => {
     const content = '<head></head>';
     const result = metaGenerator(content);
 

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const should = require('chai').should(); // eslint-disable-line
+
+describe('Meta Generator', function() {
+  const Hexo = require('../../../lib/hexo');
+  const hexo = new Hexo();
+  const metaGenerator = require('../../../lib/plugins/filter/meta_generator').bind(hexo);
+  const cheerio = require('cheerio');
+
+  it('default', function() {
+    const content = '<head><link></head>';
+    const result = metaGenerator(content);
+
+    const $ = cheerio.load(result);
+    $('meta[name="generator"]').length.should.eql(1);
+  });
+
+  it('empty <head>', function() {
+    const content = '<head></head>';
+    const result = metaGenerator(content);
+
+    // meta generator should not be prepended if <head> tag is empty
+    // see https://github.com/hexojs/hexo/pull/3315
+    const resultType = typeof result;
+    resultType.should.eql('undefined');
+  });
+});


### PR DESCRIPTION
Fix #3313. Related to #3129.

1. When a third-party plugin uses cheerio 1.0.0-rc.1+, `<html><head><body>` are automatically added to every empty or open tag (see https://github.com/cheeriojs/cheerio/issues/1031 https://github.com/cheeriojs/cheerio/issues/1239). If I have `<p>`, it will results in,
```html
<html><head></head><body><p></body></html>
```
2. meta_generator.js prepend meta generator tag to every `<head>`. e.g.
```html
<html><head><meta name="generator"...></head><body><p></body></html>
```
3. Those extra `<html><head><body>` are stripped away in the final `$.html()`, leaving
```html
<meta name="generator"...><p>
```

As a workaround, meta_generator.js prepend only to non-empty _real_ `<head>`. I assume Hexo page has at least meta charset or css in the `<head>`.

Without this workaround, if I use any plugin that uses cheerio 1.0.0+ (e.g. [hexo-nofollow](https://github.com/weyusi/hexo-nofollow/)), meta_generator will also prepend tag to `<body>` (see https://github.com/weyusi/hexo-testing/commit/f4824bbd5f8b86429168486b4c43db9ce929f9ea).

Thank you for creating a pull request to contribute to Hexo code! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

cc @h404bi 