### PR TITLE
test: allow empty attribute

### DIFF
--- a/test/scripts/tags/asset_img.js
+++ b/test/scripts/tags/asset_img.js
@@ -37,27 +37,27 @@ describe('asset_img', () => {
   }));
 
   it('default', () => {
-    assetImg('bar').should.eql('<img src="/foo/bar">');
+    assetImg('bar').should.eql('<img src="/foo/bar" class="">');
   });
 
   it('default', () => {
-    assetImg('bar title').should.eql('<img src="/foo/bar" title="title">');
+    assetImg('bar title').should.eql('<img src="/foo/bar" class="" title="title">');
   });
 
   it('with space', () => {
     // {% asset_img "spaced asset" "spaced title" %}
     assetImgTag.call(post, ['spaced asset', 'spaced title'])
-      .should.eql('<img src="/foo/spaced%20asset" title="spaced title">');
+      .should.eql('<img src="/foo/spaced%20asset" class="" title="spaced title">');
   });
 
   it('with alt and title', () => {
     assetImgTag.call(post, ['bar', '"title"', '"alt"'])
-      .should.eql('<img src="/foo/bar" title="title" alt="alt">');
+      .should.eql('<img src="/foo/bar" class="" title="title" alt="alt">');
   });
 
   it('with width height alt and title', () => {
     assetImgTag.call(post, ['bar', '100', '200', '"title"', '"alt"'])
-      .should.eql('<img src="/foo/bar" width="100" height="200" title="title" alt="alt">');
+      .should.eql('<img src="/foo/bar" class="" width="100" height="200" title="title" alt="alt">');
   });
 
   it('no slug', () => {
@@ -70,6 +70,6 @@ describe('asset_img', () => {
 
   it('with root path', () => {
     hexo.config.root = '/root/';
-    assetImg('bar').should.eql('<img src="/root/foo/bar">');
+    assetImg('bar').should.eql('<img src="/root/foo/bar" class="">');
   });
 });

--- a/test/scripts/tags/link.js
+++ b/test/scripts/tags/link.js
@@ -23,7 +23,8 @@ describe('link', () => {
 
     $('a').attr('href').should.eql('https://google.com');
     $('a').html().should.eql('Click here to Google');
-    should.not.exist($('a').attr('target'));
+    $('a').attr('title').should.eql('');
+    $('a').attr('target').should.eql('');
   });
 
   it('text + url + title', () => {
@@ -46,7 +47,7 @@ describe('link', () => {
 
     $('a').attr('href').should.eql('https://google.com');
     $('a').html().should.eql('Click here to Google');
-    should.not.exist($('a').attr('target'));
+    $('a').attr('target').should.eql('');
     $('a').attr('title').should.eql('Google link');
   });
 });


### PR DESCRIPTION
## What does it do?
`asset_img()` and `link()` utilize hexo-util. https://github.com/hexojs/hexo-util/pull/36 introduced a change, where empty attributes (attribute without any value) are retained, instead of being removed.

This PR modifies the test cases to adapt to new behavior of hexo-util@1.0.0. 


## How to test

```sh
git clone -b unit-test https://github.com/curbengh/hexo.git
cd hexo
```

```diff
package.json:
- "hexo-util": "^0.6.3",
+ "hexo-util": "1.0.0-rc1",
```

```sh
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
  - Will only pass after hexo starts using hexo-util@1.0.0.
