### PR TITLE
chore(stale): stale bot limit to only issue

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -28,4 +28,4 @@ unmarkComment: false
 # Comment to post when closing a stale Issue or Pull Request. Set to `false` to disable
 closeComment: false
 # Limit to only `issues` or `pulls`
-# only: issues
+only: issues


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Stale bot limit to only issue
IMHO old PR should not close automatically by stale bot.

For example #3335 

## How to test

Nothing

## Screenshots

Nothing

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
