### PR TITLE
Ignore plugins whose name is started with "@types/"

### DIFF
--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -34,6 +34,9 @@ function loadModuleList(ctx) {
     // Ignore plugins whose name is not started with "hexo-"
     if (!/^hexo-|^@[^/]+\/hexo-/.test(name)) return false;
 
+    // Ignore typescript definition file that is started with "@types/"
+    if (/^@types\//.test(name)) return false;
+
     // Make sure the plugin exists
     const path = ctx.resolvePlugin(name);
     return fs.exists(path);


### PR DESCRIPTION
I use hexo with TypeScript, and fixed an issue with using TypeScript declaration module of any hexo-plugin.

## What does it do?

In `load_plugins.js`, hexo shoud not load module started with `@types/`

`@types/*` is module of TypeScript Declaration File.
https://github.com/DefinitelyTyped/DefinitelyTyped/

That contains no js code, only type declaration file `*.d.ts`, so hexo will fail to load it as plugin.

```
# npm i @types/hexo-util
# hexo g > /dev/null
ERROR Plugin load failed: @types/hexo-util
Error: EISDIR: illegal operation on a directory, read
```
One of TypeScript declaration module's naming is as follows.
https://github.com/DefinitelyTyped/DefinitelyTyped#create-a-new-package
> If you are adding typings for an NPM package, create a directory **with the same name**.

The name of any plugin's type declaration file necessarily contains `hexo-`.
And namespace `@types`  does not include anything except TypeScript declaration module.
So, they should be ignored at once.

## How to test

```sh
git clone -b no-load-typescript-dts-as-plugin git@github.com:KentarouTakeda/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

Nothing.

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
