### PR TITLE
fix: set english as default

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -6,7 +6,7 @@ module.exports = {
   subtitle: '',
   description: '',
   author: 'John Doe',
-  language: '',
+  language: 'en',
   timezone: '',
   // URL
   url: 'http://yoursite.com',


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Set default language as english. to match [the docs](https://hexo.io/docs/configuration#Site). Main purpose is to [set it in `<html>`](https://github.com/hexojs/hexo-theme-light/blob/b28cf1e9e1f3827e52cc654f59311752ca455306/layout/layout.ejs#L2), as [recommended](https://www.w3.org/International/questions/qa-html-language-declarations#attributes) by W3C.

I will update hexo-starter too. Edit: https://github.com/hexojs/hexo-starter/pull/12

## How to test

```sh
git clone -b default-lang https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
