### PR TITLE
fix: encode url and permalink by default

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -25,7 +25,7 @@ const defaultConfig = require('./default_config');
 const loadDatabase = require('./load_database');
 const multiConfigPath = require('./multi_config_path');
 const resolve = require('resolve');
-const { encodeURL } = require('hexo-util');
+const full_url_for = require('../plugins/helper/full_url_for');
 
 const { cloneDeep, debounce } = _;
 
@@ -286,13 +286,14 @@ function stopWatcher(box) {
 
 Hexo.prototype._generateLocals = function() {
   const { config, theme } = this;
+  const ctx = { config: { url: this.config.url } };
 
   function Locals(path, locals) {
     this.page = typeof locals === 'object' ? locals : {};
     if (this.page.path == null) this.page.path = path;
 
     this.path = path;
-    this.url = encodeURL(config.url + '/' + path);
+    this.url = full_url_for.call(ctx, path);
   }
 
   Locals.prototype.config = config;

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -25,6 +25,7 @@ const defaultConfig = require('./default_config');
 const loadDatabase = require('./load_database');
 const multiConfigPath = require('./multi_config_path');
 const resolve = require('resolve');
+const { encodeURL } = require('hexo-util');
 
 const { cloneDeep, debounce } = _;
 
@@ -291,7 +292,7 @@ Hexo.prototype._generateLocals = function() {
     if (this.page.path == null) this.page.path = path;
 
     this.path = path;
-    this.url = `${config.url}/${path}`;
+    this.url = encodeURL(config.url + '/' + path);
   }
 
   Locals.prototype.config = config;

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -2,6 +2,7 @@
 
 const { Schema } = require('warehouse');
 const { slugize } = require('hexo-util');
+const { encodeURL } = require('hexo-util');
 
 module.exports = ctx => {
   const Category = new Schema({
@@ -41,7 +42,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = this.path;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return `${ctx.config.url}/${partial_url}`;
+    return encodeURL(ctx.config.url + '/' + this.path);
   });
 
   Category.virtual('posts').get(function() {

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -2,7 +2,7 @@
 
 const { Schema } = require('warehouse');
 const { slugize } = require('hexo-util');
-const { encodeURL } = require('hexo-util');
+const full_url_for = require('../plugins/helper/full_url_for');
 
 module.exports = ctx => {
   const Category = new Schema({
@@ -42,7 +42,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = this.path;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return encodeURL(ctx.config.url + '/' + this.path);
+    return full_url_for.call(ctx, partial_url);
   });
 
   Category.virtual('posts').get(function() {

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -40,9 +40,9 @@ module.exports = ctx => {
 
   Category.virtual('permalink').get(function() {
     const { config } = ctx;
-    let partial_url = this.path;
-    if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return full_url_for.call(ctx, partial_url);
+    let url = full_url_for.call(ctx, this.path);
+    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    return url;
   });
 
   Category.virtual('posts').get(function() {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -4,7 +4,7 @@ const { Schema } = require('warehouse');
 const { join } = require('path');
 const Moment = require('./types/moment');
 const moment = require('moment');
-const { encodeURL } = require('hexo-util');
+const full_url_for = require('../plugins/helper/full_url_for');
 
 module.exports = ctx => {
   const Page = new Schema({
@@ -36,7 +36,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = this.path;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return encodeURL(ctx.config.url + '/' + this.path);
+    return full_url_for.call(ctx, partial_url);
   });
 
   Page.virtual('full_source').get(function() {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -34,9 +34,9 @@ module.exports = ctx => {
 
   Page.virtual('permalink').get(function() {
     const { config } = ctx;
-    let partial_url = this.path;
-    if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return full_url_for.call(ctx, partial_url);
+    let url = full_url_for.call(ctx, this.path);
+    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    return url;
   });
 
   Page.virtual('full_source').get(function() {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -4,6 +4,7 @@ const { Schema } = require('warehouse');
 const { join } = require('path');
 const Moment = require('./types/moment');
 const moment = require('moment');
+const { encodeURL } = require('hexo-util');
 
 module.exports = ctx => {
   const Page = new Schema({
@@ -35,7 +36,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = this.path;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return `${ctx.config.url}/${partial_url}`;
+    return encodeURL(ctx.config.url + '/' + this.path);
   });
 
   Page.virtual('full_source').get(function() {

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -54,8 +54,8 @@ module.exports = ctx => {
   Post.virtual('permalink').get(function() {
     const { config } = ctx;
     let partial_url = url_for.call(ctx, this.path);
-    if (config.relative_link) partial_url = `/${partial_url}`;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
+    if (config.relative_link) partial_url = `/${partial_url}`;
     return full_url_for.call(ctx, partial_url.replace(config.root, '/'));
   });
 

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -5,7 +5,6 @@ const moment = require('moment');
 const { extname, join, sep } = require('path');
 const Promise = require('bluebird');
 const Moment = require('./types/moment');
-const url_for = require('../plugins/helper/url_for');
 const full_url_for = require('../plugins/helper/full_url_for');
 
 function pickID(data) {
@@ -53,10 +52,9 @@ module.exports = ctx => {
 
   Post.virtual('permalink').get(function() {
     const { config } = ctx;
-    let partial_url = url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    if (config.relative_link) partial_url = `/${partial_url}`;
-    return full_url_for.call(ctx, partial_url.replace(config.root, '/'));
+    let url = full_url_for.call(ctx, this.path);
+    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    return url;
   });
 
   Post.virtual('full_source').get(function() {

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -5,7 +5,8 @@ const moment = require('moment');
 const { extname, join, sep } = require('path');
 const Promise = require('bluebird');
 const Moment = require('./types/moment');
-const { encodeURL } = require('hexo-util');
+const url_for = require('../plugins/helper/url_for');
+const full_url_for = require('../plugins/helper/full_url_for');
 
 function pickID(data) {
   return data._id;
@@ -51,12 +52,11 @@ module.exports = ctx => {
   });
 
   Post.virtual('permalink').get(function() {
-    const self = Object.assign({}, ctx.extend.helper.list(), ctx);
     const { config } = ctx;
-    let partial_url = self.url_for(this.path);
+    let partial_url = url_for.call(ctx, this.path);
     if (config.relative_link) partial_url = `/${partial_url}`;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return encodeURL(config.url + partial_url.replace(config.root, '/'));
+    return full_url_for.call(ctx, partial_url.replace(config.root, '/'));
   });
 
   Post.virtual('full_source').get(function() {

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -5,6 +5,7 @@ const moment = require('moment');
 const { extname, join, sep } = require('path');
 const Promise = require('bluebird');
 const Moment = require('./types/moment');
+const { encodeURL } = require('hexo-util');
 
 function pickID(data) {
   return data._id;
@@ -55,7 +56,7 @@ module.exports = ctx => {
     let partial_url = self.url_for(this.path);
     if (config.relative_link) partial_url = `/${partial_url}`;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return config.url + partial_url.replace(config.root, '/');
+    return encodeURL(config.url + partial_url.replace(config.root, '/'));
   });
 
   Post.virtual('full_source').get(function() {

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -3,7 +3,7 @@
 const { Schema } = require('warehouse');
 const { slugize } = require('hexo-util');
 const { hasOwnProperty: hasOwn } = Object.prototype;
-const { encodeURL } = require('hexo-util');
+const full_url_for = require('../plugins/helper/full_url_for');
 
 module.exports = ctx => {
   const Tag = new Schema({
@@ -33,7 +33,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = this.path;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return encodeURL(ctx.config.url + '/' + this.path);
+    return full_url_for.call(ctx, partial_url);
   });
 
   Tag.virtual('posts').get(function() {

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -31,9 +31,9 @@ module.exports = ctx => {
 
   Tag.virtual('permalink').get(function() {
     const { config } = ctx;
-    let partial_url = this.path;
-    if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return full_url_for.call(ctx, partial_url);
+    let url = full_url_for.call(ctx, this.path);
+    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    return url;
   });
 
   Tag.virtual('posts').get(function() {

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -3,6 +3,7 @@
 const { Schema } = require('warehouse');
 const { slugize } = require('hexo-util');
 const { hasOwnProperty: hasOwn } = Object.prototype;
+const { encodeURL } = require('hexo-util');
 
 module.exports = ctx => {
   const Tag = new Schema({
@@ -32,7 +33,7 @@ module.exports = ctx => {
     const { config } = ctx;
     let partial_url = this.path;
     if (config.pretty_urls.trailing_index === false) partial_url = partial_url.replace(/index\.html$/, '');
-    return `${ctx.config.url}/${partial_url}`;
+    return encodeURL(ctx.config.url + '/' + this.path);
   });
 
   Tag.virtual('posts').get(function() {

--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const url = require('url');
+const relative_url = require('./relative_url');
 
 function urlForHelper(path = '/', options) {
   if (path[0] === '#' || path.startsWith('//')) {
@@ -22,7 +23,7 @@ function urlForHelper(path = '/', options) {
 
   // Resolve relative url
   if (options.relative) {
-    return this.relative_url(this.path, path);
+    return relative_url(this.path, path);
   }
 
   // Prepend root path

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -425,6 +425,20 @@ describe('Hexo', () => {
     ].join('\n')));
   });
 
+  it('_generate() - should encode url', () => {
+    hexo.config.url = 'http://fôo.com';
+
+    hexo.theme.setView('test.swig', '{{ url }}');
+
+    hexo.extend.generator.register('test', () => ({
+      path: 'bár',
+      layout: 'test'
+    }));
+
+    return hexo._generate().then(() => checkStream(route.get('bár'),
+      'http://xn--fo-8ja.com/b%C3%A1r'));
+  });
+
   it('_generate() - do nothing if it\'s generating', () => {
     const spy = sinon.spy();
     hexo.extend.generator.register('test', spy);

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -121,6 +121,7 @@ describe('Category', () => {
       name: 'bár'
     }).then(data => {
       data.permalink.should.eql('http://xn--fo-8ja.com/' + data.path);
+      hexo.config.url = 'http://yoursite.com';
       return Category.removeById(data._id);
     });
   });

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -115,6 +115,16 @@ describe('Category', () => {
     });
   });
 
+  it('permalink - should be encoded', () => {
+    hexo.config.url = 'http://fôo.com';
+    return Category.insert({
+      name: 'bár'
+    }).then(data => {
+      data.permalink.should.eql('http://xn--fo-8ja.com/' + data.path);
+      return Category.removeById(data._id);
+    });
+  });
+
   it('posts - virtual', () => Post.insert([
     {source: 'foo.md', slug: 'foo'},
     {source: 'bar.md', slug: 'bar'},

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -79,6 +79,7 @@ describe('Page', () => {
       path: 'bár'
     }).then(data => {
       data.permalink.should.eql('http://xn--fo-8ja.com/b%C3%A1r');
+      hexo.config.url = 'http://yoursite.com';
       return Page.removeById(data._id);
     });
   });

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -72,6 +72,17 @@ describe('Page', () => {
     });
   });
 
+  it('permalink - should be encoded', () => {
+    hexo.config.url = 'http://fôo.com';
+    return Page.insert({
+      source: 'foo',
+      path: 'bár'
+    }).then(data => {
+      data.permalink.should.eql('http://xn--fo-8ja.com/b%C3%A1r');
+      return Page.removeById(data._id);
+    });
+  });
+
   it('full_source - virtual', () => Page.insert({
     source: 'foo',
     path: 'bar'

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -104,6 +104,7 @@ describe('Post', () => {
       slug: 'bar'
     }).then(data => {
       data.permalink.should.eql(hexo.config.url + '/' + data.path);
+      hexo.config.relative_link = false;
       return Post.removeById(data._id);
     });
   });

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -84,6 +84,18 @@ describe('Post', () => {
     });
   });
 
+  it('permalink - should be encoded', () => {
+    hexo.config.url = 'http://fôo.com';
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bár'
+    }).then(data => {
+      data.permalink.should.eql('http://xn--fo-8ja.com/b%C3%A1r');
+      hexo.config.url = 'http://yoursite.com';
+      return Post.removeById(data._id);
+    });
+  });
+
   it('permalink - virtual - when set relative_link', () => {
     hexo.config.root = '/';
     hexo.config.relative_link = true;

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -100,6 +100,16 @@ describe('Tag', () => {
     });
   });
 
+  it('permalink - should be encoded', () => {
+    hexo.config.url = 'http://fôo.com';
+    return Tag.insert({
+      name: 'bár'
+    }).then(data => {
+      data.permalink.should.eql('http://xn--fo-8ja.com/' + data.path);
+      return Tag.removeById(data._id);
+    });
+  });
+
   it('posts - virtual', () => Post.insert([
     {source: 'foo.md', slug: 'foo'},
     {source: 'bar.md', slug: 'bar'},

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -106,6 +106,7 @@ describe('Tag', () => {
       name: 'bár'
     }).then(data => {
       data.permalink.should.eql('http://xn--fo-8ja.com/' + data.path);
+      hexo.config.url = 'http://yoursite.com';
       return Tag.removeById(data._id);
     });
   });


### PR DESCRIPTION
## What does it do?
While working on https://github.com/hexojs/hexo-generator-sitemap/pull/68 and https://github.com/hexojs/hexo-generator-feed/pull/93, I find it strange that plugins have to encode url themselves.

I believe url should be [safe to consume](https://www.ietf.org/rfc/rfc1738.txt) by default. I can't think of any reason to use `this.url` in its original unescape form, except for aesthetic when displaying as a text, e.g. show http://foo.com/一二三 instead of http://foo.com/%E4%B8%80%E4%BA%8C%E4%B8%89

Displaying a full link as text should be considered as an edge case. In that case, it should be up to the user to decode it (we could write a helper to help).

Do note link inside `href` is decoded when mouse-over.
``` html
<a href="http://xn--fo-8ja.com/b%C3%A1r%20ab/">aaaaaaaaaaaaa</a>
```

![link](https://user-images.githubusercontent.com/43627182/64579944-c6dd8300-d3c3-11e9-8c84-9725af745e81.png)

It's a breaking change because existing plugins need to remove url encode function, otherwise the percent symbol gets encoded (double-encoded), e.g. `foo%20bar` becomes `foo%25%20bar`.

Note that existing plugin can remain backward compatible with v3 (if they wish) by using `encodeURI(decodeURI(str))` (instead of current `encodeURI(str)`, or use [`encodeURL()`](https://github.com/hexojs/hexo-util/blob/61551128a324cba8c7b8743896fb63232e5c97a8/lib/encode_url.js#L11) of hexo-util.

hexo-util is going to have [`decodeURL()`](https://github.com/hexojs/hexo-util/pull/97) which is an alternative to decodeURI with added ability to decode punycoded IDN.

## How to test

```sh
git clone -b encode-url https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
