### PR TITLE
perf(open_graph): only require cheerio when content contains '<img'

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -28,7 +28,6 @@ function og(name, content, escape) {
 }
 
 function openGraphHelper(options = {}) {
-  if (!cheerio) cheerio = require('cheerio');
 
   const { config, page } = this;
   const { content } = page;
@@ -59,12 +58,16 @@ function openGraphHelper(options = {}) {
   if (!images.length && content) {
     images = images.slice();
 
-    const $ = cheerio.load(content);
+    if (content.includes('<img')) {
+      if (!cheerio) cheerio = require('cheerio');
 
-    $('img').each(function() {
-      const src = $(this).attr('src');
-      if (src) images.push(src);
-    });
+      const $ = cheerio.load(content);
+
+      $('img').each(function() {
+        const src = $(this).attr('src');
+        if (src) images.push(src);
+      });
+    }
   }
 
   let result = '';


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

only require cheerio when content contains '<img'

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

https://github.com/hexojs/hexo/issues/3663#issuecomment-521629413

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
