### PR TITLE
solve There is a circle icon in front of every <li></li> when ahead o…

### DIFF
--- a/lib/plugins/helper/toc.js
+++ b/lib/plugins/helper/toc.js
@@ -41,7 +41,7 @@ function tocHelper(str, options = {}) {
 
     if (firstLevel) {
       for (let i = level; i < lastLevel; i++) {
-        result += '</li></ol>';
+        result += '</li>';
       }
 
       if (level > lastLevel) {


### PR DESCRIPTION
## Bug description
There is a circle icon in front of every `<li></li>` when ahead of used close tag `</ol>` in HOC part

## Bug source
```js
//file location: 'node_modules/hexo/lib/plugins/helper/toc.js   line 44'
     if (firstLevel) {
            for (let i = level; i < lastLevel; i++) {
                result += '</li></ol>';//should be=> result += '</li>';
            }

            if (level > lastLevel) {
                result += `<ol class="${className}-child">`;
            } else {
                result += '</li>';
            }
        } else {
            firstLevel = level;
        }

```

**Hexo and Plugin version(`npm ls --depth 0`)**

```
"hexo": "^3.9.0"
```

**Your package.json `package.json`**

```
{
  "name": "hexo-site",
  "version": "0.0.0",
  "private": true,
  "scripts": {
    "build": "hexo generate",
    "clean": "hexo clean",
    "deploy": "hexo deploy",
    "server": "hexo server"
  },
  "hexo": {
    "version": "3.9.0"
  },
  "dependencies": {
    "hexo": "^3.9.0",
    "hexo-deployer-git": "^2.0.0",
    "hexo-generator-archive": "^0.1.5",
    "hexo-generator-category": "^0.1.3",
    "hexo-generator-index": "^0.2.1",
    "hexo-generator-searchdb": "^1.1.0",
    "hexo-generator-tag": "^0.2.0",
    "hexo-renderer-ejs": "^0.3.1",
    "hexo-renderer-marked": "^2.0.0",
    "hexo-renderer-stylus": "^0.3.3",
    "hexo-server": "^0.3.3"
  }
}

```