### PR TITLE
fix post_link, asset_link when title contains <,>," charaters

### DIFF
--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -7,7 +7,7 @@ const { escapeHTML } = require('hexo-util');
  * Asset link tag
  *
  * Syntax:
- *   {% asset_link slug [escape] [title] %}
+ *   {% asset_link slug [title] [escape] %}
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
@@ -19,20 +19,16 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    let escape = args[0];
+    let escape = args[args.length - 1];
     if (escape === 'true' || escape === 'false') {
-      args.shift();
+      args.pop();
     } else {
       escape = 'true';
     }
 
     let title = args.length ? args.join(' ') : asset.slug;
-    let attrTitle;
-    if (escape === 'true') {
-      attrTitle = title = escapeHTML(title);
-    } else {
-      attrTitle = escapeHTML(title);
-    }
+    const attrTitle = escapeHTML(title);
+    if (escape === 'true') title = attrTitle;
 
     return `<a href="${url.resolve(ctx.config.root, asset.path)}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const url = require('url');
-const util = require('hexo-util');
-const escapeHTML = util.escapeHTML;
+const { escapeHTML }  = require('hexo-util');
 
 /**
  * Asset link tag

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const url = require('url');
-const { escapeHTML }  = require('hexo-util');
+const { escapeHTML } = require('hexo-util');
 
 /**
  * Asset link tag

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -23,7 +23,7 @@ module.exports = ctx => {
     if (escape === 'true' || escape === 'false') {
       args.shift();
     } else {
-      escape = 'false';
+      escape = 'true';
     }
 
     let title = args.length ? args.join(' ') : asset.slug;

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -7,7 +7,7 @@ const { escapeHTML } = require('hexo-util');
  * Asset link tag
  *
  * Syntax:
- *   {% asset_link slug [title] %}
+ *   {% asset_link slug [escape] [title] %}
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
@@ -19,8 +19,21 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const title = escapeHTML(args.length ? args.join(' ') : asset.slug);
+    let escape = args[0];
+    if (escape === 'true' || escape === 'false') {
+      args.shift();
+    } else {
+      escape = 'false';
+    }
 
-    return `<a href="${url.resolve(ctx.config.root, asset.path)}" title="${title}">${title}</a>`;
+    let title = args.length ? args.join(' ') : asset.slug;
+    let attrTitle;
+    if (escape === 'true') {
+      attrTitle = title = escapeHTML(title);
+    } else {
+      attrTitle = escapeHTML(title);
+    }
+
+    return `<a href="${url.resolve(ctx.config.root, asset.path)}" title="${attrTitle}">${title}</a>`;
   };
 };

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const url = require('url');
+const util = require('hexo-util');
+const escapeHTML = util.escapeHTML;
 
 /**
  * Asset link tag
@@ -18,7 +20,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const title = args.length ? args.join(' ') : asset.slug;
+    const title = escapeHTML(args.length ? args.join(' ') : asset.slug);
 
     return `<a href="${url.resolve(ctx.config.root, asset.path)}" title="${title}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -6,7 +6,7 @@ const { escapeHTML } = require('hexo-util');
  * Post link tag
  *
  * Syntax:
- *   {% post_link slug [escape] [title] %}
+ *   {% post_link slug [title] [escape] %}
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
@@ -15,9 +15,9 @@ module.exports = ctx => {
     const slug = args.shift();
     if (!slug) return;
 
-    let escape = args[0];
+    let escape = args[args.length - 1];
     if (escape === 'true' || escape === 'false') {
-      args.shift();
+      args.pop();
     } else {
       escape = 'true';
     }
@@ -26,12 +26,8 @@ module.exports = ctx => {
     if (!post) return;
 
     let title = args.length ? args.join(' ') : post.title;
-    let attrTitle;
-    if (escape === 'true') {
-      attrTitle = title = escapeHTML(title);
-    } else {
-      attrTitle = escapeHTML(title);
-    }
+    const attrTitle = escapeHTML(title);
+    if (escape === 'true') title = attrTitle;
 
     return `<a href="${ctx.config.root}${post.path}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const util = require('hexo-util');
-const escapeHTML = util.escapeHTML;
+const { escapeHTML } = require('hexo-util');
 
 /**
  * Post link tag

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const util = require('hexo-util');
+const escapeHTML = util.escapeHTML;
+
 /**
  * Post link tag
  *
@@ -16,7 +19,7 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const title = args.length ? args.join(' ') : post.title;
+    const title = escapeHTML(args.length ? args.join(' ') : post.title);
 
     return `<a href="${ctx.config.root}${post.path}" title="${title}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -19,7 +19,7 @@ module.exports = ctx => {
     if (escape === 'true' || escape === 'false') {
       args.shift();
     } else {
-      escape = 'false';
+      escape = 'true';
     }
 
     const post = Post.findOne({slug});

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -6,7 +6,7 @@ const { escapeHTML } = require('hexo-util');
  * Post link tag
  *
  * Syntax:
- *   {% post_link slug [title] %}
+ *   {% post_link slug [escape] [title] %}
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
@@ -15,11 +15,24 @@ module.exports = ctx => {
     const slug = args.shift();
     if (!slug) return;
 
+    let escape = args[0];
+    if (escape === 'true' || escape === 'false') {
+      args.shift();
+    } else {
+      escape = 'false';
+    }
+
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const title = escapeHTML(args.length ? args.join(' ') : post.title);
+    let title = args.length ? args.join(' ') : post.title;
+    let attrTitle;
+    if (escape === 'true') {
+      attrTitle = title = escapeHTML(title);
+    } else {
+      attrTitle = escapeHTML(title);
+    }
 
-    return `<a href="${ctx.config.root}${post.path}" title="${title}">${title}</a>`;
+    return `<a href="${ctx.config.root}${post.path}" title="${attrTitle}">${title}</a>`;
   };
 };

--- a/test/scripts/tags/asset_link.js
+++ b/test/scripts/tags/asset_link.js
@@ -44,6 +44,10 @@ describe('asset_link', () => {
     assetLink('bar Hello world').should.eql('<a href="/foo/bar" title="Hello world">Hello world</a>');
   });
 
+  it('title with tag', () => {
+    assetLink('bar Hello <world>').should.eql('<a href="/foo/bar" title="Hello &lt;world&gt;">Hello &lt;world&gt;</a>');
+  });
+
   it('with space', () => {
     // {% asset_link "spaced asset" "spaced title" %}
     assetLinkTag.call(post, ['spaced asset', 'spaced title'])

--- a/test/scripts/tags/asset_link.js
+++ b/test/scripts/tags/asset_link.js
@@ -49,11 +49,11 @@ describe('asset_link', () => {
   });
 
   it('should escape tag in title', () => {
-    assetLink('bar true "Hello" <world>').should.eql('<a href="/foo/bar" title="&quot;Hello&quot; &lt;world&gt;">&quot;Hello&quot; &lt;world&gt;</a>');
+    assetLink('bar "Hello" <world> true').should.eql('<a href="/foo/bar" title="&quot;Hello&quot; &lt;world&gt;">&quot;Hello&quot; &lt;world&gt;</a>');
   });
 
   it('should not escape tag in title', () => {
-    assetLink('bar false "Hello" <b>world</b>').should.eql('<a href="/foo/bar" title="&quot;Hello&quot; &lt;b&gt;world&lt;&#x2F;b&gt;">"Hello" <b>world</b></a>');
+    assetLink('bar "Hello" <b>world</b> false').should.eql('<a href="/foo/bar" title="&quot;Hello&quot; &lt;b&gt;world&lt;&#x2F;b&gt;">"Hello" <b>world</b></a>');
   });
 
   it('with space', () => {

--- a/test/scripts/tags/asset_link.js
+++ b/test/scripts/tags/asset_link.js
@@ -44,6 +44,10 @@ describe('asset_link', () => {
     assetLink('bar Hello world').should.eql('<a href="/foo/bar" title="Hello world">Hello world</a>');
   });
 
+  it('should escape tag in title by default', () => {
+    assetLink('bar "Hello" <world>').should.eql('<a href="/foo/bar" title="&quot;Hello&quot; &lt;world&gt;">&quot;Hello&quot; &lt;world&gt;</a>');
+  });
+
   it('should escape tag in title', () => {
     assetLink('bar true "Hello" <world>').should.eql('<a href="/foo/bar" title="&quot;Hello&quot; &lt;world&gt;">&quot;Hello&quot; &lt;world&gt;</a>');
   });

--- a/test/scripts/tags/asset_link.js
+++ b/test/scripts/tags/asset_link.js
@@ -45,7 +45,11 @@ describe('asset_link', () => {
   });
 
   it('should escape tag in title', () => {
-    assetLink('bar Hello <world>').should.eql('<a href="/foo/bar" title="Hello &lt;world&gt;">Hello &lt;world&gt;</a>');
+    assetLink('bar true "Hello" <world>').should.eql('<a href="/foo/bar" title="&quot;Hello&quot; &lt;world&gt;">&quot;Hello&quot; &lt;world&gt;</a>');
+  });
+
+  it('should not escape tag in title', () => {
+    assetLink('bar false "Hello" <b>world</b>').should.eql('<a href="/foo/bar" title="&quot;Hello&quot; &lt;b&gt;world&lt;&#x2F;b&gt;">"Hello" <b>world</b></a>');
   });
 
   it('with space', () => {

--- a/test/scripts/tags/asset_link.js
+++ b/test/scripts/tags/asset_link.js
@@ -44,7 +44,7 @@ describe('asset_link', () => {
     assetLink('bar Hello world').should.eql('<a href="/foo/bar" title="Hello world">Hello world</a>');
   });
 
-  it('title with tag', () => {
+  it('should escape tag in title', () => {
     assetLink('bar Hello <world>').should.eql('<a href="/foo/bar" title="Hello &lt;world&gt;">Hello &lt;world&gt;</a>');
   });
 

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -27,6 +27,10 @@ describe('post_link', () => {
     postLink(['foo', 'test']).should.eql('<a href="/foo/" title="test">test</a>');
   });
 
+  it('should escape tag in title by default', () => {
+    postLink(['title-with-tag']).should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">&quot;Hello&quot; &lt;new world&gt;!</a>');
+  });
+
   it('should escape tag in title', () => {
     postLink(['title-with-tag', 'true']).should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">&quot;Hello&quot; &lt;new world&gt;!</a>');
   });
@@ -37,10 +41,6 @@ describe('post_link', () => {
 
   it('should not escape tag in title', () => {
     postLink(['title-with-tag', 'false']).should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">"Hello" <new world>!</a>');
-  });
-
-  it('should not escape tag in title by default', () => {
-    postLink(['title-with-tag']).should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">"Hello" <new world>!</a>');
   });
 
   it('should not escape tag in custom title', () => {

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -27,11 +27,11 @@ describe('post_link', () => {
     postLink(['foo', 'test']).should.eql('<a href="/foo/" title="test">test</a>');
   });
 
-  it('default with tag', () => {
+  it('should escape tag in title', () => {
     postLink(['title-with-tag']).should.eql('<a href="/title-with-tag/" title="Hello &lt;new world&gt;!">Hello &lt;new world&gt;!</a>');
   });
 
-  it('title with tag', () => {
+  it('should escape tag in custom title', () => {
     postLink(['title-with-tag', '<test>']).should.eql('<a href="/title-with-tag/" title="&lt;test&gt;">&lt;test&gt;</a>');
   });
 

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -8,11 +8,16 @@ describe('post_link', () => {
 
   hexo.config.permalink = ':title/';
 
-  before(() => hexo.init().then(() => Post.insert({
+  before(() => hexo.init().then(() => Post.insert([{
     source: 'foo',
     slug: 'foo',
     title: 'Hello world'
-  })));
+  },
+  {
+    source: 'title-with-tag',
+    slug: 'title-with-tag',
+    title: 'Hello <new world>!'
+  }])));
 
   it('default', () => {
     postLink(['foo']).should.eql('<a href="/foo/" title="Hello world">Hello world</a>');
@@ -20,6 +25,14 @@ describe('post_link', () => {
 
   it('title', () => {
     postLink(['foo', 'test']).should.eql('<a href="/foo/" title="test">test</a>');
+  });
+
+  it('default with tag', () => {
+    postLink(['title-with-tag']).should.eql('<a href="/title-with-tag/" title="Hello &lt;new world&gt;!">Hello &lt;new world&gt;!</a>');
+  });
+
+  it('title with tag', () => {
+    postLink(['title-with-tag', '<test>']).should.eql('<a href="/title-with-tag/" title="&lt;test&gt;">&lt;test&gt;</a>');
   });
 
   it('no slug', () => {

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -16,7 +16,7 @@ describe('post_link', () => {
   {
     source: 'title-with-tag',
     slug: 'title-with-tag',
-    title: 'Hello <new world>!'
+    title: '"Hello" <new world>!'
   }])));
 
   it('default', () => {
@@ -28,11 +28,24 @@ describe('post_link', () => {
   });
 
   it('should escape tag in title', () => {
-    postLink(['title-with-tag']).should.eql('<a href="/title-with-tag/" title="Hello &lt;new world&gt;!">Hello &lt;new world&gt;!</a>');
+    postLink(['title-with-tag', 'true']).should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">&quot;Hello&quot; &lt;new world&gt;!</a>');
   });
 
   it('should escape tag in custom title', () => {
-    postLink(['title-with-tag', '<test>']).should.eql('<a href="/title-with-tag/" title="&lt;test&gt;">&lt;test&gt;</a>');
+    postLink(['title-with-tag', 'true', '<test>', 'title']).should.eql('<a href="/title-with-tag/" title="&lt;test&gt; title">&lt;test&gt; title</a>');
+  });
+
+  it('should not escape tag in title', () => {
+    postLink(['title-with-tag', 'false']).should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">"Hello" <new world>!</a>');
+  });
+
+  it('should not escape tag in title by default', () => {
+    postLink(['title-with-tag']).should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">"Hello" <new world>!</a>');
+  });
+
+  it('should not escape tag in custom title', () => {
+    postLink(['title-with-tag', 'false', 'This is a <b>Bold</b> "statement"'])
+      .should.eql('<a href="/title-with-tag/" title="This is a &lt;b&gt;Bold&lt;&#x2F;b&gt; &quot;statement&quot;">This is a <b>Bold</b> "statement"</a>');
   });
 
   it('no slug', () => {

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -36,7 +36,7 @@ describe('post_link', () => {
   });
 
   it('should escape tag in custom title', () => {
-    postLink(['title-with-tag', 'true', '<test>', 'title']).should.eql('<a href="/title-with-tag/" title="&lt;test&gt; title">&lt;test&gt; title</a>');
+    postLink(['title-with-tag', '<test>', 'title', 'true']).should.eql('<a href="/title-with-tag/" title="&lt;test&gt; title">&lt;test&gt; title</a>');
   });
 
   it('should not escape tag in title', () => {
@@ -44,7 +44,7 @@ describe('post_link', () => {
   });
 
   it('should not escape tag in custom title', () => {
-    postLink(['title-with-tag', 'false', 'This is a <b>Bold</b> "statement"'])
+    postLink(['title-with-tag', 'This is a <b>Bold</b> "statement"', 'false'])
       .should.eql('<a href="/title-with-tag/" title="This is a &lt;b&gt;Bold&lt;&#x2F;b&gt; &quot;statement&quot;">This is a <b>Bold</b> "statement"</a>');
   });
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

When the title contains `<,>,"` characters, it will cause some errors on browsers.

e.g.
the titles are
- `this is a title with <a tag>.`
- `this is a title with " class="badname`
```
- {% post_link test1 %}
- {% post_link test2 %}
```
generates to
```
<li><a href="/posts/test1/" title="this is a title with <a tag>.">this is a title with </a><a tag="">.</a></li>
<li><a href="/posts/test2/" title="this is a title with " class="badname">this is a title with " class="badname</a>
</li>
```

<img width="828" alt="hexo-2019090602" src="https://user-images.githubusercontent.com/51783821/64396346-eefd7700-d08f-11e9-8b42-156d1005e159.png">


### Solution:
use `util.escapeHTML` function escape the titles.

how to use `post_link` with `escape` option:
```javascript
/**
 * Post link tag
 *
 * Syntax:
 *   {% post_link slug [title] [escape] %}
 */
escape = true or omit; // escape
escape = false; // do not escape
```

e.g.
```ejs
# escape title
- {% post_link test1 %}
- {% post_link test1 '"special" custom <title>' %}
- {% post_link test1 true %}
- {% post_link test1 '"special" custom <title>' true %}

# do not escape title
- {% post_link test2 false %}
- {% post_link test2 '<b>bold custom title</b>' false %}
```

## How to test

```sh
git clone -b fix-post_link-title https://github.com/dailyrandomphoto/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
