### PR TITLE
perf(meta_generator): drop cheerio

### DIFF
--- a/lib/plugins/filter/meta_generator.js
+++ b/lib/plugins/filter/meta_generator.js
@@ -1,21 +1,14 @@
 'use strict';
 
-let cheerio;
-const hexoGeneratorTag = '<meta name="generator" content="Hexo %s" />';
-
 function hexoMetaGeneratorInject(data) {
   const { config } = this;
-  if (!config.meta_generator) return;
+  if (!config.meta_generator ||
+  data.includes('<meta name="generator" content="Hexo')) return;
 
-  if (!cheerio) cheerio = require('cheerio');
-  const $ = cheerio.load(data, {decodeEntities: false});
+  const hexoGeneratorTag = '<meta name="generator" content="Hexo %s" />'
+    .replace('%s', this.version);
 
-  if (!($('meta[name="generator"]').length > 0) &&
-  $('head').contents().length > 0) {
-    $('head').prepend(hexoGeneratorTag.replace('%s', this.version));
-
-    return $.html();
-  }
+  return data.replace(/<\/head>/, hexoGeneratorTag.concat('</head>'));
 }
 
 module.exports = hexoMetaGeneratorInject;

--- a/lib/plugins/filter/meta_generator.js
+++ b/lib/plugins/filter/meta_generator.js
@@ -8,7 +8,7 @@ function hexoMetaGeneratorInject(data) {
   const hexoGeneratorTag = '<meta name="generator" content="Hexo %s">'
     .replace('%s', this.version);
 
-  return data.replace(/<\/head>/, hexoGeneratorTag.concat('</head>'));
+  return data.replace('</title>', '</title>' + hexoGeneratorTag);
 }
 
 module.exports = hexoMetaGeneratorInject;

--- a/lib/plugins/filter/meta_generator.js
+++ b/lib/plugins/filter/meta_generator.js
@@ -5,7 +5,7 @@ function hexoMetaGeneratorInject(data) {
   if (!config.meta_generator ||
   data.includes('<meta name="generator" content="Hexo')) return;
 
-  const hexoGeneratorTag = '<meta name="generator" content="Hexo %s" />'
+  const hexoGeneratorTag = '<meta name="generator" content="Hexo %s">'
     .replace('%s', this.version);
 
   return data.replace(/<\/head>/, hexoGeneratorTag.concat('</head>'));

--- a/lib/plugins/filter/meta_generator.js
+++ b/lib/plugins/filter/meta_generator.js
@@ -3,7 +3,7 @@
 function hexoMetaGeneratorInject(data) {
   const { config } = this;
   if (!config.meta_generator ||
-  data.includes('<meta name="generator" content="Hexo')) return;
+  data.match(/<meta\s+name=['|"]?generator['|"]?/i)) return;
 
   const hexoGeneratorTag = '<meta name="generator" content="Hexo %s">'
     .replace('%s', this.version);

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -7,25 +7,15 @@ describe('Meta Generator', () => {
   const cheerio = require('cheerio');
 
   it('default', () => {
-    const content = '<head><link></head>';
+    const content = '<head><title>foo</title></head>';
     const result = metaGenerator(content);
 
-    const $ = cheerio.load(result);
-    $('meta[name="generator"]').length.should.eql(1);
-  });
-
-  it('empty <head>', () => {
-    const content = '<head><link></head><body><head></head></body>';
-    const result = metaGenerator(content);
-
-    // meta generator should not be prepended if <head> tag is empty
-    // see https://github.com/hexojs/hexo/pull/3315
     const $ = cheerio.load(result);
     $('meta[name="generator"]').length.should.eql(1);
   });
 
   it('disable meta_generator', () => {
-    const content = '<head><link></head>';
+    const content = '<head><title>foo</title></head>';
     hexo.config.meta_generator = false;
     const result = metaGenerator(content);
 

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -22,4 +22,14 @@ describe('Meta Generator', () => {
     const resultType = typeof result;
     resultType.should.eql('undefined');
   });
+
+  it('no duplicate generator tag', () => {
+    const content = '<head><title>foo</title>'
+      + '<meta name="generator" content="foo"></head>';
+    hexo.config.meta_generator = true;
+    const result = metaGenerator(content);
+
+    const resultType = typeof result;
+    resultType.should.eql('undefined');
+  });
 });

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -15,13 +15,13 @@ describe('Meta Generator', () => {
   });
 
   it('empty <head>', () => {
-    const content = '<head></head>';
+    const content = '<head><link></head><body><head></head></body>';
     const result = metaGenerator(content);
 
     // meta generator should not be prepended if <head> tag is empty
     // see https://github.com/hexojs/hexo/pull/3315
-    const resultType = typeof result;
-    resultType.should.eql('undefined');
+    const $ = cheerio.load(result);
+    $('meta[name="generator"]').length.should.eql(1);
   });
 
   it('disable meta_generator', () => {

--- a/test/scripts/hexo/render.js
+++ b/test/scripts/hexo/render.js
@@ -9,6 +9,8 @@ describe('Render', () => {
   const Hexo = require('../../../lib/hexo');
   const hexo = new Hexo(pathFn.join(__dirname, 'render_test'));
 
+  hexo.config.meta_generator = false;
+
   const body = [
     'name:',
     '  first: John',


### PR DESCRIPTION
## What does it do?
Less breaking alternative to https://github.com/hexojs/hexo/pull/3669
x-post from that PR:
> From the [benchmark](https://github.com/hexojs/hexo/issues/3663#issuecomment-521488465) performed by @SukkaW , we can see cheerio—used by meta_generator filter—incurs significant perf cost. The feature was initially introduced by https://github.com/hexojs/hexo/pull/3129.

> Despite effort to improve the situation (https://github.com/hexojs/hexo/pull/3667), the improvement was only minuscule. Hence, we try to avoid cheerio if possible.

## How to test

```sh
git clone -b metagen-cheerio https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
