### PR TITLE
chore(deps-dev): replace deprecated istanbul with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@ node_modules/
 tmp/
 *.log
 .idea/
-coverage/
 yarn.lock
 package-lock.json
+.nyc_output/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ script:
 
 after_script:
   - npm install coveralls
-  - cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
+  - nyc report --reporter=text-lcov | coveralls
 
 dist: trusty

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "eslint": "eslint-ci .",
     "test": "mocha test/index.js",
-    "test-cov": "istanbul cover --print both _mocha -- test/index.js",
+    "test-cov": "nyc npm run test",
     "lint-staged": "lint-staged"
   },
   "directories": {
@@ -72,9 +72,9 @@
     "eslint-config-hexo": "^3.0.0",
     "hexo-renderer-marked": "^0.3.0",
     "husky": "^1.1.3",
-    "istanbul": "^0.4.3",
     "lint-staged": "^8.1.0",
     "mocha": "^6.0.0",
+    "nyc": "^14.1.1",
     "rewire": "^4.0.1",
     "sinon": "^7.1.1"
   },


### PR DESCRIPTION
## What does it do?
istanbul has been [deprecated](https://www.npmjs.com/package/istanbul) (last published 3 years ago). It is [replaced by nyc](https://www.npmjs.com/package/nyc) instead.

Current version (as of v14.1.1) [still supports](https://github.com/istanbuljs/nyc/blob/fe3311bd4770726c67e6eee1e39b15a3b616457b/package.json) Node 6.

## How to test

```sh
git clone -b nyc https://github.com/weyusi/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [ ] Passed the CI test.
