### PR TITLE
chore(package): specify files to shrink package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "lib": "./lib",
     "bin": "./bin"
   },
+  "files": [
+    "lib/",
+    "bin/"
+  ],
   "repository": "hexojs/hexo",
   "homepage": "https://hexo.io/",
   "keywords": [


### PR DESCRIPTION
Specified size so that we will not publish package lock files to npm.

Before: 86.2 kB (308.5 kB)
After: 54.2 kB (199.5 kB)