### PR TITLE
chore(deps): update warehouse from ^3.0.0 to ^3.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "text-table": "^0.2.0",
     "tildify": "^2.0.0",
     "titlecase": "^1.1.2",
-    "warehouse": "^3.0.0"
+    "warehouse": "^3.0.1"
   },
   "devDependencies": {
     "@easyops/git-exec-and-restage": "^1.0.4",


### PR DESCRIPTION
## What does it do?
Closes #3758 

This is mainly to update the warehouse in the CI, as user usually would get the latest minor/patch version of each dependency.

## How to test

```sh
git clone -b warehouse-3-0-1 https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
