### PR TITLE
chore(stale): update stale exemptLabels setting

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -8,11 +8,13 @@ daysUntilClose: 7
 exemptLabels:
   - bug
   - discussion
+  - "help wanted"
   - need-verify
+  - need-investigation
   - pending-reply
+  - proposal
   - feature-request
   - enhancement
-  - question
   - documentation
 # Label to use when marking as stale
 staleLabel: stale


### PR DESCRIPTION
## What does it do?

Update stale bot setting.

## Why remove question label from exemptLabels setting

Some question issue seems closeable. But, issue reporters are not close them. Also maybe they will not close in the future.

Current stale bot do not close issue if issue added question label. IMHO this setting is no need.

## How to test

No need.

## Screenshots

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.