### PR TITLE
refactor: switch minimatch to micromatch

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -7,7 +7,7 @@ const { Pattern, HashStream } = require('hexo-util');
 const fs = require('hexo-fs');
 const chalk = require('chalk');
 const { EventEmitter } = require('events');
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 
 const defaultPattern = new Pattern(() => ({}));
 
@@ -30,10 +30,6 @@ function Box(ctx, base, options) {
   this.Cache = ctx.model('Cache');
   this.File = this._createFileClass();
   this.ignore = ctx.config.ignore;
-
-  if (!Array.isArray(this.ignore)) {
-    this.ignore = [this.ignore];
-  }
 }
 
 require('util').inherits(Box, EventEmitter);
@@ -105,7 +101,7 @@ Box.prototype.addProcessor = function(pattern, fn) {
 Box.prototype._readDir = function(base, fn, prefix = '') {
   const { ignore } = this;
 
-  if (base && ignore && ignore.length && ignore.some(item => minimatch(base, item))) {
+  if (base && ignore && ignore.length && micromatch.isMatch(base, ignore)) {
     return Promise.resolve('Ignoring dir.');
   }
 

--- a/lib/plugins/processor/common.js
+++ b/lib/plugins/processor/common.js
@@ -2,7 +2,7 @@
 
 const { Pattern } = require('hexo-util');
 const moment = require('moment-timezone');
-const minimatch = require('minimatch');
+const micromatch = require('micromatch');
 
 const DURATION_MINUTE = 1000 * 60;
 
@@ -48,7 +48,6 @@ exports.timezone = (date, timezone) => {
 
 exports.isMatch = (path, patterns) => {
   if (!patterns) return false;
-  if (!Array.isArray(patterns)) patterns = [patterns];
 
-  return patterns.some(pattern => pattern && minimatch(path, pattern));
+  return micromatch.isMatch(path, patterns);
 };

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "hexo-util": "^0.6.3",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",
-    "minimatch": "^3.0.4",
+    "micromatch": "^4.0.2",
     "moment": "^2.22.2",
     "moment-timezone": "^0.5.21",
     "nunjucks": "^3.1.3",


### PR DESCRIPTION
## What does it do?
micromatch is a replacement of minimatch. It supports multiple patterns in an array, without string-to-array conversion, along with other globbing [features](https://github.com/micromatch/picomatch#library-comparisons). It's also [faster](https://github.com/micromatch/micromatch#latest-results) and updated much more frequently ([micromatch](https://github.com/micromatch/micromatch/commits/master) vs [minimatch](https://github.com/isaacs/minimatch/commits/master)). It's already utilized in hexo, indirectly through chokidar dep. `npm ls --depth 5` shows 4 instances of it.

Using micromatch@4 is rather drastic since it depends on Node >=8, considering other deps currently use micromatch@3. But it's not a major issue, as Node 6 will be eventually dropped (#3508).

~~Personally, I would prefer to enable the [matchBase](https://github.com/micromatch/micromatch#optionsbasename) option. With this option, I can just use `'ignore-this.txt'` to exclude that file (assuming the filename is unique. I'm aware of the underscore ignore), instead of `'**/ignore-this.txt'`. When globbing is used, if I want to exclude all `.txt`, I only need `'*.txt'`, instead of `'**/*.txt'`. In the case of #3306, it can be just `'abc*'`. The doc needs to be updated though if this behavior is introduced.~~

## How to test

```sh
git clone -b micromatch https://github.com/weyusi/hexo.git
cd hexo
npm install
npm test
```
github page: https://github.com/weyusi/hexo-testing


## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
  - will not pass in Node 6 environment.
