### PR TITLE
chore(deps-dev): update hexo-renderer-marked requirement from ^0.3.0 to ^1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "eslint": "^5.9.0",
     "eslint-ci": "^1.0.0",
     "eslint-config-hexo": "^3.0.0",
-    "hexo-renderer-marked": "^0.3.0",
+    "hexo-renderer-marked": "^1.0.1",
     "husky": "^1.1.3",
     "istanbul": "^0.4.3",
     "lint-staged": "^8.1.0",

--- a/test/fixtures/post_render.js
+++ b/test/fixtures/post_render.js
@@ -29,11 +29,11 @@ exports.content = content;
 exports.expected = [
   '<h1 id="Title"><a href="#Title" class="headerlink" title="Title"></a>Title</h1>',
   util.highlight(code, {lang: 'python'}),
-  '\n<p>some content</p>\n',
+  '\n\n<p>some content</p>\n',
   '<h2 id="Another-title"><a href="#Another-title" class="headerlink" title="Another title"></a>Another title</h2>',
   '<blockquote>',
   '<p>quote content</p>\n',
-  '</blockquote>\n',
+  '</blockquote>\n\n',
   '<blockquote><p>quote content</p>\n',
   '<footer><strong>Hello World</strong></footer></blockquote>'
 ].join('');


### PR DESCRIPTION
## What does it do?
Update devDeps. Somehow hexo-renderer-marked@1 results in extra new lines.

Supersede #3548 

## How to test

```sh
git clone -b marked https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Passed the CI test.
