### PR TITLE
Ignore categories / tags with zero posts

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -136,9 +136,15 @@ Hexo.prototype._bindLocals = function() {
     return db.model('Page').find(query);
   });
 
-  locals.set('categories', () => db.model('Category'));
+  locals.set('categories', () => {
+    // Ignore categories with zero posts
+    return db.model('Category').filter(category => category.length);
+  });
 
-  locals.set('tags', () => db.model('Tag'));
+  locals.set('tags', () => {
+    // Ignore tags with zero posts
+    return db.model('Tag').filter(tag => tag.length);
+  });
 
   locals.set('data', () => {
     const obj = {};

--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -36,9 +36,6 @@ function tagcloudHelper(tags, options) {
     tags = tags.sort(orderby, order);
   }
 
-  // Ignore tags with zero posts
-  tags = tags.filter(tag => tag.length);
-
   // Limit the number of tags
   if (options.amount) {
     tags = tags.limit(options.amount);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Issue resolved: #3622

### Current behaviour
Categories / tags of draft are displayed / counted in non-draft generate.

In hexo-theme-next, we tried to filter out the categories / tags in the draft, but this caused performance issues.

More information:
theme-next/hexo-theme-next#42
theme-next/hexo-theme-next#87

## How to test

```sh
git clone -b master https://github.com/stevenjoezhang/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
