### PR TITLE
{% raw %} tags shown when mixed triple backtick and raw blocks are used with hljs

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -3,17 +3,17 @@
 require('chai').use(require('chai-as-promised'));
 
 describe('Hexo', () => {
-  require('./scripts/box');
-  require('./scripts/console');
-  require('./scripts/extend');
-  require('./scripts/filters');
-  require('./scripts/generators');
-  require('./scripts/helpers');
+  // require('./scripts/box');
+  // require('./scripts/console');
+  // require('./scripts/extend');
+  // require('./scripts/filters');
+  // require('./scripts/generators');
+  // require('./scripts/helpers');
   require('./scripts/hexo');
-  require('./scripts/models');
-  require('./scripts/processors');
-  require('./scripts/renderers');
-  require('./scripts/tags');
-  require('./scripts/theme');
-  require('./scripts/theme_processors');
+  // require('./scripts/models');
+  // require('./scripts/processors');
+  // require('./scripts/renderers');
+  // require('./scripts/tags');
+  // require('./scripts/theme');
+  // require('./scripts/theme_processors');
 });

--- a/test/scripts/hexo/index.js
+++ b/test/scripts/hexo/index.js
@@ -1,15 +1,15 @@
 'use strict';
 
 describe('Core', () => {
-  require('./hexo');
-  require('./load_config');
-  require('./load_database');
-  require('./load_plugins');
-  require('./locals');
-  require('./multi_config_path');
+  // require('./hexo');
+  // require('./load_config');
+  // require('./load_database');
+  // require('./load_plugins');
+  // require('./locals');
+  // require('./multi_config_path');
   require('./post');
-  require('./render');
-  require('./router');
-  require('./scaffold');
-  require('./update_package');
+  // require('./render');
+  // require('./router');
+  // require('./scaffold');
+  // require('./update_package');
 });

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -643,6 +643,36 @@ describe('Post', () => {
     });
   });
 
+  it.only('render triple backticks and raw tags properly', () => {
+    hexo.config.highlight.hljs = true;
+    const content = [
+      '```js',
+      'alert("Foo")',
+      '```',
+      '{% raw %}',
+      '<p>Foo</p>',
+      '{% endraw %}',
+      '```html',
+      '<div></div>',
+      '```'
+    ].join('\n');
+
+    return post.render(null, {
+      content,
+      engine: 'markdown'
+    }).then(data => {
+      const expected = [
+        '<figure class="highlight js"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><code class="hljs js">alert(<span class="hljs-string">"Foo"</span>)<br></code></pre></td></tr></table></figure>',
+        '',
+        '<p>Foo</p>',
+        '',
+        '<figure class="highlight html"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span><br></code></pre></td></tr></table></figure>'
+      ].join('\n');
+      data.content.trim().should.eql(expected);
+      hexo.config.highlight.hljs = false;
+    });
+  });
+
   it('render() - recover escaped swig blocks which is html escaped', () => {
     const content = '`{% raw %}{{ test }}{% endraw %}`';
 


### PR DESCRIPTION
On vuejs.org, we're encountering a [weird issue](https://github.com/vuejs/vuejs.org/issues/1992) where `{% raw %}` and `{% endraw %}` tags are visible with a very specific set of settings. 

## What does it do?

To reproduce the bug with minimal settings.


## How to test

```sh
git clone -b raw-bug-poc https://github.com/phanan-forks/hexo.git
cd hexo
npm install
npm test
```

You'll notice that with the provided stub (`content`) AND `hexo.config.highlight.hljs` set to `true`, hexo will leave the `{% raw %}` and `{% endraw %}` tags untouched, and the (only) test case will fail with this assertion error:

```diff
+ expected - actual

<figure class="highlight js"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><code class="hljs js">alert(<span class="hljs-string">"Foo"</span>)<br></code></pre></td></tr></table></figure>
-{% raw %}
+
<p>Foo</p>
-{% endraw %}
+
<figure class="highlight html"><table><tr><td class="gutter"><pre><span class="line">1</span><br></pre></td><td class="code"><pre><code class="hljs html"><span class="hljs-tag">&lt;<span class="hljs-name">div</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">div</span>&gt;</span><br></code></pre></td></tr></table></figure>
```


## Screenshots

None.

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
