### PR TITLE
chore: drop Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ cache:
     - node_modules
 
 node_js:
-  - "6"
   - "8"
   - "10"
   - "node"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,9 @@ install:
 before_test:
   - npm install
 
+cache:
+  - node_modules -> package.json
+
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,6 @@ install:
 before_test:
   - npm install
 
-cache:
-  - node_modules -> package.json
-
 # Post-install test scripts.
 test_script:
   # Output useful info for debugging.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ image:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
     - nodejs_version: "11"

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "sinon": "^7.1.1"
   },
   "engines": {
-    "node": ">=6.9.0"
+    "node": ">=8.6.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## What does it do?
Drop Node 6 as per #3508 . It has [reached EOL](https://github.com/nodejs/Release) since 2019-04-30.

## How to test

```sh
git clone -b drop-node6 https://github.com/weyusi/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Passed the CI test.
