### PR TITLE
feat(open_graph): only require moment when (page.updated)

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const urlFn = require('url');
-const moment = require('moment');
+
 const { escapeHTML, htmlTag, stripHTML } = require('hexo-util');
 let cheerio;
 
@@ -110,6 +110,8 @@ function openGraphHelper(options = {}) {
   });
 
   if (updated) {
+    const moment = require('moment');
+
     if ((moment.isMoment(updated) || moment.isDate(updated)) && !isNaN(updated.valueOf())) {
       result += og('og:updated_time', updated.toISOString());
     }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

From https://github.com/hexojs/hexo/issues/3663#issuecomment-521563403 we can know `open_graph` helper will slow down generating speed by 28%, and #3670 makes `open_graph` helper require `cheerio` only when needed. So I come up with this PR, which require `moment` when `page.updated` is given.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

**Test A**

latest `hexojs/hexo#master` with hexo-theme-landscape and meta_generator set to false

![image](https://user-images.githubusercontent.com/40715044/63140759-977e6500-c015-11e9-80b2-31ed1f7614b0.png)

**Test B**

![image](https://user-images.githubusercontent.com/40715044/63140772-9cdbaf80-c015-11e9-923a-7675a1c1db2f.png)

`sukkaw/hexo#lazy-moment` with hexo-theme-landscape and meta_generator set to false

It is 1.4% faster.

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
