### PR TITLE
feat(filter): use existing excerpt if possible

### DIFF
--- a/lib/plugins/filter/after_post_render/excerpt.js
+++ b/lib/plugins/filter/after_post_render/excerpt.js
@@ -5,7 +5,9 @@ const rExcerpt = /<!--+\s*more\s*--+>/i;
 function excerptFilter(data) {
   const { content } = data;
 
-  if (rExcerpt.test(content)) {
+  if (typeof data.excerpt !== 'undefined') {
+    data.more = content;
+  } else if (rExcerpt.test(content)) {
     data.content = content.replace(rExcerpt, (match, index) => {
       data.excerpt = content.substring(0, index).trim();
       data.more = content.substring(index + match.length).trim();

--- a/test/scripts/filters/excerpt.js
+++ b/test/scripts/filters/excerpt.js
@@ -119,4 +119,35 @@ describe('Excerpt', () => {
       'baz'
     ].join('\n'));
   });
+
+  it('skip processing if post/page.excerpt is present', () => {
+    const content = [
+      'foo',
+      '<!-- more -->',
+      'bar'
+    ].join('\n');
+
+    const data = {
+      content,
+      excerpt: 'baz'
+    };
+
+    excerpt(data);
+
+    data.content.should.eql([
+      'foo',
+      '<!-- more -->',
+      'bar'
+    ].join('\n'));
+
+    data.excerpt.should.eql([
+      'baz'
+    ].join('\n'));
+
+    data.more.should.eql([
+      'foo',
+      '<!-- more -->',
+      'bar'
+    ].join('\n'));
+  });
 });

--- a/test/scripts/filters/excerpt.js
+++ b/test/scripts/filters/excerpt.js
@@ -120,7 +120,7 @@ describe('Excerpt', () => {
     ].join('\n'));
   });
 
-  it('skip processing if post/page.excerpt is present', () => {
+  it('skip processing if post/page.excerpt is present in the front-matter', () => {
     const content = [
       'foo',
       '<!-- more -->',


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Skip excerpt generation for posts or pages if it is set in the front matter. This gives users the ability to write down whatever abstract they want instead of just showing begining part of the post.

For example:
```yaml
title: An article about blah blah blah
excerpt: This article is all about blah blah blah blah blah blah
---
Actual markdown content...
```

will generate:

```js
{
    excerpt: 'This article is all about blah blah blah blah blah blah',
    more: 'Actual markdown content...',
    content: 'Actual markdown content...'
}
```

## How to test

```sh
git clone -b BRANCH https://github.com/ppoffice/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

N/A

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
