### PR TITLE
chore(package): update rewire to 4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "istanbul": "^0.4.3",
     "lint-staged": "^7.0.0",
     "mocha": "^5.0.5",
-    "rewire": "^3.0.2",
+    "rewire": "^4.0.1",
     "sinon": "^7.1.1"
   },
   "engines": {


### PR DESCRIPTION
This PR divided from (#3277)

The rewire 4.0.0 has two breaking changes.
One is drop nodejs v4. This hexo repository already set node-engines higher 6.9.0, so we don't worry this breaking change.
Another one is potentially breaking, sorry I can not be say absolutely no problem, but unit test are passed. I think may be no problem.

* [rewire 4.0.0](https://github.com/jhnns/rewire/releases/tag/v4.0.0)

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
