### PR TITLE
feat(css_helper): add support for custom attributes

### DIFF
--- a/lib/plugins/helper/css.js
+++ b/lib/plugins/helper/css.js
@@ -1,15 +1,50 @@
 'use strict';
 
-function cssHelper(...args) {
-  return args.reduce((result, path, i) => {
-    if (i) result += '\n';
-
-    if (Array.isArray(path)) {
-      return result + Reflect.apply(cssHelper, this, path);
+const flatten = function(arr, result = []) {
+  for (const i in arr) {
+    const value = arr[i];
+    if (Array.isArray(value)) {
+      flatten(value, result);
+    } else {
+      result.push(value);
     }
-    if (!path.includes('?') && !path.endsWith('.css')) path += '.css';
-    return `${result}<link rel="stylesheet" href="${this.url_for(path)}">`;
-  }, '');
+  }
+  return result;
+};
+
+function cssHelper(...args) {
+  let result = '\n';
+  let items = args;
+
+  if (!Array.isArray(args)) {
+    items = [args];
+  }
+
+  items = flatten(items);
+
+  items.forEach(item => {
+    // Old syntax
+    if (typeof item === 'string' || item instanceof String) {
+      let path = item;
+      if (!path.endsWith('.css')) {
+        path += '.css';
+      }
+      result += `<link rel="stylesheet" href="${this.url_for(path)}">\n`;
+    } else {
+      // New syntax
+      let tmpResult = '<link rel="stylesheet"';
+      for (const attribute in item) {
+        if (attribute === 'href') {
+          item[attribute] = this.url_for(item[attribute]);
+          if (!item[attribute].endsWith('.css')) item[attribute] += '.css';
+        }
+        tmpResult += ` ${attribute}="${item[attribute]}"`;
+      }
+      tmpResult += '>\n';
+      result += tmpResult;
+    }
+  });
+  return result;
 }
 
 module.exports = cssHelper;

--- a/lib/plugins/helper/css.js
+++ b/lib/plugins/helper/css.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const { htmlTag } = require('hexo-util');
+const url_for = require('./url_for');
+
 const flatten = function(arr, result = []) {
   for (const i in arr) {
     const value = arr[i];
@@ -32,16 +35,9 @@ function cssHelper(...args) {
       result += `<link rel="stylesheet" href="${this.url_for(path)}">\n`;
     } else {
       // New syntax
-      let tmpResult = '<link rel="stylesheet"';
-      Object.keys(item).forEach(attribute => {
-        if (attribute === 'href') {
-          item[attribute] = this.url_for(item[attribute]);
-          if (!item[attribute].endsWith('.css')) item[attribute] += '.css';
-        }
-        tmpResult += ` ${attribute}="${item[attribute]}"`;
-      });
-      tmpResult += '>\n';
-      result += tmpResult;
+      item.href = url_for.call(this, item.href);
+      if (!item.href.endsWith('.css')) item.href += '.css';
+      result += htmlTag('link', { rel: 'stylesheet', ...item }) + '\n';
     }
   });
   return result;

--- a/lib/plugins/helper/css.js
+++ b/lib/plugins/helper/css.js
@@ -33,13 +33,13 @@ function cssHelper(...args) {
     } else {
       // New syntax
       let tmpResult = '<link rel="stylesheet"';
-      for (const attribute in item) {
+      Object.keys(item).forEach(attribute => {
         if (attribute === 'href') {
           item[attribute] = this.url_for(item[attribute]);
           if (!item[attribute].endsWith('.css')) item[attribute] += '.css';
         }
         tmpResult += ` ${attribute}="${item[attribute]}"`;
-      }
+      });
       tmpResult += '>\n';
       result += tmpResult;
     }


### PR DESCRIPTION
## What does it do?
This is mainly to add [subresource integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) (SRI) to `<layout>`, though arbitrary attributes are supported as well.

Existing syntax is still supported (credit to https://github.com/hexojs/hexo/pull/3681#issuecomment-524648521).

Supported syntax:
- `<%- css('layout.css') %>`
- `<%- css(['layout.css', 'gallery.css']) %>`
- `<%- css({href: 'layout.css', integrity: 'hash-value'}) %>`
- `<%- css({href: 'layout.css', integrity: 'hash-value'}) %>`
- `<%- css({href: 'layout.css', integrity: 'hash-value'}, {href: 'gallery.css', integrity: 'hash-stuff'}) %>`
- `<%- css([{href: 'layout.css', integrity: 'hash-value'}, {href: 'gallery.css', integrity: 'hash-stuff'}]) %>`
- `<%- css([{href: 'layout.css', integrity: 'hash-value'}, {href: 'gallery.css', integrity: 'hash-stuff'}]) %>`

Related to #3681, without support of `async` nor `defer` (not used in `<link>`).

## How to test

```sh
git clone -b sri-css https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
