### PR TITLE
chore(appveyor): replace node 11 with 12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - nodejs_version: "6"
     - nodejs_version: "8"
     - nodejs_version: "10"
-    - nodejs_version: "11"
+    - nodejs_version: "12"
     
 matrix:
   fast_finish: true


### PR DESCRIPTION
## What does it do?
appveyor supports node 12 since [2019-06-14](https://www.appveyor.com/updates/2019/06/14/).
v11 is EOL since 2019-06-01.


## How to test

```sh
git clone -b node-12 https://github.com/weyusi/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Passed the CI test.
