### PR TITLE
feat(js_helper): add support for custom attributes

### DIFF
--- a/lib/plugins/helper/js.js
+++ b/lib/plugins/helper/js.js
@@ -38,7 +38,7 @@ function jsHelper(...args) {
     } else {
       // New syntax
       item.src = url_for.call(this, item.src);
-      if (!item.src.endsWith('.css')) item.src += '.css';
+      if (!item.src.endsWith('.js')) item.src += '.js';
       result += htmlTag('script', { ...item }, '') + '\n';
     }
   });

--- a/lib/plugins/helper/js.js
+++ b/lib/plugins/helper/js.js
@@ -1,5 +1,10 @@
 'use strict';
 
+const { htmlTag } = require('hexo-util');
+const url_for = require('./url_for');
+
+/* flatten() to be replaced by Array.flat()
+after Node 10 has reached EOL */
 const flatten = function(arr, result = []) {
   for (const i in arr) {
     const value = arr[i];
@@ -32,18 +37,9 @@ function jsHelper(...args) {
       result += `<script src="${this.url_for(path)}"></script>\n`;
     } else {
       // New syntax
-      let tmpResult = '<script';
-      Object.keys(item).forEach(attribute => {
-        if (attribute === 'src') {
-          item[attribute] = this.url_for(item[attribute]);
-          if (!item[attribute].endsWith('.js')) item[attribute] += '.js';
-        }
-
-        if (item[attribute] === true) tmpResult += ' ' + attribute;
-        else tmpResult += ` ${attribute}="${item[attribute]}"`;
-      });
-      tmpResult += '></script>\n';
-      result += tmpResult;
+      item.src = url_for.call(this, item.src);
+      if (!item.src.endsWith('.css')) item.src += '.css';
+      result += htmlTag('script', { ...item }, '') + '\n';
     }
   });
   return result;

--- a/lib/plugins/helper/js.js
+++ b/lib/plugins/helper/js.js
@@ -33,7 +33,7 @@ function jsHelper(...args) {
     } else {
       // New syntax
       let tmpResult = '<script';
-      for (const attribute in item) {
+      Object.keys(item).forEach(attribute => {
         if (attribute === 'src') {
           item[attribute] = this.url_for(item[attribute]);
           if (!item[attribute].endsWith('.js')) item[attribute] += '.js';
@@ -41,7 +41,7 @@ function jsHelper(...args) {
 
         if (item[attribute] === true) tmpResult += ' ' + attribute;
         else tmpResult += ` ${attribute}="${item[attribute]}"`;
-      }
+      });
       tmpResult += '></script>\n';
       result += tmpResult;
     }

--- a/lib/plugins/helper/js.js
+++ b/lib/plugins/helper/js.js
@@ -1,15 +1,52 @@
 'use strict';
 
-function jsHelper(...args) {
-  return args.reduce((result, path, i) => {
-    if (i) result += '\n';
-
-    if (Array.isArray(path)) {
-      return result + Reflect.apply(jsHelper, this, path);
+const flatten = function(arr, result = []) {
+  for (const i in arr) {
+    const value = arr[i];
+    if (Array.isArray(value)) {
+      flatten(value, result);
+    } else {
+      result.push(value);
     }
-    if (!path.includes('?') && !path.endsWith('.js')) path += '.js';
-    return `${result}<script src="${this.url_for(path)}"></script>`;
-  }, '');
+  }
+  return result;
+};
+
+function jsHelper(...args) {
+  let result = '\n';
+  let items = args;
+
+  if (!Array.isArray(args)) {
+    items = [args];
+  }
+
+  items = flatten(items);
+
+  items.forEach(item => {
+    // Old syntax
+    if (typeof item === 'string' || item instanceof String) {
+      let path = item;
+      if (!path.endsWith('.js')) {
+        path += '.js';
+      }
+      result += `<script src="${this.url_for(path)}"></script>\n`;
+    } else {
+      // New syntax
+      let tmpResult = '<script';
+      for (const attribute in item) {
+        if (attribute === 'src') {
+          item[attribute] = this.url_for(item[attribute]);
+          if (!item[attribute].endsWith('.js')) item[attribute] += '.js';
+        }
+
+        if (item[attribute] === true) tmpResult += ' ' + attribute;
+        else tmpResult += ` ${attribute}="${item[attribute]}"`;
+      }
+      tmpResult += '></script>\n';
+      result += tmpResult;
+    }
+  });
+  return result;
 }
 
 module.exports = jsHelper;

--- a/test/scripts/helpers/js.js
+++ b/test/scripts/helpers/js.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const cheerio = require('cheerio');
+
 describe('js', () => {
   const Hexo = require('../../../lib/hexo');
   const hexo = new Hexo(__dirname);
@@ -12,14 +14,26 @@ describe('js', () => {
 
   const js = require('../../../lib/plugins/helper/js').bind(ctx);
 
-  function assertResult(result) {
-    let expected = '';
+  function assertResult(result, expected) {
+    const $ = cheerio.load(result);
 
-    for (let i = 1, len = arguments.length; i < len; i++) {
-      expected += '<script src="' + arguments[i] + '"></script>\n';
+    if (!Array.isArray(expected)) {
+      expected = [expected];
     }
 
-    result.should.eql(expected.trim());
+    expected.forEach((item, index) => {
+      if (typeof item === 'string' || item instanceof String) {
+        $('script').eq(index).attr('src').should.eql(item);
+      } else {
+        for (const attribute in item) {
+          if (item[attribute] === true) {
+            $('script').eq(index).attr(attribute).should.eql(attribute);
+          } else {
+            $('script').eq(index).attr(attribute).should.eql(item[attribute]);
+          }
+        }
+      }
+    });
   }
 
   it('a string', () => {
@@ -30,18 +44,41 @@ describe('js', () => {
   });
 
   it('an array', () => {
-    assertResult(js(['foo', 'bar', 'baz']), '/foo.js', '/bar.js', '/baz.js');
+    assertResult(js(['foo', 'bar', 'baz']), ['/foo.js', '/bar.js', '/baz.js']);
   });
 
   it('multiple strings', () => {
-    assertResult(js('foo', 'bar', 'baz'), '/foo.js', '/bar.js', '/baz.js');
+    assertResult(js('foo', 'bar', 'baz'), ['/foo.js', '/bar.js', '/baz.js']);
   });
 
   it('multiple arrays', () => {
-    assertResult(js(['foo', 'bar'], ['baz']), '/foo.js', '/bar.js', '/baz.js');
+    assertResult(js(['foo', 'bar'], ['baz']), ['/foo.js', '/bar.js', '/baz.js']);
   });
 
   it('mixed', () => {
-    assertResult(js(['foo', 'bar'], 'baz'), '/foo.js', '/bar.js', '/baz.js');
+    assertResult(js(['foo', 'bar'], 'baz'), ['/foo.js', '/bar.js', '/baz.js']);
+  });
+
+  it('an object', () => {
+    assertResult(js({src: 'script.js'}), {src: '/script.js'});
+    assertResult(js({src: '/script.js'}), {src: '/script.js'});
+    assertResult(js({src: '/script.js', foo: 'bar'}), {src: '/script.js', foo: 'bar'});
+  });
+
+  it('mulitple objects', () => {
+    assertResult(js({src: '/foo.js'}, {src: '/bar.js'}), [{src: '/foo.js'}, {src: '/bar.js'}]);
+    assertResult(js({src: '/aaa.js', bbb: 'ccc'}, {src: '/ddd.js', eee: 'fff'}),
+      [{src: '/aaa.js', bbb: 'ccc'}, {src: '/ddd.js', eee: 'fff'}]);
+  });
+
+  it('an array of objects', () => {
+    assertResult(js([{src: '/foo.js'}, {src: '/bar.js'}]), [{src: '/foo.js'}, {src: '/bar.js'}]);
+    assertResult(js([{src: '/aaa.js', bbb: 'ccc'}, {src: '/ddd.js', eee: 'fff'}]),
+      [{src: '/aaa.js', bbb: 'ccc'}, {src: '/ddd.js', eee: 'fff'}]);
+  });
+
+  it('async and defer attributes', () => {
+    assertResult(js({src: '/foo.js', 'async': true}), {src: '/foo.js', 'async': true});
+    assertResult(js({src: '/bar.js', 'defer': true}), {src: '/bar.js', 'defer': true});
   });
 });


### PR DESCRIPTION
## What does it do?
This is mainly to add [subresource integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) to `<script>`, though arbitrary attributes are supported as well.

Existing syntax is still supported (credit to https://github.com/hexojs/hexo/pull/3681#issuecomment-524648521).

Supported syntax:
- `<%- js('script.js') %>`
- `<%- js(['script.js', 'gallery.js']) %>`
- `<%- js({src: 'script.js', integrity: 'hash-value'}) %>`
- `<%- js({src: 'script.js', integrity: 'hash-value', async: true}) %>`
- `<%- js({src: 'script.js', integrity: 'hash-value'}, {src: 'gallery.js', integrity: 'hash-stuff'}) %>`
- `<%- js([{src: 'script.js', integrity: 'hash-value'}, {src: 'gallery.js', integrity: 'hash-stuff'}]) %>`
- `<%- js([{src: 'script.js', integrity: 'hash-value', defer: true}, {src: 'gallery.js', integrity: 'hash-stuff'}]) %>`

## How to test

```sh
git clone -b sri https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.

Closes #3687