### PR TITLE
 feat(open_graph): add article:published_time & article:modified_time

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -118,6 +118,7 @@ function openGraphHelper(options = {}) {
 
   if (updated) {
     if ((moment.isMoment(updated) || moment.isDate(updated)) && !isNaN(updated.valueOf())) {
+      result += og('article:modified_time', updated.toISOString());
       result += og('og:updated_time', updated.toISOString());
     }
   }

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -118,7 +118,7 @@ function openGraphHelper(options = {}) {
 
   if (updated) {
     if ((moment.isMoment(updated) || moment.isDate(updated)) && !isNaN(updated.valueOf())) {
-      result += og('og:updated_time', updated.toISOString());
+      result += og('article:modified_time', updated.toISOString());
     }
   }
 

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -118,7 +118,6 @@ function openGraphHelper(options = {}) {
 
   if (updated) {
     if ((moment.isMoment(updated) || moment.isDate(updated)) && !isNaN(updated.valueOf())) {
-      result += og('article:modified_time', updated.toISOString());
       result += og('og:updated_time', updated.toISOString());
     }
   }

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -30,6 +30,7 @@ function openGraphHelper(options = {}) {
   let url = options.url || this.url;
   const siteName = options.site_name || config.title;
   const twitterCard = options.twitter_card || 'summary';
+  const date = options.date !== false ? options.date || page.date : false;
   const updated = options.updated !== false ? options.updated || page.updated : false;
   const language = options.language || page.lang || page.language || config.language;
 
@@ -108,6 +109,12 @@ function openGraphHelper(options = {}) {
   images.forEach(path => {
     result += og('og:image', path);
   });
+
+  if (date) {
+    if ((moment.isMoment(date) || moment.isDate(date)) && !isNaN(date.valueOf())) {
+      result += og('article:published_time', date.toISOString());
+    }
+  }
 
   if (updated) {
     if ((moment.isMoment(updated) || moment.isDate(updated)) && !isNaN(updated.valueOf())) {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -38,7 +38,6 @@ describe('open_graph', () => {
         meta({property: 'og:site_name', content: hexo.config.title}),
         meta({property: 'og:locale', content: 'en'}),
         meta({property: 'article:published_time', content: post.date.toISOString()}),
-        meta({property: 'article:modified_time', content: post.updated.toISOString()}),
         meta({property: 'og:updated_time', content: post.updated.toISOString()}),
         meta({name: 'twitter:card', content: 'summary'})
       ].join('\n'));

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -436,27 +436,27 @@ describe('open_graph', () => {
       is_post: isPost
     }, { });
 
-    result.should.contain(meta({property: 'og:updated_time', content: '2016-05-23T21:20:21.372Z'}));
+    result.should.contain(meta({property: 'article:modified_time', content: '2016-05-23T21:20:21.372Z'}));
   });
 
-  it('updated - options - allow overriding og:updated_time', () => {
+  it('updated - options - allow overriding article:modified_time', () => {
     const result = openGraph.call({
       page: { updated: moment('2016-05-23T21:20:21.372Z') },
       config: hexo.config,
       is_post: isPost
     }, { updated: moment('2015-04-22T20:19:20.371Z') });
 
-    result.should.contain(meta({property: 'og:updated_time', content: '2015-04-22T20:19:20.371Z'}));
+    result.should.contain(meta({property: 'article:modified_time', content: '2015-04-22T20:19:20.371Z'}));
   });
 
-  it('updated - options - allow disabling og:updated_time', () => {
+  it('updated - options - allow disabling article:modified_time', () => {
     const result = openGraph.call({
       page: { updated: moment('2016-05-23T21:20:21.372Z') },
       config: hexo.config,
       is_post: isPost
     }, { updated: false });
 
-    result.should.not.contain(meta({property: 'og:updated_time', content: '2016-05-23T21:20:21.372Z'}));
+    result.should.not.contain(meta({property: 'article:modified_time', content: '2016-05-23T21:20:21.372Z'}));
   });
 
   it('description - do not add /(?:og:)?description/ meta tags if there is no description', () => {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -38,7 +38,7 @@ describe('open_graph', () => {
         meta({property: 'og:site_name', content: hexo.config.title}),
         meta({property: 'og:locale', content: 'en'}),
         meta({property: 'article:published_time', content: post.date.toISOString()}),
-        meta({property: 'og:updated_time', content: post.updated.toISOString()}),
+        meta({property: 'article:modified_time', content: post.updated.toISOString()}),
         meta({name: 'twitter:card', content: 'summary'})
       ].join('\n'));
 

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -37,6 +37,8 @@ describe('open_graph', () => {
         meta({property: 'og:url'}),
         meta({property: 'og:site_name', content: hexo.config.title}),
         meta({property: 'og:locale', content: 'en'}),
+        meta({property: 'article:published_time', content: post.date.toISOString()}),
+        meta({property: 'article:modified_time', content: post.updated.toISOString()}),
         meta({property: 'og:updated_time', content: post.updated.toISOString()}),
         meta({name: 'twitter:card', content: 'summary'})
       ].join('\n'));


### PR DESCRIPTION
## What does it do?
`article:published_time` and `article:modified_time` are listed in the [Open Graph](https://ogp.me/) spec. The spec doesn't include `og:updated_time` (removed in more recent spec?), but somehow it's widely adopted (thanks to [Yoast](https://kb.yoast.com/kb/getting-open-graph-for-your-articles/)?).

Edit: `og_updated_time` has been deprecated, hence it's not included in the spec. This PR replaces it with `article:modified_time`.


## How to test

```sh
git clone -b og-updated https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test. (Pending https://github.com/hexojs/hexo/pull/3660)
