### PR TITLE
style: no-useless-concat & one-var (uninitialized)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,19 +1,6 @@
 {
   "extends": "hexo",
   "root": true,
-  "rules": {
-    "one-var": 0,
-    "operator-linebreak": [
-      2,
-      "after"
-    ],
-    "comma-spacing": [
-      2,
-      {
-        "after": true
-      }
-    ]
-  },
   "parserOptions": {
     "ecmaVersion": 2018
   }

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -138,8 +138,8 @@ class Hexo {
 
     const mcp = multiConfigPath(this);
 
-    this.config_path = args.config ? mcp(base, args.config, args.output) :
-      join(base, '_config.yml');
+    this.config_path = args.config ? mcp(base, args.config, args.output)
+      : join(base, '_config.yml');
 
     registerModels(this);
 

--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -11,8 +11,8 @@ const urlObj = (str) => {
 };
 
 const isExternal = (url, config) => {
-  const exclude = Array.isArray(config.external_link.exclude) ? config.external_link.exclude :
-    [config.external_link.exclude];
+  const exclude = Array.isArray(config.external_link.exclude) ? config.external_link.exclude
+    : [config.external_link.exclude];
   const data = urlObj(url);
   const host = data.hostname;
   const sitehost = typeof urlObj(config.url) === 'object' ? urlObj(config.url).hostname : config.url;
@@ -34,16 +34,16 @@ const isExternal = (url, config) => {
 function externalLinkFilter(data) {
   const { config } = this;
 
-  if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object' ||
-    config.external_link === true) {
+  if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
+    || config.external_link === true) {
     config.external_link = Object.assign({
       enable: true,
       field: 'site',
       exclude: ''
     }, config.external_link);
   }
-  if (config.external_link === false || config.external_link.enable === false ||
-        config.external_link.field !== 'post') return;
+  if (config.external_link === false || config.external_link.enable === false
+    || config.external_link.field !== 'post') return;
 
   data.content = data.content.replace(/<a.*?(href=['"](.*?)['"]).*?>/gi, (str, hrefStr, href) => {
     if (/target=/gi.test(str) || !isExternal(href, config)) return str;

--- a/lib/plugins/filter/after_render/external_link.js
+++ b/lib/plugins/filter/after_render/external_link.js
@@ -17,8 +17,8 @@ const urlObj = (str) => {
  * @returns {Boolean} True if the link doesn't have protocol or link has same host with config.url
  */
 const isExternal = (url, config) => {
-  const exclude = Array.isArray(config.external_link.exclude) ? config.external_link.exclude :
-    [config.external_link.exclude];
+  const exclude = Array.isArray(config.external_link.exclude) ? config.external_link.exclude
+    : [config.external_link.exclude];
   const data = urlObj(url);
   const host = data.hostname;
   const sitehost = typeof urlObj(config.url) === 'object' ? urlObj(config.url).hostname : config.url;
@@ -40,16 +40,16 @@ const isExternal = (url, config) => {
 function externalLinkFilter(data) {
   const { config } = this;
 
-  if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object' ||
-    config.external_link === true) {
+  if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
+    || config.external_link === true) {
     config.external_link = Object.assign({
       enable: true,
       field: 'site',
       exclude: ''
     }, config.external_link);
   }
-  if (config.external_link === false || config.external_link.enable === false ||
-    config.external_link.field !== 'site') return;
+  if (config.external_link === false || config.external_link.enable === false
+    || config.external_link.field !== 'site') return;
 
   data = data.replace(/<a.*?(href=['"](.*?)['"]).*?>/gi, (str, hrefStr, href) => {
     if (/target=/gi.test(str) || !isExternal(href, config)) return str;

--- a/lib/plugins/filter/after_render/meta_generator.js
+++ b/lib/plugins/filter/after_render/meta_generator.js
@@ -2,8 +2,8 @@
 
 function hexoMetaGeneratorInject(data) {
   const { config } = this;
-  if (!config.meta_generator ||
-  data.match(/<meta\s+name=['|"]?generator['|"]?/i)) return;
+  if (!config.meta_generator
+    || data.match(/<meta\s+name=['|"]?generator['|"]?/i)) return;
 
   const hexoGeneratorTag = `<meta name="generator" content="Hexo ${this.version}">`;
 

--- a/lib/plugins/helper/toc.js
+++ b/lib/plugins/helper/toc.js
@@ -23,9 +23,7 @@ function tocHelper(str, options = {}) {
   function getId(ele) {
     const id = $(ele).attr('id');
     const $parent = $(ele).parent();
-    return id ||
-    ($parent.length < 1 ? null :
-      getId($parent));
+    return id || ($parent.length < 1 ? null : getId($parent));
   }
 
   headings.each(function() {

--- a/lib/plugins/tag/img.js
+++ b/lib/plugins/tag/img.js
@@ -33,7 +33,7 @@ module.exports = ctx => {
 
   return function imgTag(args, content) {
     const classes = [];
-    let src;
+    let src, width, height, title, alt;
 
     // Find image URL and class name
     while (args.length > 0) {
@@ -45,8 +45,6 @@ module.exports = ctx => {
         classes.push(item);
       }
     }
-
-    let width, height, title, alt;
 
     // Find image width and height
     if (args && args.length) {

--- a/test/scripts/filters/external_link.js
+++ b/test/scripts/filters/external_link.js
@@ -178,9 +178,7 @@ describe('External link - post', () => {
   };
 
   it('disabled', () => {
-    const content = 'foo'
-      + '<a href="https://hexo.io/">Hexo</a>'
-      + 'bar';
+    const content = 'foo<a href="https://hexo.io/">Hexo</a>bar';
 
     const data = {content};
     hexo.config.external_link.enable = false;

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -35,34 +35,28 @@ describe('Meta Generator', () => {
   });
 
   it('ignore empty head tag', () => {
-    const content = '<head></head>'
-      + '<head><link></head>'
-      + '<head></head>';
+    const content = '<head></head><head><link></head><head></head>';
     hexo.config.meta_generator = true;
     const result = metaGenerator(content);
 
     const $ = cheerio.load(result);
     $('meta[name="generator"]').length.should.eql(1);
 
-    const expected = '<head></head>'
-    + '<head><link><meta name="generator" content="Hexo ' + hexo.version + '"></head>'
-    + '<head></head>';
+    const expected = '<head></head><head><link><meta name="generator" content="Hexo '
+      + hexo.version + '"></head><head></head>';
     result.should.eql(expected);
   });
 
   it('apply to first non-empty head tag only', () => {
-    const content = '<head></head>'
-      + '<head><link></head>'
-      + '<head><link></head>';
+    const content = '<head></head><head><link></head><head><link></head>';
     hexo.config.meta_generator = true;
     const result = metaGenerator(content);
 
     const $ = cheerio.load(result);
     $('meta[name="generator"]').length.should.eql(1);
 
-    const expected = '<head></head>'
-    + '<head><link><meta name="generator" content="Hexo ' + hexo.version + '"></head>'
-    + '<head><link></head>';
+    const expected = '<head></head><head><link><meta name="generator" content="Hexo '
+      + hexo.version + '"></head><head><link></head>';
     result.should.eql(expected);
   });
 

--- a/test/scripts/hexo/multi_config_path.js
+++ b/test/scripts/hexo/multi_config_path.js
@@ -163,7 +163,7 @@ describe('config flag handling', () => {
     mcp(base, notFile).should.eql(pathFn.join(base, '_config.yml'));
     hexo.log.reader[0].type.should.eql('warning');
     hexo.log.reader[0].msg.should.eql('Config file ' + notFile
-                          + ' not found, using default.');
+      + ' not found, using default.');
   });
 
   it('1 not found file warning absolute', () => {
@@ -172,7 +172,7 @@ describe('config flag handling', () => {
     mcp(base, notFile).should.eql(pathFn.join(base, '_config.yml'));
     hexo.log.reader[0].type.should.eql('warning');
     hexo.log.reader[0].msg.should.eql('Config file ' + notFile
-                          + ' not found, using default.');
+      + ' not found, using default.');
   });
 
   it('combined config output', () => {
@@ -194,8 +194,7 @@ describe('config flag handling', () => {
 
     mcp(base, 'notafile.yml,alsonotafile.json').should.not.eql(combinedPath);
     hexo.log.reader[11].type.should.eql('error');
-    hexo.log.reader[11].msg.should.eql('No config files found.'
-                                     + ' Using _config.yml.');
+    hexo.log.reader[11].msg.should.eql('No config files found. Using _config.yml.');
   });
 
   it('combine config output with absolute paths', () => {
@@ -278,7 +277,6 @@ describe('config flag handling', () => {
     hexo.log.reader[7].type.should.eql('info');
     hexo.log.reader[7].msg.should.eql('Config based on 1 files');
     hexo.log.reader[11].type.should.eql('error');
-    hexo.log.reader[11].msg.should.eql('No config files found.'
-                                     + ' Using _config.yml.');
+    hexo.log.reader[11].msg.should.eql('No config files found. Using _config.yml.');
   });
 });


### PR DESCRIPTION
## What does it do?
`no-useless-concat` somehow is not enforced in recent commits.

I also remove rules override in `.eslintrc.json` for consistency across hexo projects.

Removing rules override is also in preparation for [prettier](https://github.com/hexojs/eslint-config-hexo/pull/25) to avoid conflicting rules (e.g. [[1]](https://github.com/prettier/prettier-eslint/issues/186), [[2]](https://github.com/prettier/prettier/issues/3806)).
## How to test

```sh
git clone -b no-useless-concat https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
