### PR TITLE
feat(full_url_for): utilize hexo-util module

### DIFF
--- a/lib/plugins/helper/full_url_for.js
+++ b/lib/plugins/helper/full_url_for.js
@@ -3,7 +3,7 @@
 const { parse } = require('url');
 
 function urlForHelper(path = '/') {
-  if (path[0] === '#' || path.startsWith('//')) {
+  if (path.startsWith('//')) {
     return path;
   }
 

--- a/lib/plugins/helper/full_url_for.js
+++ b/lib/plugins/helper/full_url_for.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const { parse } = require('url');
+
+function urlForHelper(path = '/') {
+  if (path[0] === '#' || path.startsWith('//')) {
+    return path;
+  }
+
+  const { config } = this;
+  const data = parse(path);
+
+  // Exit if this is an external path
+  if (data.protocol) {
+    return path;
+  }
+
+  // Prepend root path
+  path = config.url + `/${path}`.replace(/\/{2,}/g, '/');
+  return path;
+}
+
+module.exports = urlForHelper;

--- a/lib/plugins/helper/full_url_for.js
+++ b/lib/plugins/helper/full_url_for.js
@@ -1,23 +1,6 @@
 'use strict';
+const { full_url_for } = require('hexo-util');
 
-const { parse } = require('url');
-
-function urlForHelper(path = '/') {
-  if (path.startsWith('//')) {
-    return path;
-  }
-
-  const { config } = this;
-  const data = parse(path);
-
-  // Exit if this is an external path
-  if (data.protocol) {
-    return path;
-  }
-
-  // Prepend root path
-  path = config.url + `/${path}`.replace(/\/{2,}/g, '/');
-  return path;
-}
-
-module.exports = urlForHelper;
+module.exports = function(path = '/') {
+  return full_url_for.call(this, path);
+};

--- a/lib/plugins/helper/full_url_for.js
+++ b/lib/plugins/helper/full_url_for.js
@@ -1,6 +1,6 @@
 'use strict';
 const { full_url_for } = require('hexo-util');
 
-module.exports = function(path = '/') {
+module.exports = function(path) {
   return full_url_for.call(this, path);
 };

--- a/lib/plugins/helper/index.js
+++ b/lib/plugins/helper/index.js
@@ -70,6 +70,7 @@ module.exports = ctx => {
 
   helper.register('relative_url', require('./relative_url'));
   helper.register('url_for', require('./url_for'));
+  helper.register('full_url_for', require('./full_url_for'));
 
   const debug = require('./debug');
   helper.register('inspect', debug.inspectObject);

--- a/test/scripts/helpers/full_url_for.js
+++ b/test/scripts/helpers/full_url_for.js
@@ -2,18 +2,16 @@
 
 describe('full_url_for', () => {
   const ctx = {
-    config: {}
+    config: { url: 'https://example.com' }
   };
 
   const fullUrlFor = require('../../../lib/plugins/helper/full_url_for').bind(ctx);
 
-  it('internal url', () => {
-    ctx.config.root = '/';
-    fullUrlFor('index.html').should.eql(ctx.config.url + '/index.html');
-    fullUrlFor('/').should.eql(ctx.config.url + '/');
-    fullUrlFor('/index.html').should.eql(ctx.config.url + '/index.html');
+  it('no path input', () => {
+    fullUrlFor().should.eql(ctx.config.url + '/');
+  });
 
-    ctx.config.root = '/blog/';
+  it('internal url', () => {
     fullUrlFor('index.html').should.eql(ctx.config.url + '/index.html');
     fullUrlFor('/').should.eql(ctx.config.url + '/');
     fullUrlFor('/index.html').should.eql(ctx.config.url + '/index.html');

--- a/test/scripts/helpers/full_url_for.js
+++ b/test/scripts/helpers/full_url_for.js
@@ -29,6 +29,6 @@ describe('full_url_for', () => {
   });
 
   it('only hash', () => {
-    fullUrlFor('#test').should.eql('#test');
+    fullUrlFor('#test').should.eql(ctx.config.url + '/#test');
   });
 });

--- a/test/scripts/helpers/full_url_for.js
+++ b/test/scripts/helpers/full_url_for.js
@@ -1,0 +1,34 @@
+'use strict';
+
+describe('full_url_for', () => {
+  const ctx = {
+    config: {}
+  };
+
+  const fullUrlFor = require('../../../lib/plugins/helper/full_url_for').bind(ctx);
+
+  it('internal url', () => {
+    ctx.config.root = '/';
+    fullUrlFor('index.html').should.eql(ctx.config.url + '/index.html');
+    fullUrlFor('/').should.eql(ctx.config.url + '/');
+    fullUrlFor('/index.html').should.eql(ctx.config.url + '/index.html');
+
+    ctx.config.root = '/blog/';
+    fullUrlFor('index.html').should.eql(ctx.config.url + '/index.html');
+    fullUrlFor('/').should.eql(ctx.config.url + '/');
+    fullUrlFor('/index.html').should.eql(ctx.config.url + '/index.html');
+  });
+
+  it('external url', () => {
+    [
+      'https://hexo.io/',
+      '//google.com/'
+    ].forEach(url => {
+      fullUrlFor(url).should.eql(url);
+    });
+  });
+
+  it('only hash', () => {
+    fullUrlFor('#test').should.eql('#test');
+  });
+});

--- a/test/scripts/helpers/index.js
+++ b/test/scripts/helpers/index.js
@@ -7,6 +7,7 @@ describe('Helpers', () => {
   require('./favicon_tag');
   require('./feed_tag');
   require('./fragment_cache');
+  require('./full_url_for');
   require('./gravatar');
   require('./image_tag');
   require('./is');


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do? 

https://github.com/hexojs/hexo-util/pull/84

Returns a url with the `config.url` prefixed.

**Use Case 1**

`link[canonical]` tag, which is one of a best practice for SEO, needs an absolute url of current page.

According to [the test carried out by theme NexT team](https://github.com/theme-next/hexo-theme-next/pull/1143#issuecomment-526828133):

> `{{ page.permalink }}` works on every page exclude index and archive page.
> `{{ url }}` is everywhere.

A `full_url_for(page.path)` can be used in this case.

**Use Case 2**

Use url to share the post at social media, which is similar to the first case:

- Sina Weibo `http://service.weibo.com/share/share.php?appkey=&title=[title]&url=[url]&pic=[site logo]&searchPic=false&style=simple`
- Twitter `https://twitter.com/intent/tweet?text=[title]&url=[url]`
- Facebook `https://www.facebook.com/sharer/sharer.php?u=[url]`
- Telegram `https://t.me/share/url?url=[url]&text=[title]`

Absolute urls are needed for `[url]` and `[site logo]`, and `full_url_for(page.path)` & `full_url_for(${site_logo_url})` can be used.

**Use Case 3**

All examples of [structured data](https://developers.google.com/search/docs/guides/intro-structured-data) (Image, Page path...) and [open-graph](https://ogp.me/) use absolute urls. If they are best practices, then `full_url_for` helper can be used.

## How to test

```sh
git clone -b full_url_for https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

I have implemented a [`_full_url_for`](https://github.com/SukkaW/hexo-theme-suka/blob/529b05e723365722861661eae23dd98d5870973d/includes/helpers/url_for.js) for my suka theme and it works perfectly.

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
