### PR TITLE
fix(paginator): compatibility with hexo-util@1.3.0

### DIFF
--- a/lib/plugins/helper/paginator.js
+++ b/lib/plugins/helper/paginator.js
@@ -44,7 +44,7 @@ const pagenasionPartShow = (tags, options, ctx) => {
   const rightEnd = total - current <= endSize ? current + 1 : total - endSize + 1;
   const leftMid = current - midSize <= endSize ? leftEnd + 1 : current - midSize;
   const rightMid = current + midSize + endSize > total ? rightEnd - 1 : current + midSize;
-  const spaceHtml = htmlTag('span', { class: 'space' }, space);
+  const spaceHtml = htmlTag('span', { class: 'space' }, space, false);
 
   const pageTag = createPageTag(options, ctx);
 

--- a/lib/plugins/helper/paginator.js
+++ b/lib/plugins/helper/paginator.js
@@ -10,13 +10,13 @@ const createLink = (options, ctx) => {
 
 const createPageTag = (options, ctx) => {
   const link = createLink(options, ctx);
-  const { current, transform } = options;
+  const { current, escape, transform } = options;
 
   return i => {
     if (i === current) {
-      return htmlTag('span', { class: 'page-number current' }, transform ? transform(i) : i, false);
+      return htmlTag('span', { class: 'page-number current' }, transform ? transform(i) : i, escape);
     }
-    return htmlTag('a', { class: 'page-number', href: link(i) }, transform ? transform(i) : i, false);
+    return htmlTag('a', { class: 'page-number', href: link(i) }, transform ? transform(i) : i, escape);
   };
 };
 
@@ -97,7 +97,8 @@ function paginatorHelper(options = {}) {
     space: '&hellip;',
     next_text: 'Next',
     prev_text: 'Prev',
-    prev_next: true
+    prev_next: true,
+    escape: true
   }, options);
 
   const {
@@ -105,7 +106,8 @@ function paginatorHelper(options = {}) {
     total,
     prev_text: prevText,
     next_text: nextText,
-    prev_next: prevNext
+    prev_next: prevNext,
+    escape
   } = options;
 
   if (!current) return '';
@@ -116,7 +118,7 @@ function paginatorHelper(options = {}) {
 
   // Display the link to the previous page
   if (prevNext && current > 1) {
-    tags.push(htmlTag('a', { class: 'extend prev', rel: 'prev', href: link(current - 1)}, prevText, false));
+    tags.push(htmlTag('a', { class: 'extend prev', rel: 'prev', href: link(current - 1)}, prevText, escape));
   }
 
   if (options.show_all) {
@@ -127,7 +129,7 @@ function paginatorHelper(options = {}) {
 
   // Display the link to the next page
   if (prevNext && current < total) {
-    tags.push(htmlTag('a', { class: 'extend next', rel: 'next', href: link(current + 1) }, nextText, false));
+    tags.push(htmlTag('a', { class: 'extend next', rel: 'next', href: link(current + 1) }, nextText, escape));
   }
 
   return tags.join('');

--- a/lib/plugins/helper/paginator.js
+++ b/lib/plugins/helper/paginator.js
@@ -14,9 +14,9 @@ const createPageTag = (options, ctx) => {
 
   return i => {
     if (i === current) {
-      return htmlTag('span', { class: 'page-number current' }, transform ? transform(i) : i);
+      return htmlTag('span', { class: 'page-number current' }, transform ? transform(i) : i, false);
     }
-    return htmlTag('a', { class: 'page-number', href: link(i) }, transform ? transform(i) : i);
+    return htmlTag('a', { class: 'page-number', href: link(i) }, transform ? transform(i) : i, false);
   };
 };
 
@@ -116,7 +116,7 @@ function paginatorHelper(options = {}) {
 
   // Display the link to the previous page
   if (prevNext && current > 1) {
-    tags.push(htmlTag('a', { class: 'extend prev', rel: 'prev', href: link(current - 1)}, prevText));
+    tags.push(htmlTag('a', { class: 'extend prev', rel: 'prev', href: link(current - 1)}, prevText, false));
   }
 
   if (options.show_all) {
@@ -127,7 +127,7 @@ function paginatorHelper(options = {}) {
 
   // Display the link to the next page
   if (prevNext && current < total) {
-    tags.push(htmlTag('a', { class: 'extend next', rel: 'next', href: link(current + 1) }, nextText));
+    tags.push(htmlTag('a', { class: 'extend next', rel: 'next', href: link(current + 1) }, nextText, false));
   }
 
   return tags.join('');

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hexo-fs": "^2.0.0",
     "hexo-i18n": "^1.0.0",
     "hexo-log": "^0.2.0",
-    "hexo-util": "^1.2.0",
+    "hexo-util": "^1.3.1",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",
     "micromatch": "^4.0.2",

--- a/test/scripts/helpers/paginator.js
+++ b/test/scripts/helpers/paginator.js
@@ -284,14 +284,14 @@ describe('paginator', () => {
   it('escape', () => {
     const result = paginator({
       current: 2,
-      prev_text: '<i class="fa fa-angle-left"</i>',
-      next_text: '<i class="fa fa-angle-right"</i>',
+      prev_text: '<foo>',
+      next_text: '<bar>',
       escape: false
     });
 
     result.should.eql([
       '<a class="extend prev" rel="prev" href="/">',
-      '<i class="fa fa-angle-left"</i></a>',
+      '<foo></a>',
       '<a class="page-number" href="/">1</a>',
       '<span class="page-number current">2</span>',
       '<a class="page-number" href="/page/3/">3</a>',
@@ -299,7 +299,7 @@ describe('paginator', () => {
       '<span class="space">&hellip;</span>',
       '<a class="page-number" href="/page/10/">10</a>',
       '<a class="extend next" rel="next" href="/page/3/">',
-      '<i class="fa fa-angle-right"</i></a>'
+      '<bar></a>'
     ].join(''));
   });
 });

--- a/test/scripts/helpers/paginator.js
+++ b/test/scripts/helpers/paginator.js
@@ -280,4 +280,26 @@ describe('paginator', () => {
 
     result.should.eql('');
   });
+
+  it('escape', () => {
+    const result = paginator({
+      current: 2,
+      prev_text: '<i class="fa fa-angle-left"</i>',
+      next_text: '<i class="fa fa-angle-right"</i>',
+      escape: false
+    });
+
+    result.should.eql([
+      '<a class="extend prev" rel="prev" href="/">',
+      '<i class="fa fa-angle-left"</i></a>',
+      '<a class="page-number" href="/">1</a>',
+      '<span class="page-number current">2</span>',
+      '<a class="page-number" href="/page/3/">3</a>',
+      '<a class="page-number" href="/page/4/">4</a>',
+      '<span class="space">&hellip;</span>',
+      '<a class="page-number" href="/page/10/">10</a>',
+      '<a class="extend next" rel="next" href="/page/3/">',
+      '<i class="fa fa-angle-right"</i></a>'
+    ].join(''));
+  });
 });

--- a/test/scripts/tags/link.js
+++ b/test/scripts/tags/link.js
@@ -8,20 +8,20 @@ describe('link', () => {
   it('text + url', () => {
     const $ = cheerio.load(link('Click here to Google https://google.com'.split(' ')));
 
-    $('a').attr('href').should.eql('https://google.com');
+    $('a').attr('href').should.eql('https://google.com/');
     $('a').html().should.eql('Click here to Google');
   });
 
   it('text + url + external', () => {
     let $ = cheerio.load(link('Click here to Google https://google.com true'.split(' ')));
 
-    $('a').attr('href').should.eql('https://google.com');
+    $('a').attr('href').should.eql('https://google.com/');
     $('a').html().should.eql('Click here to Google');
     $('a').attr('target').should.eql('_blank');
 
     $ = cheerio.load(link('Click here to Google https://google.com false'.split(' ')));
 
-    $('a').attr('href').should.eql('https://google.com');
+    $('a').attr('href').should.eql('https://google.com/');
     $('a').html().should.eql('Click here to Google');
     $('a').attr('title').should.eql('');
     $('a').attr('target').should.eql('');
@@ -30,7 +30,7 @@ describe('link', () => {
   it('text + url + title', () => {
     const $ = cheerio.load(link('Click here to Google https://google.com Google link'.split(' ')));
 
-    $('a').attr('href').should.eql('https://google.com');
+    $('a').attr('href').should.eql('https://google.com/');
     $('a').html().should.eql('Click here to Google');
     $('a').attr('title').should.eql('Google link');
   });
@@ -38,14 +38,14 @@ describe('link', () => {
   it('text + url + external + title', () => {
     let $ = cheerio.load(link('Click here to Google https://google.com true Google link'.split(' ')));
 
-    $('a').attr('href').should.eql('https://google.com');
+    $('a').attr('href').should.eql('https://google.com/');
     $('a').html().should.eql('Click here to Google');
     $('a').attr('target').should.eql('_blank');
     $('a').attr('title').should.eql('Google link');
 
     $ = cheerio.load(link('Click here to Google https://google.com false Google link'.split(' ')));
 
-    $('a').attr('href').should.eql('https://google.com');
+    $('a').attr('href').should.eql('https://google.com/');
     $('a').html().should.eql('Click here to Google');
     $('a').attr('target').should.eql('');
     $('a').attr('title').should.eql('Google link');


### PR DESCRIPTION
## What does it do?
htmlTag in hexo-util@1.3.0 onward escape html tag and encode url by default. This PR adds trailing slash to expected value of `href`; trailing slash is added by encodeURL() of html-util.

In paginator helper,
- `spaceHtml` is not escaped to avoid double escaping the '&hellip;'.
- add `escape` option (enabled by default). Closes https://github.com/hexojs/hexo/issues/3729


## How to test

```sh
git clone -b escape-html https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
