### PR TITLE
fix(helpers, tag plugins): encode url by default

### DIFF
--- a/lib/plugins/helper/relative_url.js
+++ b/lib/plugins/helper/relative_url.js
@@ -3,5 +3,5 @@
 const { relative_url } = require('hexo-util');
 
 module.exports = function(from, to) {
-  return relative_url.call(this, from, to);
+  return relative_url(from, to);
 };

--- a/lib/plugins/helper/relative_url.js
+++ b/lib/plugins/helper/relative_url.js
@@ -1,6 +1,7 @@
 'use strict';
 
+const { relative_url } = require('hexo-util');
+
 module.exports = function(from, to) {
-  const relative_url = require('hexo-util').relative_url.bind(this);
-  return relative_url(from, to);
+  return relative_url.call(this, from, to);
 };

--- a/lib/plugins/helper/relative_url.js
+++ b/lib/plugins/helper/relative_url.js
@@ -1,29 +1,6 @@
 'use strict';
 
-function relativeUrlHelper(from = '', to = '') {
-  const fromParts = from.split('/');
-  const toParts = to.split('/');
-  const length = Math.min(fromParts.length, toParts.length);
-  let i = 0;
-
-  for (; i < length; i++) {
-    if (fromParts[i] !== toParts[i]) break;
-  }
-
-  let out = toParts.slice(i);
-
-  for (let j = fromParts.length - i - 1; j > 0; j--) {
-    out.unshift('..');
-  }
-
-  const outLength = out.length;
-
-  // If the last 2 elements of `out` is empty strings, replace them with `index.html`.
-  if (outLength > 1 && !out[outLength - 1] && !out[outLength - 2]) {
-    out = out.slice(0, outLength - 2).concat('index.html');
-  }
-
-  return out.join('/').replace(/\/{2,}/g, '/');
-}
-
-module.exports = relativeUrlHelper;
+module.exports = function(from, to) {
+  const relative_url = require('hexo-util').relative_url.bind(this);
+  return relative_url(from, to);
+};

--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -27,9 +27,9 @@ function urlForHelper(path = '/', options) {
   }
 
   // Prepend root path
-  path = root + path;
+  path = encodeURL((root + path).replace(/\/{2,}/g, '/'));
 
-  return path.replace(/\/{2,}/g, '/');
+  return path;
 }
 
 module.exports = urlForHelper;

--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -1,35 +1,7 @@
 'use strict';
 
-const url = require('url');
-const relative_url = require('./relative_url');
+const { url_for } = require('hexo-util');
 
-function urlForHelper(path = '/', options) {
-  if (path[0] === '#' || path.startsWith('//')) {
-    return path;
-  }
-
-  const { config } = this;
-  const { root } = config;
-  const data = url.parse(path);
-
-  options = Object.assign({
-    relative: config.relative_link
-  }, options);
-
-  // Exit if this is an external path
-  if (data.protocol) {
-    return path;
-  }
-
-  // Resolve relative url
-  if (options.relative) {
-    return relative_url(this.path, path);
-  }
-
-  // Prepend root path
-  path = encodeURL((root + path).replace(/\/{2,}/g, '/'));
-
-  return path;
-}
-
-module.exports = urlForHelper;
+module.exports = function(path, options) {
+  return url_for.call(this, path, options);
+};

--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -1,6 +1,7 @@
 'use strict';
 
+const url_for = require('hexo-util');
+
 module.exports = function(path, options) {
-  const url_for = require('hexo-util').url_for.bind(this);
-  return url_for(path, options);
+  return url_for.call(this, path, options);
 };

--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const { url_for } = require('hexo-util');
-
 module.exports = function(path, options) {
-  return url_for.call(this, path, options);
+  const url_for = require('hexo-util').url_for.bind(this);
+  return url_for(path, options);
 };

--- a/lib/plugins/helper/url_for.js
+++ b/lib/plugins/helper/url_for.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const url_for = require('hexo-util');
+const { url_for } = require('hexo-util');
 
 module.exports = function(path, options) {
   return url_for.call(this, path, options);

--- a/lib/plugins/tag/asset_img.js
+++ b/lib/plugins/tag/asset_img.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const { resolve } = require('url');
 const img = require('./img');
 const { encodeURL } = require('hexo-util');
 
@@ -19,7 +20,7 @@ module.exports = ctx => {
     for (let i = 0; i < len; i++) {
       const asset = PostAsset.findOne({post: this._id, slug: args[i]});
       if (asset) {
-        args[i] = encodeURL('/' + asset.path);
+        args[i] = encodeURL(resolve('/', asset.path));
         return img(ctx)(args);
       }
     }

--- a/lib/plugins/tag/asset_img.js
+++ b/lib/plugins/tag/asset_img.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const url = require('url');
 const img = require('./img');
+const { encodeURL } = require('hexo-util');
 
 /**
  * Asset image tag
@@ -19,7 +19,7 @@ module.exports = ctx => {
     for (let i = 0; i < len; i++) {
       const asset = PostAsset.findOne({post: this._id, slug: args[i]});
       if (asset) {
-        args[i] = url.resolve('/', asset.path);
+        args[i] = encodeURL('/' + asset.path);
         return img(ctx)(args);
       }
     }

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const url = require('url');
-const { escapeHTML } = require('hexo-util');
+const { encodeURL, escapeHTML } = require('hexo-util');
 
 /**
  * Asset link tag

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -11,7 +11,6 @@ const { encodeURL, escapeHTML } = require('hexo-util');
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
-  const url_for = require('../../plugins/helper/url_for').bind(ctx);
 
   return function assetLinkTag(args) {
     const slug = args.shift();
@@ -30,6 +29,7 @@ module.exports = ctx => {
     let title = args.length ? args.join(' ') : asset.slug;
     const attrTitle = escapeHTML(title);
     if (escape === 'true') title = attrTitle;
+    const link = encodeURL(url_for.call(ctx, asset.path));
 
     return `<a href="${url.resolve(ctx.config.root, asset.path)}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -11,7 +11,6 @@ const { encodeURL, escapeHTML } = require('hexo-util');
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
-  const url_for = require('../helper/url_for').bind(ctx);
 
   return function assetLinkTag(args) {
     const slug = args.shift();

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -11,6 +11,7 @@ const { encodeURL, escapeHTML } = require('hexo-util');
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
+  const url_for = require('../../plugins/helper/url_for').bind(ctx);
 
   return function assetLinkTag(args) {
     const slug = args.shift();

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -11,6 +11,7 @@ const { encodeURL, escapeHTML } = require('hexo-util');
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
+  const url_for = require('../helper/url_for').bind(ctx);
 
   return function assetLinkTag(args) {
     const slug = args.shift();

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const url = require('url');
 const { encodeURL, escapeHTML } = require('hexo-util');
+const { resolve } = require('url');
 
 /**
  * Asset link tag
@@ -29,8 +29,9 @@ module.exports = ctx => {
     let title = args.length ? args.join(' ') : asset.slug;
     const attrTitle = escapeHTML(title);
     if (escape === 'true') title = attrTitle;
-    const link = encodeURL(url_for.call(ctx, asset.path));
 
-    return `<a href="${url.resolve(ctx.config.root, asset.path)}" title="${attrTitle}">${title}</a>`;
+    const link = encodeURL(resolve(ctx.config.root, asset.path));
+
+    return `<a href="${link}" title="${attrTitle}">${title}</a>`;
   };
 };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -10,6 +10,7 @@ const { encodeURL } = require('hexo-util');
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
+  const url_for = require('../../plugins/helper/url_for').bind(ctx);
 
   return function assetPathTag(args) {
     const slug = args.shift();
@@ -18,7 +19,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const path = encodeURL(ctx.config.root + asset.path);
+    const path = encodeURL(url_for(asset.path));
 
     return path;
   };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const url = require('url');
+const { encodeURL } = require('hexo-util');
 
 /**
  * Asset path tag
@@ -18,6 +18,8 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    return url.resolve(ctx.config.root, asset.path);
+    const path = encodeURL(ctx.config.root + asset.path);
+
+    return path;
   };
 };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { encodeURL } = require('hexo-util');
+const url_for = require('../../plugins/helper/url_for');
 
 /**
  * Asset path tag
@@ -10,7 +11,6 @@ const { encodeURL } = require('hexo-util');
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
-  const url_for = require('../../plugins/helper/url_for').bind(ctx);
 
   return function assetPathTag(args) {
     const slug = args.shift();
@@ -19,7 +19,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const path = encodeURL(url_for(asset.path));
+    const path = encodeURL(url_for.call(ctx, asset.path));
 
     return path;
   };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const url_for = require('../helper/url_for');
+
 /**
  * Asset path tag
  *
@@ -8,7 +10,6 @@
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
-  const url_for = require('../helper/url_for').bind(ctx);
 
   return function assetPathTag(args) {
     const slug = args.shift();
@@ -17,7 +18,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const path = url_for(asset.path);
+    const path = url_for.call(ctx, asset.path);
 
     return path;
   };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { encodeURL } = require('hexo-util');
-const url_for = require('../helper/url_for');
 
 /**
  * Asset path tag
@@ -11,6 +10,7 @@ const url_for = require('../helper/url_for');
  */
 module.exports = ctx => {
   const PostAsset = ctx.model('PostAsset');
+  const url_for = require('../helper/url_for').bind(ctx);
 
   return function assetPathTag(args) {
     const slug = args.shift();
@@ -19,7 +19,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const path = encodeURL(url_for.call(ctx, asset.path));
+    const path = encodeURL(url_for(asset.path));
 
     return path;
   };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { encodeURL } = require('hexo-util');
-const url_for = require('../../plugins/helper/url_for');
+const url_for = require('../helper/url_for');
 
 /**
  * Asset path tag

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const url_for = require('../helper/url_for');
+const { resolve } = require('url');
+const { encodeURL } = require('hexo-util');
 
 /**
  * Asset path tag
@@ -18,7 +19,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const path = url_for.call(ctx, asset.path);
+    const path = encodeURL(resolve(ctx.config.root, asset.path));
 
     return path;
   };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { encodeURL } = require('hexo-util');
-
 /**
  * Asset path tag
  *
@@ -19,7 +17,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const path = encodeURL(url_for(asset.path));
+    const path = url_for(asset.path);
 
     return path;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -10,6 +10,7 @@ const { encodeURL, escapeHTML } = require('hexo-util');
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
+  const url_for = require('../helper/url_for').bind(ctx);
 
   return function postLinkTag(args) {
     const slug = args.shift();
@@ -30,7 +31,7 @@ module.exports = ctx => {
     if (escape === 'true') title = attrTitle;
     const title = args.length ? args.join(' ') : post.title;
 
-    const link = encodeURL(url_for.call(ctx, post.path));
+    const link = encodeURL(url_for(post.path));
 
     return `<a href="${ctx.config.root}${post.path}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { escapeHTML } = require('hexo-util');
+const { encodeURL, escapeHTML } = require('hexo-util');
 
 /**
  * Post link tag

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { encodeURL, escapeHTML } = require('hexo-util');
+const { resolve } = require('url');
 
 /**
  * Post link tag
@@ -28,10 +29,9 @@ module.exports = ctx => {
     let title = args.length ? args.join(' ') : post.title;
     const attrTitle = escapeHTML(title);
     if (escape === 'true') title = attrTitle;
-    const title = args.length ? args.join(' ') : post.title;
 
-    const link = url_for.call(ctx, post.path);
+    const link = encodeURL(resolve(ctx.config.root, post.path));
 
-    return `<a href="${ctx.config.root}${post.path}" title="${attrTitle}">${title}</a>`;
+    return `<a href="${link}" title="${attrTitle}">${title}</a>`;
   };
 };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -10,7 +10,6 @@ const { encodeURL, escapeHTML } = require('hexo-util');
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
-  const url_for = require('../helper/url_for').bind(ctx);
 
   return function postLinkTag(args) {
     const slug = args.shift();
@@ -31,7 +30,7 @@ module.exports = ctx => {
     if (escape === 'true') title = attrTitle;
     const title = args.length ? args.join(' ') : post.title;
 
-    const link = url_for(post.path);
+    const link = url_for.call(ctx, post.path);
 
     return `<a href="${ctx.config.root}${post.path}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -31,7 +31,7 @@ module.exports = ctx => {
     if (escape === 'true') title = attrTitle;
     const title = args.length ? args.join(' ') : post.title;
 
-    const link = encodeURL(url_for(post.path));
+    const link = url_for(post.path);
 
     return `<a href="${ctx.config.root}${post.path}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -10,7 +10,6 @@ const { encodeURL, escapeHTML } = require('hexo-util');
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
-  const url_for = require('../../plugins/helper/url_for').bind(ctx);
 
   return function postLinkTag(args) {
     const slug = args.shift();
@@ -29,6 +28,9 @@ module.exports = ctx => {
     let title = args.length ? args.join(' ') : post.title;
     const attrTitle = escapeHTML(title);
     if (escape === 'true') title = attrTitle;
+    const title = args.length ? args.join(' ') : post.title;
+
+    const link = encodeURL(url_for.call(ctx, post.path));
 
     return `<a href="${ctx.config.root}${post.path}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -10,6 +10,7 @@ const { encodeURL, escapeHTML } = require('hexo-util');
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
+  const url_for = require('../../plugins/helper/url_for').bind(ctx);
 
   return function postLinkTag(args) {
     const slug = args.shift();

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -10,6 +10,7 @@ const { encodeURL } = require('hexo-util');
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
+  const url_for = require('../../plugins/helper/url_for').bind(ctx);
 
   return function postPathTag(args) {
     const slug = args.shift();
@@ -18,7 +19,7 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const link = encodeURL(ctx.config.root + post.path);
+    const link = encodeURL(url_for(post.path));
 
     return link;
   };

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { encodeURL } = require('hexo-util');
+const url_for = require('../../plugins/helper/url_for');
 
 /**
  * Post path tag
@@ -10,7 +11,6 @@ const { encodeURL } = require('hexo-util');
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
-  const url_for = require('../../plugins/helper/url_for').bind(ctx);
 
   return function postPathTag(args) {
     const slug = args.shift();
@@ -19,7 +19,7 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const link = encodeURL(url_for(post.path));
+    const link = encodeURL(url_for.call(this, post.path));
 
     return link;
   };

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { encodeURL } = require('hexo-util');
+
 /**
  * Post path tag
  *
@@ -16,6 +18,8 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    return ctx.config.root + post.path;
+    const link = encodeURL(ctx.config.root + post.path);
+
+    return link;
   };
 };

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const url_for = require('../helper/url_for');
+const { resolve } = require('url');
+const { encodeURL } = require('hexo-util');
 
 /**
  * Post path tag
@@ -18,7 +19,7 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const link = url_for.call(ctx, post.path);
+    const link = encodeURL(resolve(ctx.config.root, post.path));
 
     return link;
   };

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const url_for = require('../helper/url_for');
+
 /**
  * Post path tag
  *
@@ -8,7 +10,6 @@
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
-  const url_for = require('../helper/url_for').bind(ctx);
 
   return function postPathTag(args) {
     const slug = args.shift();
@@ -17,7 +18,7 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const link = url_for(post.path);
+    const link = url_for.call(ctx, post.path);
 
     return link;
   };

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { encodeURL } = require('hexo-util');
-const url_for = require('../../plugins/helper/url_for');
+const url_for = require('../helper/url_for');
 
 /**
  * Post path tag

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { encodeURL } = require('hexo-util');
-const url_for = require('../helper/url_for');
 
 /**
  * Post path tag
@@ -11,6 +10,7 @@ const url_for = require('../helper/url_for');
  */
 module.exports = ctx => {
   const Post = ctx.model('Post');
+  const url_for = require('../helper/url_for').bind(ctx);
 
   return function postPathTag(args) {
     const slug = args.shift();
@@ -19,7 +19,7 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const link = encodeURL(url_for.call(this, post.path));
+    const link = encodeURL(url_for(post.path));
 
     return link;
   };

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const { encodeURL } = require('hexo-util');
-
 /**
  * Post path tag
  *
@@ -19,7 +17,7 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const link = encodeURL(url_for(post.path));
+    const link = url_for(post.path);
 
     return link;
   };

--- a/test/scripts/helpers/relative_url.js
+++ b/test/scripts/helpers/relative_url.js
@@ -27,4 +27,8 @@ describe('relative_url', () => {
     relativeURL('foo/', '/').should.eql('../index.html');
     relativeURL('foo/index.html', '/').should.eql('../index.html');
   });
+
+  it('should encode path', () => {
+    relativeURL('foo/', 'css/fôo.css').should.eql('../css/f%C3%B4o.css');
+  });
 });

--- a/test/scripts/helpers/url_for.js
+++ b/test/scripts/helpers/url_for.js
@@ -8,6 +8,14 @@ describe('url_for', () => {
 
   const urlFor = require('../../../lib/plugins/helper/url_for').bind(ctx);
 
+  it('should encode path', () => {
+    ctx.config.root = '/';
+    urlFor('fôo.html').should.eql('/f%C3%B4o.html');
+
+    ctx.config.root = '/fôo/';
+    urlFor('bár.html').should.eql('/f%C3%B4o/b%C3%A1r.html');
+  });
+
   it('internal url (relative off)', () => {
     ctx.config.root = '/';
     urlFor('index.html').should.eql('/index.html');

--- a/test/scripts/tags/asset_img.js
+++ b/test/scripts/tags/asset_img.js
@@ -29,6 +29,11 @@ describe('asset_img', () => {
         post: post._id
       }),
       PostAsset.insert({
+        _id: 'bár',
+        slug: 'bár',
+        post: post._id
+      }),
+      PostAsset.insert({
         _id: 'spaced asset',
         slug: 'spaced asset',
         post: post._id
@@ -38,6 +43,10 @@ describe('asset_img', () => {
 
   it('default', () => {
     assetImg('bar').should.eql('<img src="/foo/bar" class="">');
+  });
+
+  it('should encode path', () => {
+    assetImg('bár').should.eql('<img src="/foo/b%C3%A1r" class="">');
   });
 
   it('default', () => {

--- a/test/scripts/tags/asset_link.js
+++ b/test/scripts/tags/asset_link.js
@@ -29,6 +29,11 @@ describe('asset_link', () => {
         post: post._id
       }),
       PostAsset.insert({
+        _id: 'bár',
+        slug: 'bár',
+        post: post._id
+      }),
+      PostAsset.insert({
         _id: 'spaced asset',
         slug: 'spaced asset',
         post: post._id
@@ -38,6 +43,10 @@ describe('asset_link', () => {
 
   it('default', () => {
     assetLink('bar').should.eql('<a href="/foo/bar" title="bar">bar</a>');
+  });
+
+  it('should encode path', () => {
+    assetLink('bár').should.eql('<a href="/foo/b%C3%A1r" title="bár">bár</a>');
   });
 
   it('title', () => {

--- a/test/scripts/tags/asset_path.js
+++ b/test/scripts/tags/asset_path.js
@@ -29,6 +29,11 @@ describe('asset_path', () => {
         post: post._id
       }),
       PostAsset.insert({
+        _id: 'bár',
+        slug: 'bár',
+        post: post._id
+      }),
+      PostAsset.insert({
         _id: 'spaced asset',
         slug: 'spaced asset',
         post: post._id
@@ -38,6 +43,10 @@ describe('asset_path', () => {
 
   it('default', () => {
     assetPath('bar').should.eql('/foo/bar');
+  });
+
+  it('should encode path', () => {
+    assetPath('bár').should.eql('/foo/b%C3%A1r');
   });
 
   it('with space', () => {

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -17,10 +17,19 @@ describe('post_link', () => {
     source: 'title-with-tag',
     slug: 'title-with-tag',
     title: '"Hello" <new world>!'
+  },
+  {
+    source: 'fôo',
+    slug: 'fôo',
+    title: 'Hello world'
   }])));
 
   it('default', () => {
     postLink(['foo']).should.eql('<a href="/foo/" title="Hello world">Hello world</a>');
+  });
+
+  it('should encode path', () => {
+    postLink(['fôo']).should.eql('<a href="/f%C3%B4o/" title="Hello world">Hello world</a>');
   });
 
   it('title', () => {

--- a/test/scripts/tags/post_path.js
+++ b/test/scripts/tags/post_path.js
@@ -8,13 +8,20 @@ describe('post_path', () => {
 
   hexo.config.permalink = ':title/';
 
-  before(() => hexo.init().then(() => Post.insert({
+  before(() => hexo.init().then(() => Post.insert([{
     source: 'foo',
     slug: 'foo'
-  })));
+  }, {
+    source: 'fôo',
+    slug: 'fôo'
+  }])));
 
   it('default', () => {
     postPath(['foo']).should.eql('/foo/');
+  });
+
+  it('should encode path', () => {
+    postPath(['fôo']).should.eql('/f%C3%B4o/');
   });
 
   it('no slug', () => {


### PR DESCRIPTION
## What does it do?
Continuation of https://github.com/hexojs/hexo/pull/3708, this PR deals with helpers and tag plugins.


## How to test

```sh
git clone -b encode-url-helper https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
