### PR TITLE
fix(mtime): Use UnixTime at all of the modified fields

### DIFF
--- a/lib/models/cache.js
+++ b/lib/models/cache.js
@@ -7,7 +7,7 @@ module.exports = ctx => {
   const Cache = new Schema({
     _id: {type: String, required: true},
     hash: {type: String, default: ''},
-    modified: {type: Number, default: Date.now}
+    modified: {type: Number, default: Date.now() } // UnixTime
   });
 
   Cache.static('compareFile', function(id, hashFn, statFn) {
@@ -19,7 +19,7 @@ module.exports = ctx => {
       return Promise.all([hashFn(id), statFn(id)]).spread((hash, stats) => this.insert({
         _id: id,
         hash,
-        modified: stats.mtime
+        modified: stats.mtime.getTime()
       })).thenReturn({
         type: 'create'
       });
@@ -29,7 +29,7 @@ module.exports = ctx => {
 
     // Get file stats
     return statFn(id).then(stats => {
-      mtime = stats.mtime;
+      mtime = stats.mtime.getTime();
 
       // Skip the file if the modified time is unchanged
       if (cache.modified === mtime) {

--- a/test/scripts/box/box.js
+++ b/test/scripts/box/box.js
@@ -158,8 +158,7 @@ describe('Box', () => {
     box.addProcessor(processor);
 
     return fs.writeFile(path, 'a').then(() => fs.stat(path)).then(stats => box.Cache.insert({
-      _id: cacheId,
-      modified: stats.mtime
+      _id: cacheId
     })).then(() => box.process()).then(() => {
       const file = processor.args[0][0];
       file.type.should.eql('update');


### PR DESCRIPTION
##  What does it do?

A current `modified` field mixed  `UnixTime` and `ISO8601`.
It seems `modified` field [expect to use UnixTime](https://github.com/hexojs/hexo/blob/2ed17cd105768df379dad8bbbe4df30964fe8f2d/lib/models/cache.js#L10) but `stats.mtime` return `ISO8601` format.

Migrates to warehouse `v3.0` test failure (#3736)  caused by this type of diff.
Because before warehouse `v3.0`, the warehouse `replaceById` method [return UnixTime](https://github.com/hexojs/warehouse/pull/19/files/b203b7c7a7178e46146ac3d7e02d8e17eea5a6e4#diff-a140b60b6a99a8c69f4b5d0d1f1f2bfaR333) forcibly.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

Nothing

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
