### PR TITLE
fix(open_graph): remove duplicate twitter card tags

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -116,10 +116,6 @@ function openGraphHelper(options = {}) {
   }
 
   result += meta('twitter:card', twitterCard);
-  result += meta('twitter:title', title);
-  if (description) {
-    result += meta('twitter:description', description, false);
-  }
 
   if (images.length) {
     result += meta('twitter:image', images[0], false);

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -423,7 +423,7 @@ describe('open_graph', () => {
     result.should.not.contain(meta({property: 'og:updated_time', content: '2016-05-23T21:20:21.372Z'}));
   });
 
-  it('description - do not add /(?:og:|twitter:)?description/ meta tags if there is no description', () => {
+  it('description - do not add /(?:og:)?description/ meta tags if there is no description', () => {
     const result = openGraph.call({
       page: { },
       config: {},
@@ -431,7 +431,6 @@ describe('open_graph', () => {
     }, { });
 
     result.should.not.contain(meta({property: 'og:description'}));
-    result.should.not.contain(meta({property: 'twitter:description'}));
     result.should.not.contain(meta({property: 'description'}));
   });
 

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -36,8 +36,7 @@ describe('open_graph', () => {
         meta({property: 'og:url'}),
         meta({property: 'og:site_name', content: hexo.config.title}),
         meta({property: 'og:updated_time', content: post.updated.toISOString()}),
-        meta({name: 'twitter:card', content: 'summary'}),
-        meta({name: 'twitter:title', content: hexo.config.title})
+        meta({name: 'twitter:card', content: 'summary'})
       ].join('\n'));
 
       return Post.removeById(post._id);


### PR DESCRIPTION
## What does it do?

Remove `twitter:title` and `twitter:description` which is duplicated with `og:title` and `og:description`

According to the [Twitter Card Docs](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started.html):

> When using Open Graph protocol to describe data on a page, it is easy to generate a Twitter card without duplicating tags and data. When the Twitter card processor looks for tags on a page, it first checks for the Twitter-specific property, and if not present, falls back to the supported Open Graph property.

SInce the value of `twitter:title` and `twitter:description` is the same as `og:title` and `og:description`, they can be removed.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
