### PR TITLE
perf(open_graph): replace cheerio with dom-parser

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -57,13 +57,15 @@ function openGraphHelper(options = {}) {
   if (!images.length && content) {
     images = images.slice();
 
-    const dom = new DomParser().parseFromString(content);
-    const imgTags = dom.getElementsByTagName('img');
+    if (content.includes('<img')) {
+      const dom = new DomParser().parseFromString(content);
+      const imgTags = dom.getElementsByTagName('img');
 
-    imgTags.forEach(img => {
-      const src = img.getAttribute('src');
-      if (src) images.push(src);
-    });
+      imgTags.forEach(img => {
+        const src = img.getAttribute('src');
+        if (src) images.push(src);
+      });
+    }
   }
 
   let result = '';

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -3,7 +3,7 @@
 const urlFn = require('url');
 const moment = require('moment');
 const { escapeHTML, htmlTag, stripHTML } = require('hexo-util');
-let cheerio;
+const DomParser = require('dom-parser');
 
 function meta(name, content, escape) {
   if (escape !== false && typeof content === 'string') {
@@ -28,8 +28,6 @@ function og(name, content, escape) {
 }
 
 function openGraphHelper(options = {}) {
-  if (!cheerio) cheerio = require('cheerio');
-
   const { config, page } = this;
   const { content } = page;
   let images = options.image || options.images || page.photos || [];
@@ -59,10 +57,11 @@ function openGraphHelper(options = {}) {
   if (!images.length && content) {
     images = images.slice();
 
-    const $ = cheerio.load(content);
+    const dom = new DomParser().parseFromString(content);
+    const imgTags = dom.getElementsByTagName('img');
 
-    $('img').each(function() {
-      const src = $(this).attr('src');
+    imgTags.forEach(img => {
+      const src = img.getAttribute('src');
       if (src) images.push(src);
     });
   }

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "bluebird": "^3.5.2",
     "chalk": "^2.4.1",
     "cheerio": "0.22.0",
+    "dom-parser": "^0.1.6",
     "hexo-cli": "^2.0.0",
     "hexo-front-matter": "^0.2.3",
     "hexo-fs": "^1.0.0",


### PR DESCRIPTION
##  What does it do?
The [benchmark shows](https://github.com/snakazawa/html-parser-comparison) shows dom-parser is faster than cheerio.

Supersedes and closes #3670 

## How to test

```sh
git clone -b og-domparser https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.

