### PR TITLE
refactor(meta_generator): update regex and avoid edge case

### DIFF
--- a/lib/plugins/filter/meta_generator.js
+++ b/lib/plugins/filter/meta_generator.js
@@ -7,7 +7,7 @@ function hexoMetaGeneratorInject(data) {
 
   const hexoGeneratorTag = `<meta name="generator" content="Hexo ${this.version}">`;
 
-  return data.replace('</title>', '</title>' + hexoGeneratorTag);
+  return data.replace(/<head>(?!<\/head>).+?<\/head>/, (str) => str.replace('</head>', `${hexoGeneratorTag}</head>`));
 }
 
 module.exports = hexoMetaGeneratorInject;

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -7,7 +7,7 @@ describe('Meta Generator', () => {
   const cheerio = require('cheerio');
 
   it('default', () => {
-    const content = '<head><title>foo</title></head>';
+    const content = '<head><link></head>';
     const result = metaGenerator(content);
 
     const $ = cheerio.load(result);
@@ -16,7 +16,7 @@ describe('Meta Generator', () => {
   });
 
   it('disable meta_generator', () => {
-    const content = '<head><title>foo</title></head>';
+    const content = '<head><link></head>';
     hexo.config.meta_generator = false;
     const result = metaGenerator(content);
 
@@ -25,7 +25,7 @@ describe('Meta Generator', () => {
   });
 
   it('no duplicate generator tag', () => {
-    const content = '<head><title>foo</title>'
+    const content = '<head><link>'
       + '<meta name="generator" content="foo"></head>';
     hexo.config.meta_generator = true;
     const result = metaGenerator(content);
@@ -37,7 +37,6 @@ describe('Meta Generator', () => {
   it('ignore empty head tag', () => {
     const content = '<head></head>'
       + '<head><link></head>'
-      + '<head><link></head>'
       + '<head></head>';
     hexo.config.meta_generator = true;
     const result = metaGenerator(content);
@@ -47,8 +46,23 @@ describe('Meta Generator', () => {
 
     const expected = '<head></head>'
     + '<head><link><meta name="generator" content="Hexo ' + hexo.version + '"></head>'
-    + '<head><link></head>'
     + '<head></head>';
+    result.should.eql(expected);
+  });
+
+  it('apply to first non-empty head tag only', () => {
+    const content = '<head></head>'
+      + '<head><link></head>'
+      + '<head><link></head>';
+    hexo.config.meta_generator = true;
+    const result = metaGenerator(content);
+
+    const $ = cheerio.load(result);
+    $('meta[name="generator"]').length.should.eql(1);
+
+    const expected = '<head></head>'
+    + '<head><link><meta name="generator" content="Hexo ' + hexo.version + '"></head>'
+    + '<head><link></head>';
     result.should.eql(expected);
   });
 });

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -12,6 +12,7 @@ describe('Meta Generator', () => {
 
     const $ = cheerio.load(result);
     $('meta[name="generator"]').length.should.eql(1);
+    $('meta[name="generator"]').attr('content').should.eql(`Hexo ${hexo.version}`);
   });
 
   it('disable meta_generator', () => {
@@ -31,5 +32,23 @@ describe('Meta Generator', () => {
 
     const resultType = typeof result;
     resultType.should.eql('undefined');
+  });
+
+  it('ignore empty head tag', () => {
+    const content = '<head></head>'
+      + '<head><link></head>'
+      + '<head><link></head>'
+      + '<head></head>';
+    hexo.config.meta_generator = true;
+    const result = metaGenerator(content);
+
+    const $ = cheerio.load(result);
+    $('meta[name="generator"]').length.should.eql(1);
+
+    const expected = '<head></head>'
+    + '<head><link><meta name="generator" content="Hexo ' + hexo.version + '"></head>'
+    + '<head><link></head>'
+    + '<head></head>';
+    result.should.eql(expected);
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

After #3671 & #3696 , meta_generator filter will replace `</title>` with `<meta name="generator" content="Hexo ${hexo.version}"></title>`.

@curbengh [has mentioned](https://github.com/hexojs/hexo/pull/3696#issuecomment-526819260) some [edge cases](https://github.com/hexojs/hexo/pull/3696#issuecomment-526822365) will cause unwanted behavior:

```html
<html>
<head>
<!-- A inline svg in css might include <title> tag -->
<style>
  .foo {
    background: url(data:image/svg+xml;utf8,<svg width="500" height="300" xmlns="http://www.w3.org/2000/svg"><g><title>svg</title></g></svg>);
  }    
</style>
<title>TITLE</title>
</head>
...
</html>
```

This PR introduce replacing `</head>` with `<meta name="generator" content="Hexo ${hexo.version}"></head>` with [a pattern](https://regex101.com/r/4yIsOT/1/) that [ignore empty `<head>` tag](https://github.com/hexojs/hexo/pull/3315).

## How to test

```sh
git clone -b meta-generator https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

A test case about `ignore empty head tag` has been added in this PR as well. 

## Screenshots

According to [benchmark](https://travis-ci.com/theme-suka/performance-test), use regex to match `</head>` is about `1%` slower than replace `</title>` directly.

| | NodeJS 8 | NodeJS 10 | NodeJS 12 |
|:---:|:---:|:---:|:---:| 
| Disable `meta_generator` | 6.15s | 5.18s | 5.85s  |
| Replace `</title>` directly (current master branch) | 6.25s | 5.25s | 5.94s |
| This PR | 6.3s | 5.30s | 5.94s |

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
