### PR TITLE
test(open_graph): language is 'en' by default

### DIFF
--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -35,6 +35,7 @@ describe('open_graph', () => {
         meta({property: 'og:title', content: hexo.config.title}),
         meta({property: 'og:url'}),
         meta({property: 'og:site_name', content: hexo.config.title}),
+        meta({property: 'og:locale', content: 'en'}),
         meta({property: 'og:updated_time', content: post.updated.toISOString()}),
         meta({name: 'twitter:card', content: 'summary'}),
         meta({name: 'twitter:title', content: hexo.config.title})


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
After https://github.com/hexojs/hexo/pull/3654, `language:` defaults to `en`, thus no longer empty by default.


## How to test

```sh
git clone -b locale https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
