### PR TITLE
chore(husky): update husky to 1.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "eslint": "eslint-ci .",
     "test": "mocha test/index.js",
     "test-cov": "istanbul cover --print both _mocha -- test/index.js",
-    "precommit": "lint-staged",
     "lint-staged": "lint-staged"
   },
   "directories": {
@@ -68,7 +67,7 @@
     "eslint-ci": "^0.1.1",
     "eslint-config-hexo": "^3.0.0",
     "hexo-renderer-marked": "^0.3.0",
-    "husky": "^0.14.3",
+    "husky": "^1.1.3",
     "istanbul": "^0.4.3",
     "lint-staged": "^7.0.0",
     "mocha": "^5.0.5",
@@ -77,5 +76,10 @@
   },
   "engines": {
     "node": ">=6.9.0"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
   }
 }


### PR DESCRIPTION
Update husky from 0.14.3 to 1.1.3 and change husky's script, because it [has breaking change in v1.0.0](https://github.com/typicode/husky#upgrading-from-014)
This PR divided from (#3277)

Thank you for creating a pull request to contribute to Hexo code! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
