### PR TITLE
chore(package): update strip-ansi to 5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "nunjucks": "^3.1.3",
     "pretty-hrtime": "^1.0.3",
     "resolve": "^1.8.1",
-    "strip-ansi": "^4.0.0",
+    "strip-ansi": "^5.0.0",
     "strip-indent": "^2.0.0",
     "swig-extras": "0.0.1",
     "swig-templates": "^2.0.3",


### PR DESCRIPTION
### Proposal

Update major version of strip-ansi package dependency.

### Description

The strip-ansi between 4.0 and 5.0 seems no [breaking change](https://github.com/chalk/strip-ansi/compare/c299056a42b31d7a479d6a89b41318b2a2462cc7...dfab6777144e0292c7b4be9969c180025d7d2d97). I think we can update major version of it.

### Checks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
