### PR TITLE
fix(open_graph): percent-encode url, not html escape

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -78,11 +78,12 @@ function openGraphHelper(options = {}) {
   result += og('og:type', type);
   result += og('og:title', title);
 
-  if (config.pretty_urls.trailing_index === false) {
-    url = url.replace(/index\.html$/, '');
+  if (url) {
+    if (config.pretty_urls.trailing_index === false) {
+      url = url.replace(/index\.html$/, '');
+    }
+    url = encodeURL(url);
   }
-
-  if (url) url = encodeURL(url);
   result += og('og:url', url);
 
   result += og('og:site_name', siteName);

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -90,11 +90,13 @@ function openGraphHelper(options = {}) {
     url = url.replace(/index\.html$/, '');
   }
 
-  url = urlFn.format({
-    protocol: urlFn.parse(url).protocol,
-    hostname: urlFn.parse(url).hostname,
-    pathname: encodeURI(urlFn.parse(url).pathname)
-  });
+  if (url) {
+    url = urlFn.format({
+      protocol: urlFn.parse(url).protocol,
+      hostname: urlFn.parse(url).hostname,
+      pathname: encodeURI(urlFn.parse(url).pathname)
+    });
+  }
   result += og('og:url', url, false);
 
   result += og('og:site_name', siteName);

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -2,24 +2,16 @@
 
 const urlFn = require('url');
 const moment = require('moment');
-const { encodeURL, escapeHTML, htmlTag, stripHTML } = require('hexo-util');
+const { encodeURL, htmlTag, stripHTML } = require('hexo-util');
 
-function meta(name, content, escape) {
-  if (escape !== false && typeof content === 'string') {
-    content = escapeHTML(content);
-  }
-
+function meta(name, content) {
   return `${htmlTag('meta', {
     name,
     content
   })}\n`;
 }
 
-function og(name, content, escape) {
-  if (escape !== false && typeof content === 'string') {
-    content = escapeHTML(content);
-  }
-
+function og(name, content) {
   return `${htmlTag('meta', {
     property: name,
     content
@@ -70,7 +62,7 @@ function openGraphHelper(options = {}) {
   let result = '';
 
   if (description) {
-    result += meta('description', description, false);
+    result += meta('description', description);
   }
 
   if (keywords) {
@@ -91,15 +83,15 @@ function openGraphHelper(options = {}) {
   }
 
   if (url) url = encodeURL(url);
-  result += og('og:url', url, false);
+  result += og('og:url', url);
 
   result += og('og:site_name', siteName);
   if (description) {
-    result += og('og:description', description, false);
+    result += og('og:description', description);
   }
 
   if (language) {
-    result += og('og:locale', language, false);
+    result += og('og:locale', language);
   }
 
   images = images.map(path => {
@@ -113,7 +105,7 @@ function openGraphHelper(options = {}) {
   });
 
   images.forEach(path => {
-    result += og('og:image', path, false);
+    result += og('og:image', path);
   });
 
   if (updated) {
@@ -125,7 +117,7 @@ function openGraphHelper(options = {}) {
   result += meta('twitter:card', twitterCard);
 
   if (images.length) {
-    result += meta('twitter:image', images[0], false);
+    result += meta('twitter:image', images[0]);
   }
 
   if (options.twitter_id) {
@@ -136,7 +128,7 @@ function openGraphHelper(options = {}) {
   }
 
   if (options.twitter_site) {
-    result += meta('twitter:site', options.twitter_site, false);
+    result += meta('twitter:site', options.twitter_site);
   }
 
   if (options.google_plus) {

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -90,6 +90,11 @@ function openGraphHelper(options = {}) {
     url = url.replace(/index\.html$/, '');
   }
 
+  url = urlFn.format({
+    protocol: urlFn.parse(url).protocol,
+    hostname: urlFn.parse(url).hostname,
+    pathname: encodeURI(urlFn.parse(url).pathname)
+  });
   result += og('og:url', url, false);
 
   result += og('og:site_name', siteName);

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -2,7 +2,7 @@
 
 const urlFn = require('url');
 const moment = require('moment');
-const { escapeHTML, htmlTag, stripHTML } = require('hexo-util');
+const { encodeURL, escapeHTML, htmlTag, stripHTML } = require('hexo-util');
 
 function meta(name, content, escape) {
   if (escape !== false && typeof content === 'string') {
@@ -90,13 +90,7 @@ function openGraphHelper(options = {}) {
     url = url.replace(/index\.html$/, '');
   }
 
-  if (url) {
-    url = urlFn.format({
-      protocol: urlFn.parse(url).protocol,
-      hostname: urlFn.parse(url).hostname,
-      pathname: encodeURI(urlFn.parse(url).pathname)
-    });
-  }
+  if (url) url = encodeURL(url);
   result += og('og:url', url, false);
 
   result += og('og:site_name', siteName);

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hexo-fs": "^2.0.0",
     "hexo-i18n": "^1.0.0",
     "hexo-log": "^1.0.0",
-    "hexo-util": "^1.3.1",
+    "hexo-util": "^1.4.0",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",
     "micromatch": "^4.0.2",

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -129,6 +129,19 @@ describe('open_graph', () => {
     hexo.config.pretty_urls.trailing_index = true;
   });
 
+  it('url - IDN', () => {
+    const ctx = {
+      page: {},
+      config: hexo.config,
+      is_post: isPost,
+      url: 'https://foô.com/bár'
+    };
+
+    const result = openGraph.call(ctx);
+
+    result.should.contain(meta({property: 'og:url', content: 'https://xn--fo-9ja.com/b%C3%A1r'}));
+  });
+
   it('images - content', () => {
     const result = openGraph.call({
       page: {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -10,7 +10,6 @@ describe('open_graph', () => {
   const isPost = require('../../../lib/plugins/helper/is').post;
   const tag = require('hexo-util').htmlTag;
   const Post = hexo.model('Post');
-  const cheerio = require('cheerio');
 
   function meta(options) {
     return tag('meta', options);
@@ -592,8 +591,7 @@ describe('open_graph', () => {
     const result = openGraph.call(ctx);
     const keywords = 'optimize,web&amp;&lt;&gt;&quot;&#39;&#x2F;,site';
 
-    const $ = cheerio.load(result, { decodeEntities: false });
-    $('meta[name="keywords"]').attr('content').should.eql(keywords);
+    result.should.contain(meta({name: 'keywords', content: keywords}));
   });
 
   it('og:locale - options.language', () => {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -10,6 +10,7 @@ describe('open_graph', () => {
   const isPost = require('../../../lib/plugins/helper/is').post;
   const tag = require('hexo-util').htmlTag;
   const Post = hexo.model('Post');
+  const cheerio = require('cheerio');
 
   function meta(options) {
     return tag('meta', options);
@@ -591,7 +592,8 @@ describe('open_graph', () => {
     const result = openGraph.call(ctx);
     const keywords = 'optimize,web&amp;&lt;&gt;&quot;&#39;&#x2F;,site';
 
-    result.should.contain(meta({name: 'keywords', content: keywords}));
+    const $ = cheerio.load(result, { decodeEntities: false });
+    $('meta[name="keywords"]').attr('content').should.eql(keywords);
   });
 
   it('og:locale - options.language', () => {

--- a/test/scripts/tags/asset_img.js
+++ b/test/scripts/tags/asset_img.js
@@ -50,7 +50,7 @@ describe('asset_img', () => {
   });
 
   it('default', () => {
-    assetImg('bar title').should.eql('<img src="/foo/bar" class="" title="title">');
+    assetImg('bar "a title"').should.eql('<img src="/foo/bar" class="" title="a title">');
   });
 
   it('with space', () => {
@@ -60,13 +60,13 @@ describe('asset_img', () => {
   });
 
   it('with alt and title', () => {
-    assetImgTag.call(post, ['bar', '"title"', '"alt"'])
-      .should.eql('<img src="/foo/bar" class="" title="title" alt="alt">');
+    assetImgTag.call(post, ['bar', '"a title"', '"an alt"'])
+      .should.eql('<img src="/foo/bar" class="" title="a title" alt="an alt">');
   });
 
   it('with width height alt and title', () => {
-    assetImgTag.call(post, ['bar', '100', '200', '"title"', '"alt"'])
-      .should.eql('<img src="/foo/bar" class="" width="100" height="200" title="title" alt="alt">');
+    assetImgTag.call(post, ['bar', '100', '200', '"a title"', '"an alt"'])
+      .should.eql('<img src="/foo/bar" class="" width="100" height="200" title="a title" alt="an alt">');
   });
 
   it('no slug', () => {


### PR DESCRIPTION
root/path value should be percent-encoded, not html escaped.

## What does it do?

``` yml
_config.yml
url: https://日本語テストgôg.com/hexô-testing
```

### Current behavior
``` html
<meta property="og:url" content="https://&#x65E5;&#x672C;&#x8A9E;&#x30C6;&#x30B9;&#x30C8;g&#xF4;g.com/hex&#xF4;-testing/index.html">
```

### Expected behavior
``` html
<meta property="og:url" content="https://xn--gg-8ja8200c3ban0926g0ecl32k.com/hex%C3%B4-testing/index.html">
```

## How to test

```sh
git clone -b url-encoding https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
