### PR TITLE
fix(open_graph): remove index.html from url

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -86,7 +86,7 @@ function openGraphHelper(options = {}) {
   result += og('og:type', type);
   result += og('og:title', title);
 
-  if (config.pretty_urls.trailing_index && config.pretty_urls.trailing_index === false) {
+  if (config.pretty_urls.trailing_index === false) {
     url = url.replace(/index\.html$/, '');
   }
 

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -35,7 +35,7 @@ function openGraphHelper(options = {}) {
   const keywords = page.keywords || (page.tags && page.tags.length ? page.tags : undefined) || config.keywords;
   const title = options.title || page.title || config.title;
   const type = options.type || (this.is_post() ? 'article' : 'website');
-  const url = options.url || (this.url ? this.url.replace(/index.html$/, '') : '');
+  let url = options.url || this.url;
   const siteName = options.site_name || config.title;
   const twitterCard = options.twitter_card || 'summary';
   const updated = options.updated !== false ? options.updated || page.updated : false;
@@ -85,7 +85,10 @@ function openGraphHelper(options = {}) {
 
   result += og('og:type', type);
   result += og('og:title', title);
+
+  if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
   result += og('og:url', url, false);
+
   result += og('og:site_name', siteName);
   if (description) {
     result += og('og:description', description, false);

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -35,7 +35,7 @@ function openGraphHelper(options = {}) {
   const keywords = page.keywords || (page.tags && page.tags.length ? page.tags : undefined) || config.keywords;
   const title = options.title || page.title || config.title;
   const type = options.type || (this.is_post() ? 'article' : 'website');
-  const url = options.url || this.url;
+  const url = options.url || (this.url ? this.url.replace(/index.html$/, '') : '');
   const siteName = options.site_name || config.title;
   const twitterCard = options.twitter_card || 'summary';
   const updated = options.updated !== false ? options.updated || page.updated : false;

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -86,7 +86,10 @@ function openGraphHelper(options = {}) {
   result += og('og:type', type);
   result += og('og:title', title);
 
-  if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+  if (config.pretty_urls.trailing_index && config.pretty_urls.trailing_index === false) {
+    url = url.replace(/index\.html$/, '');
+  }
+
   result += og('og:url', url, false);
 
   result += og('og:site_name', siteName);

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -114,9 +114,10 @@ describe('open_graph', () => {
   });
 
   it('url - should not ends with index.html', () => {
+    hexo.config.pretty_urls.trailing_index = false;
     const result = openGraph.call({
       page: {},
-      config: { pretty_urls: { trailing_index: false } },
+      config: hexo.config,
       is_post: isPost,
       url: 'http://yoursite.com/page/index.html'
     });
@@ -124,6 +125,8 @@ describe('open_graph', () => {
     const $ = cheerio.load(result);
 
     $('meta[property="og:url"]').attr('content').endsWith('index.html').should.be.false;
+
+    hexo.config.pretty_urls.trailing_index = true;
   });
 
   it('images - content', () => {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const moment = require('moment');
+const cheerio = require('cheerio');
 
 describe('open_graph', () => {
   const Hexo = require('../../../lib/hexo');
@@ -110,6 +111,19 @@ describe('open_graph', () => {
     }, {url: 'https://hexo.io/bar'});
 
     result.should.contain(meta({property: 'og:url', content: 'https://hexo.io/bar'}));
+  });
+
+  it('url - should not ends with index.html', () => {
+    const result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost,
+      url: 'http://yoursite.com/page/index.html'
+    });
+
+    const $ = cheerio.load(result);
+
+    $('meta[property="og:url"]').attr('content').endsWith('index.html').should.be.false;
   });
 
   it('images - content', () => {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -418,7 +418,7 @@ describe('open_graph', () => {
   it('updated - options', () => {
     const result = openGraph.call({
       page: { updated: moment('2016-05-23T21:20:21.372Z') },
-      config: {},
+      config: hexo.config,
       is_post: isPost
     }, { });
 
@@ -428,7 +428,7 @@ describe('open_graph', () => {
   it('updated - options - allow overriding og:updated_time', () => {
     const result = openGraph.call({
       page: { updated: moment('2016-05-23T21:20:21.372Z') },
-      config: {},
+      config: hexo.config,
       is_post: isPost
     }, { updated: moment('2015-04-22T20:19:20.371Z') });
 
@@ -438,7 +438,7 @@ describe('open_graph', () => {
   it('updated - options - allow disabling og:updated_time', () => {
     const result = openGraph.call({
       page: { updated: moment('2016-05-23T21:20:21.372Z') },
-      config: {},
+      config: hexo.config,
       is_post: isPost
     }, { updated: false });
 
@@ -448,7 +448,7 @@ describe('open_graph', () => {
   it('description - do not add /(?:og:)?description/ meta tags if there is no description', () => {
     const result = openGraph.call({
       page: { },
-      config: {},
+      config: hexo.config,
       is_post: isPost
     }, { });
 
@@ -459,7 +459,7 @@ describe('open_graph', () => {
   it('keywords - page keywords string', () => {
     const ctx = {
       page: { keywords: 'optimize,web' },
-      config: {},
+      config: hexo.config,
       is_post: isPost
     };
 
@@ -472,7 +472,7 @@ describe('open_graph', () => {
   it('keywords - page keywords array', () => {
     const ctx = {
       page: { keywords: ['optimize', 'web'] },
-      config: {},
+      config: hexo.config,
       is_post: isPost
     };
 
@@ -485,7 +485,7 @@ describe('open_graph', () => {
   it('keywords - page tags', () => {
     const ctx = {
       page: { tags: ['optimize', 'web'] },
-      config: {},
+      config: hexo.config,
       is_post: isPost
     };
 
@@ -496,9 +496,10 @@ describe('open_graph', () => {
   });
 
   it('keywords - config keywords string', () => {
+    hexo.config.keywords = 'optimize,web';
     const ctx = {
       page: {},
-      config: { keywords: 'optimize,web' },
+      config: hexo.config,
       is_post: isPost
     };
 
@@ -509,9 +510,10 @@ describe('open_graph', () => {
   });
 
   it('keywords - config keywords array', () => {
+    hexo.config.keywords = ['optimize', 'web'];
     const ctx = {
       page: {},
-      config: { keywords: ['optimize', 'web'] },
+      config: hexo.config,
       is_post: isPost
     };
 
@@ -522,12 +524,13 @@ describe('open_graph', () => {
   });
 
   it('keywords - page keywords first', () => {
+    hexo.config.keywords = 'web5,web6';
     const ctx = {
       page: {
         keywords: ['web1', 'web2'],
         tags: ['web3', 'web4']
       },
-      config: { keywords: 'web5,web6' },
+      config: hexo.config,
       is_post: isPost
     };
 
@@ -538,9 +541,10 @@ describe('open_graph', () => {
   });
 
   it('keywords - page tags second', () => {
+    hexo.config.keywords = 'web5,web6';
     const ctx = {
       page: { tags: ['optimize', 'web'] },
-      config: { keywords: 'web5,web6' },
+      config: hexo.config,
       is_post: isPost
     };
 
@@ -551,9 +555,10 @@ describe('open_graph', () => {
   });
 
   it('keywords - page tags empty', () => {
+    hexo.config.keywords = 'web5,web6';
     const ctx = {
       page: { tags: [] },
-      config: { keywords: 'web5,web6' },
+      config: hexo.config,
       is_post: isPost
     };
 
@@ -566,7 +571,7 @@ describe('open_graph', () => {
   it('keywords - escape', () => {
     const ctx = {
       page: { keywords: 'optimize,web&<>"\'/,site' },
-      config: {},
+      config: hexo.config,
       is_post: isPost
     };
 

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -116,7 +116,7 @@ describe('open_graph', () => {
   it('url - should not ends with index.html', () => {
     const result = openGraph.call({
       page: {},
-      config: hexo.config,
+      config: { pretty_urls: { trailing_index: false } },
       is_post: isPost,
       url: 'http://yoursite.com/page/index.html'
     });


### PR DESCRIPTION
## What does it do?
Uses canonical url (the one that doesn't end with `index.html`) for open graph tags.


## How to test

```sh
git clone -b ograph-canonical https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
