### PR TITLE
Fix to use root to export Permalink

### DIFF
--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -38,7 +38,7 @@ module.exports = ctx => {
   });
 
   Category.virtual('permalink').get(function() {
-    return `${ctx.config.url}/${this.path}`;
+    return `${ctx.config.url}${ctx.config.root}${this.path}`;
   });
 
   Category.virtual('posts').get(function() {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -32,7 +32,7 @@ module.exports = ctx => {
   });
 
   Page.virtual('permalink').get(function() {
-    return `${ctx.config.url}/${this.path}`;
+    return `${ctx.config.url}${ctx.config.root}${this.path}`;
   });
 
   Page.virtual('full_source').get(function() {

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -29,7 +29,7 @@ module.exports = ctx => {
   });
 
   Tag.virtual('permalink').get(function() {
-    return `${ctx.config.url}/${this.path}`;
+    return `${ctx.config.url}${ctx.config.root}${this.path}`;
   });
 
   Tag.virtual('posts').get(function() {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Fix to use root to export permalink.
It fix #3601 .

```js
[Page,Category,Tag].virtual('permalink').get(function() {
// return `${ctx.config.url}/${this.path}`; 
// to
  return `${ctx.config.url}${ctx.config.root}${this.path}`;
});
```

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```
