### PR TITLE
chore(package): update sinon to 7.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "lint-staged": "^7.0.0",
     "mocha": "^5.0.5",
     "rewire": "^3.0.2",
-    "sinon": "^4.1.2"
+    "sinon": "^7.1.1"
   },
   "engines": {
     "node": ">=6.9.0"


### PR DESCRIPTION
This PR divided from (#3277)

Sinon breaking changes in 5.x , 6.x and 7.x is only removed `spt.reset()`. But this repositories doesn't using `spy.reset()`.

Please see sinon migrate guide.

* [4.x to 5.x](https://sinonjs.org/guides/migrating-to-5.0)
* [5.x to 6.x](https://sinonjs.org/guides/migrating-to-6.0)

6.x to 7.x migration guide nothing, but I  confirmed [7.x](https://github.com/sinonjs/sinon/blob/d193bb932bd03b587a661bbb74cc6772f2e6941f/docs/changelog.md#700--2018-10-14) change logs. It seems nothing breaking changes.


- [ ] Add test cases for the changes.
- [x] Passed the CI test.
