### PR TITLE
fix site is not defined error

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -300,6 +300,7 @@ Hexo.prototype._generateLocals = function() {
   Locals.prototype.layout = 'layout';
   Locals.prototype.env = this.env;
   Locals.prototype.view_dir = join(this.theme_dir, 'layout') + sep;
+  Locals.prototype.site = this.locals.toObject();
 
   return Locals;
 };


### PR DESCRIPTION
## Problem

`Locals.prototype.site` were deleted in (#3359)
`hexo generate` command has error, If theme or others use `this.site.xxxxx`.

## Logs

```
ReferenceError: \themes\tranquilpeak\layout\all-categories.ejs:116
    115|     <section class="boxes">
 >> 116|         <% site.categories.sort('name').each(function(category) { %>
    117|             <% if (!category.parent) { %>
    118|                 <%- displayCategories(category) %>
    119|             <% } %>

site is not defined
    at eval (eval at compile (C:\Users\N.Yoshinori\work\site\_main\node_modules\ejs\lib\ejs.js:618:12), <anonymous>:123:8)
    at returnedFn (C:\Users\N.Yoshinori\work\site\_main\node_modules\ejs\lib\ejs.js:653:17)
    at Theme._View.View._compiled.locals [as _compiled] (C:\Users\N.Yoshinori\work\site\_main\node_modules\hexo\lib\theme\view.js:123:48)
    at Theme._View.View.View.render (C:\Users\N.Yoshinori\work\site\_main\node_modules\hexo\lib\theme\view.js:29:15)
    at C:\Users\N.Yoshinori\work\site\_main\node_modules\hexo\lib\hexo\index.js:348:21
    at tryCatcher (C:\Users\N.Yoshinori\work\site\_main\node_modules\bluebird\js\release\util.js:16:23)
    at C:\Users\N.Yoshinori\work\site\_main\node_modules\bluebird\js\release\method.js:15:34
    at RouteStream._read (C:\Users\N.Yoshinori\work\site\_main\node_modules\hexo\lib\hexo\router.js:123:3)
    at RouteStream.Readable.read (_stream_readable.js:452:10)
    at resume_ (_stream_readable.js:899:12)
    at process._tickCallback (internal/process/next_tick.js:63:19)
```

Thank you for creating a pull request to contribute to Hexo code! Before you open the request please review the following guidelines and tips to help it be more easily integrated:

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
