### PR TITLE
feat: add option to disable meta generator tag

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -54,6 +54,9 @@ module.exports = {
   deploy: {},
 
   // ignore files from processing
-  ignore: []
+  ignore: [],
+
+  // Category & Tag
+  meta_generator: true
 };
 

--- a/lib/plugins/filter/meta_generator.js
+++ b/lib/plugins/filter/meta_generator.js
@@ -6,8 +6,11 @@ const hexoGeneratorTag = '<meta name="generator" content="Hexo %s" />';
 function hexoMetaGeneratorInject(data) {
   if (!cheerio) cheerio = require('cheerio');
   const $ = cheerio.load(data, {decodeEntities: false});
+  const { config } = this;
 
-  if (!($('meta[name="generator"]').length > 0) && $('head').contents().length > 0) {
+  if (!($('meta[name="generator"]').length > 0) &&
+  $('head').contents().length > 0 &&
+  config.meta_generator) {
     $('head').prepend(hexoGeneratorTag.replace('%s', this.version));
 
     return $.html();

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -23,4 +23,13 @@ describe('Meta Generator', () => {
     const resultType = typeof result;
     resultType.should.eql('undefined');
   });
+
+  it('disable meta_generator', () => {
+    const content = '<head><link></head>';
+    hexo.config.meta_generator = false;
+    const result = metaGenerator(content);
+
+    const resultType = typeof result;
+    resultType.should.eql('undefined');
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Add `meta_generator` option (enabled by default) to disable addition of `<meta name="generator" content="Hexo 3.9.0">`.

Fix https://github.com/hexojs/hexo/issues/3652#issuecomment-518601732


## How to test

```sh
git clone -b meta-generator https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.

cc @JoeyBling