### PR TITLE
chore(appveyor): always update npm

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,8 +18,7 @@ matrix:
 # Install scripts. (runs after repo cloning)
 install:
   - ps: Install-Product node $env:nodejs_version
-  
-before_test:
+  - npm install -g npm
   - npm install
 
 cache:


### PR DESCRIPTION
## What does it do?
Noticed from https://github.com/hexojs/hexo-util/pull/71, this PR ensure npm is always the latest.

also move `npm install` to `install:` step. [Restore build cache](https://www.appveyor.com/docs/build-configuration/#build-pipeline) step will still run before `install:`.


## How to test

```sh
git clone -b appveyor-npm https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Passed the CI test.
