### PR TITLE
feat(permalink): add pretty_urls option to remove index.html from url

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -13,7 +13,9 @@ module.exports = {
   root: '/',
   permalink: ':year/:month/:day/:title/',
   permalink_defaults: {},
-  canonical_url: false,
+  trailing_url: {
+    trailing_index: true
+  },
   // Directory
   source_dir: 'source',
   public_dir: 'public',

--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -13,6 +13,7 @@ module.exports = {
   root: '/',
   permalink: ':year/:month/:day/:title/',
   permalink_defaults: {},
+  canonical_url: false,
   // Directory
   source_dir: 'source',
   public_dir: 'public',

--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -13,7 +13,7 @@ module.exports = {
   root: '/',
   permalink: ':year/:month/:day/:title/',
   permalink_defaults: {},
-  trailing_url: {
+  pretty_urls: {
     trailing_index: true
   },
   // Directory

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -40,7 +40,7 @@ module.exports = ctx => {
   Category.virtual('permalink').get(function() {
     const { config } = ctx;
     let partial_url = this.path;
-    if (config.trailing_url.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
     return `${ctx.config.url}/${partial_url}`;
   });
 

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -38,7 +38,10 @@ module.exports = ctx => {
   });
 
   Category.virtual('permalink').get(function() {
-    return `${ctx.config.url}/${this.path}`;
+    const { config } = ctx;
+    let partial_url = this.path;
+    if (config.canonical_url) partial_url = partial_url.replace(/index\.html$/, '');
+    return `${ctx.config.url}/${partial_url}`;
   });
 
   Category.virtual('posts').get(function() {

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -40,7 +40,7 @@ module.exports = ctx => {
   Category.virtual('permalink').get(function() {
     const { config } = ctx;
     let partial_url = this.path;
-    if (config.canonical_url) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.trailing_url.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
     return `${ctx.config.url}/${partial_url}`;
   });
 

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -34,7 +34,7 @@ module.exports = ctx => {
   Page.virtual('permalink').get(function() {
     const { config } = ctx;
     let partial_url = this.path;
-    if (config.trailing_url.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
     return `${ctx.config.url}/${partial_url}`;
   });
 

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -32,7 +32,10 @@ module.exports = ctx => {
   });
 
   Page.virtual('permalink').get(function() {
-    return `${ctx.config.url}/${this.path}`;
+    const { config } = ctx;
+    let partial_url = this.path;
+    if (config.canonical_url) partial_url = partial_url.replace(/index\.html$/, '');
+    return `${ctx.config.url}/${partial_url}`;
   });
 
   Page.virtual('full_source').get(function() {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -34,7 +34,7 @@ module.exports = ctx => {
   Page.virtual('permalink').get(function() {
     const { config } = ctx;
     let partial_url = this.path;
-    if (config.canonical_url) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.trailing_url.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
     return `${ctx.config.url}/${partial_url}`;
   });
 

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -54,6 +54,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = self.url_for(this.path);
     if (config.relative_link) partial_url = `/${partial_url}`;
+    if (config.canonical_url) partial_url = partial_url.replace(/index\.html$/, '');
     return config.url + partial_url.replace(config.root, '/');
   });
 

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -54,7 +54,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = self.url_for(this.path);
     if (config.relative_link) partial_url = `/${partial_url}`;
-    if (config.canonical_url) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.trailing_url.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
     return config.url + partial_url.replace(config.root, '/');
   });
 

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -54,7 +54,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = self.url_for(this.path);
     if (config.relative_link) partial_url = `/${partial_url}`;
-    if (config.trailing_url.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
     return config.url + partial_url.replace(config.root, '/');
   });
 

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -29,7 +29,10 @@ module.exports = ctx => {
   });
 
   Tag.virtual('permalink').get(function() {
-    return `${ctx.config.url}/${this.path}`;
+    const { config } = ctx;
+    let partial_url = this.path;
+    if (config.canonical_url) partial_url = partial_url.replace(/index\.html$/, '');
+    return `${ctx.config.url}/${partial_url}`;
   });
 
   Tag.virtual('posts').get(function() {

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -31,7 +31,7 @@ module.exports = ctx => {
   Tag.virtual('permalink').get(function() {
     const { config } = ctx;
     let partial_url = this.path;
-    if (config.trailing_url.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
     return `${ctx.config.url}/${partial_url}`;
   });
 

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -31,7 +31,7 @@ module.exports = ctx => {
   Tag.virtual('permalink').get(function() {
     const { config } = ctx;
     let partial_url = this.path;
-    if (config.canonical_url) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.trailing_url.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
     return `${ctx.config.url}/${partial_url}`;
   });
 

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -110,6 +110,7 @@ describe('Category', () => {
       name: 'foo'
     }).then(data => {
       data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
+      hexo.config.pretty_urls.trailing_index = true;
       return Category.removeById(data._id);
     });
   });

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -104,6 +104,16 @@ describe('Category', () => {
     return Category.removeById(data._id);
   }));
 
+  it('permalink - canonical_url', () => {
+    hexo.config.canonical_url = true;
+    return Category.insert({
+      name: 'foo'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
+      return Category.removeById(data._id);
+    });
+  });
+
   it('posts - virtual', () => Post.insert([
     {source: 'foo.md', slug: 'foo'},
     {source: 'bar.md', slug: 'bar'},

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -105,7 +105,7 @@ describe('Category', () => {
   }));
 
   it('permalink - trailing_index', () => {
-    hexo.config.trailing_url.trailing_index = false;
+    hexo.config.pretty_urls.trailing_index = false;
     return Category.insert({
       name: 'foo'
     }).then(data => {

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -104,8 +104,8 @@ describe('Category', () => {
     return Category.removeById(data._id);
   }));
 
-  it('permalink - canonical_url', () => {
-    hexo.config.canonical_url = true;
+  it('permalink - trailing_index', () => {
+    hexo.config.trailing_url.trailing_index = false;
     return Category.insert({
       name: 'foo'
     }).then(data => {

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -60,13 +60,14 @@ describe('Page', () => {
     return Page.removeById(data._id);
   }));
 
-  it('permalink - canonical_url', () => {
+  it('permalink - trailing_index', () => {
     hexo.config.pretty_urls.trailing_index = false;
     return Page.insert({
       source: 'foo.md',
       path: 'bar/index.html'
     }).then(data => {
       data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
+      hexo.config.pretty_urls.trailing_index = true;
       return Page.removeById(data._id);
     });
   });

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -61,7 +61,7 @@ describe('Page', () => {
   }));
 
   it('permalink - canonical_url', () => {
-    hexo.config.trailing_url.trailing_index = false;
+    hexo.config.pretty_urls.trailing_index = false;
     return Page.insert({
       source: 'foo.md',
       path: 'bar/index.html'

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -60,6 +60,17 @@ describe('Page', () => {
     return Page.removeById(data._id);
   }));
 
+  it('permalink - canonical_url', () => {
+    hexo.config.canonical_url = true;
+    return Page.insert({
+      source: 'foo.md',
+      path: 'bar/index.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
+      return Page.removeById(data._id);
+    });
+  });
+
   it('full_source - virtual', () => Page.insert({
     source: 'foo',
     path: 'bar'

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -61,7 +61,7 @@ describe('Page', () => {
   }));
 
   it('permalink - canonical_url', () => {
-    hexo.config.canonical_url = true;
+    hexo.config.trailing_url.trailing_index = false;
     return Page.insert({
       source: 'foo.md',
       path: 'bar/index.html'

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -121,6 +121,17 @@ describe('Post', () => {
     });
   });
 
+  it('permalink - canonical_url', () => {
+    hexo.config.canonical_url = true;
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bar'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
+      return Post.removeById(data._id);
+    });
+  });
+
   it('full_source - virtual', () => Post.insert({
     source: 'foo.md',
     slug: 'bar'

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -121,13 +121,14 @@ describe('Post', () => {
     });
   });
 
-  it('permalink - canonical_url', () => {
+  it('permalink - trailing_index', () => {
     hexo.config.pretty_urls.trailing_index = false;
     return Post.insert({
       source: 'foo.md',
       slug: 'bar'
     }).then(data => {
       data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
+      hexo.config.pretty_urls.trailing_index = true;
       return Post.removeById(data._id);
     });
   });

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -122,7 +122,7 @@ describe('Post', () => {
   });
 
   it('permalink - canonical_url', () => {
-    hexo.config.trailing_url.trailing_index = false;
+    hexo.config.pretty_urls.trailing_index = false;
     return Post.insert({
       source: 'foo.md',
       slug: 'bar'

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -122,7 +122,7 @@ describe('Post', () => {
   });
 
   it('permalink - canonical_url', () => {
-    hexo.config.canonical_url = true;
+    hexo.config.trailing_url.trailing_index = false;
     return Post.insert({
       source: 'foo.md',
       slug: 'bar'

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -89,12 +89,13 @@ describe('Tag', () => {
     return Tag.removeById(data._id);
   }));
 
-  it('permalink - canonical_url', () => {
+  it('permalink - trailing_index', () => {
     hexo.config.pretty_urls.trailing_index = false;
     return Tag.insert({
       name: 'foo'
     }).then(data => {
       data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
+      hexo.config.pretty_urls.trailing_index = true;
       return Tag.removeById(data._id);
     });
   });

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -89,6 +89,16 @@ describe('Tag', () => {
     return Tag.removeById(data._id);
   }));
 
+  it('permalink - canonical_url', () => {
+    hexo.config.canonical_url = true;
+    return Tag.insert({
+      name: 'foo'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
+      return Tag.removeById(data._id);
+    });
+  });
+
   it('posts - virtual', () => Post.insert([
     {source: 'foo.md', slug: 'foo'},
     {source: 'bar.md', slug: 'bar'},

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -90,7 +90,7 @@ describe('Tag', () => {
   }));
 
   it('permalink - canonical_url', () => {
-    hexo.config.trailing_url.trailing_index = false;
+    hexo.config.pretty_urls.trailing_index = false;
     return Tag.insert({
       name: 'foo'
     }).then(data => {

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -90,7 +90,7 @@ describe('Tag', () => {
   }));
 
   it('permalink - canonical_url', () => {
-    hexo.config.canonical_url = true;
+    hexo.config.trailing_url.trailing_index = false;
     return Tag.insert({
       name: 'foo'
     }).then(data => {


### PR DESCRIPTION
## What does it do?
Currently `permalink` variable of post, page, tag, category may end with "index.html". This PR adds `canonical_url` option to remove that. `canonical_url` defaults to false to avoid breaking change.

This is useful for SEO when web server (including `hexo server`) rewrite "index.html", so the url without it is the canonical version.

This way, plugins that use post.permalink don't need to remove it. Tested with [hexo-generator-sitemap](https://github.com/hexojs/hexo-generator-sitemap).
Related:
- https://github.com/hexojs/hexo-generator-sitemap/pull/59
- https://github.com/hexojs/hexo-generator-sitemap/issues/13

Note this PR doesn't cover `this.url`(https://github.com/hexojs/hexo/pull/3661).

## How to test

```sh
git clone -b canonical https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.

Fixes #1306 cc @sapegin @pyyzcwg2833