### PR TITLE
chore(dev-deps): remove unneeded eslint-ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "hexo": "./bin/hexo"
   },
   "scripts": {
-    "eslint": "eslint-ci .",
+    "eslint": "eslint .",
     "test": "mocha test/index.js",
     "test-cov": "nyc npm run test",
     "lint-staged": "lint-staged"
@@ -68,7 +68,6 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "eslint": "^6.0.1",
-    "eslint-ci": "^1.0.0",
     "eslint-config-hexo": "^3.0.0",
     "hexo-renderer-marked": "^1.0.1",
     "husky": "^3.0.0",


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
`"scripts"` handles binaries in `./node_modules/.bin/` well, so there's no need for cli version of eslint. Most of the plugins are eslint-ed without eslint-ci just fine.

To run eslint locally, there are a few ways:
1. `$ npm run eslint`
2. `$ npx eslint .`
3. Add "./node_modules/.bin" to $PATH


## How to test

```sh
git clone -b eslint-ci https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Passed the CI test.
