### PR TITLE
fix: performance improvements when meta_generator is disabled

### DIFF
--- a/lib/plugins/filter/meta_generator.js
+++ b/lib/plugins/filter/meta_generator.js
@@ -4,13 +4,14 @@ let cheerio;
 const hexoGeneratorTag = '<meta name="generator" content="Hexo %s" />';
 
 function hexoMetaGeneratorInject(data) {
+  const { config } = this;
+  if (!config.meta_generator) return;
+
   if (!cheerio) cheerio = require('cheerio');
   const $ = cheerio.load(data, {decodeEntities: false});
-  const { config } = this;
 
   if (!($('meta[name="generator"]').length > 0) &&
-  $('head').contents().length > 0 &&
-  config.meta_generator) {
+  $('head').contents().length > 0) {
     $('head').prepend(hexoGeneratorTag.replace('%s', this.version));
 
     return $.html();


### PR DESCRIPTION
# What does it do?

When `hexo.config.meta_generator` is `false`, return before `cheerio.load`.

Discussion: https://github.com/hexojs/hexo/issues/3663#issuecomment-521471346

## How to test

### Environment

- Travis CI
- [`theme-suka/hexo-theme-unit-test`](https://github.com/theme-suka/hexo-theme-unit-test) as basic hexo site
- [`hexo-theme-suka`](https://github.com/sukkaw/hexo-theme-suka)
- [`hexo-many-posts`](https://github.com/SukkaLab/hexo-many-posts): 300 posts that have 1 category, 5 tags, all markdown styles and large amounts of code blocks
- All the css, js & images are deleted before hexo clean && hexo g to make sure every file generated is rendered HTML.

## Screenshots

Raw build log can be found [here](https://travis-ci.com/theme-suka/performance-test/builds/123322706).

**Test A**

- The latest master branch of Hexo from `git+https://github.com/hexojs/hexo.git`
- `meta_generator` set to true

![image](https://user-images.githubusercontent.com/40715044/63073943-a0abfb00-bf5d-11e9-8272-afe63bcfd8bb.png)

`694 Files / 20 sec`

**Test B**

- The latest master branch of Hexo from `git+https://github.com/hexojs/hexo.git`
- `meta_generator` set to false

![image](https://user-images.githubusercontent.com/40715044/63074073-4495a680-bf5e-11e9-81a2-3937213cb081.png)

`694 Files / 20 sec`

**Test C**

- The latest master branch of Hexo from `git+https://github.com/hexojs/hexo.git`
- `meta_generator` set to false
- `sed -i "s|filter.register('after_render:html', require('./meta_generator'))|//filter.register('after_render:html', require('./meta_generator'))|g"  ./node_modules/hexo/lib/plugins/filter/index.js` to comment out https://github.com/hexojs/hexo/blob/master/lib/plugins/filter/index.js#L14

![image](https://user-images.githubusercontent.com/40715044/63074123-7149be00-bf5e-11e9-84a1-0ee1ec703704.png)

`694 Files / 8.62 sec`

**Test D**

- The latest master branch of Hexo from `git+https://github.com/sukkaw/hexo.git#meta-generator-config`
- `meta_generator` set to true

![image](https://user-images.githubusercontent.com/40715044/63074181-9a6a4e80-bf5e-11e9-9f2d-6f080dfb974a.png)

`694 Files / 20 sec`

**Test E**

- The latest master branch of Hexo from `git+https://github.com/sukkaw/hexo.git#meta-generator-config`
- `meta_generator` set to false

![image](https://user-images.githubusercontent.com/40715044/63074202-ab1ac480-bf5e-11e9-98d6-9f7c6c6842b0.png)

`694 Files / 8.56 sec`

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
