### PR TITLE
code block in markdown are not rendered correctly after set disableNunjucks to true

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -270,9 +270,11 @@ Post.prototype.render = function(source, data = {}, callback) {
       engine: data.engine,
       toString: true,
       onRenderEnd(content) {
-        if (disableNunjucks) return content;
         // Replace cache data with real contents
         data.content = cacheObj.loadContent(content);
+
+        // Return content after replace the placeholders
+        if (disableNunjucks) return data.content;
 
         // Render with Nunjucks
         return tag.render(data.content, data);

--- a/test/fixtures/post_render.js
+++ b/test/fixtures/post_render.js
@@ -37,3 +37,16 @@ exports.expected = [
   '<blockquote><p>quote content</p>\n',
   '<footer><strong>Hello World</strong></footer></blockquote>'
 ].join('');
+
+exports.expected_disable_nunjucks = [
+  '<h1 id="Title"><a href="#Title" class="headerlink" title="Title"></a>Title</h1>',
+  util.highlight(code, {lang: 'python'}),
+  '\n\n<p>some content</p>\n',
+  '<h2 id="Another-title"><a href="#Another-title" class="headerlink" title="Another title"></a>Another title</h2>',
+  '<p>{% blockquote %}<br>',
+  'quote content<br>',
+  '{% endblockquote %}</p>\n',
+  '<p>{% quote Hello World %}<br>',
+  'quote content<br>',
+  '{% endquote %}</p>'
+].join('');

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -686,4 +686,21 @@ describe('Post', () => {
       callback();
     });
   });
+
+  // test for PR [#3573](https://github.com/hexojs/hexo/pull/3573)
+  it('render() - disableNunjucks', () => {
+    const renderer = hexo.render.renderer.get('markdown');
+    renderer.disableNunjucks = true;
+
+    return post.render(null, {
+      content: fixture.content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql(fixture.expected_disable_nunjucks);
+    }).then(data => {
+      renderer.disableNunjucks = false;
+    });
+
+  });
+
 });

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -688,7 +688,7 @@ describe('Post', () => {
   });
 
   // test for PR [#3573](https://github.com/hexojs/hexo/pull/3573)
-  it('render() - disableNunjucks', () => {
+  it('render() - (disableNunjucks === true)', () => {
     const renderer = hexo.render.renderer.get('markdown');
     renderer.disableNunjucks = true;
 
@@ -700,7 +700,21 @@ describe('Post', () => {
     }).then(data => {
       renderer.disableNunjucks = false;
     });
+  });
 
+  // test for PR [#3573](https://github.com/hexojs/hexo/pull/3573)
+  it('render() - (disableNunjucks === false)', () => {
+    const renderer = hexo.render.renderer.get('markdown');
+    renderer.disableNunjucks = false;
+
+    return post.render(null, {
+      content: fixture.content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql(fixture.expected);
+    }).then(data => {
+      renderer.disableNunjucks = false;
+    });
   });
 
 });


### PR DESCRIPTION
Fix the issue that code blocks in markdown are rendered as placeholder after disabling nunjucks

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fix the issue that "code block in markdown are not rendered correctly after set `disableNunjucks` to true", which is introduced in PR https://github.com/hexojs/hexo/pull/2593

Expected behavior: 
1. most tag plugins (nunjucks) feature should be disabled after set `disableNunjucks` to true ;
1. however, markdown features like code blocks should still work;


## How to test

### (1) Hexo Test

```sh
git clone -b master https://github.com/think-in-universe/hexo.git
cd hexo
npm install
npm test     # passed in my local test
```

### (2) Test "Disable Nunjucks" At Renderer-Level

To test `disableNunjucks`, we can use the [hexo-stop-tag-plugins](https://www.npmjs.com/package/hexo-stop-tag-plugins) plugin created by me. The plugin has been submitted to the plugins list via the PR https://github.com/hexojs/site/pull/966

```sh
git clone -b master https://github.com/think-in-universe/hexo-stop-tag-plugins.git
cd hexo-stop-tag-plugins
npm install
npm test    # 4 of 11 test failed
npm install think-in-universe/hexo#master   # override the hexo package
npm test   # 11 or 11 tests passed, after include the change in this PR
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
