### PR TITLE
Correct processing of backtick code block on blockquote (fix Issue#2969)

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -50,6 +50,7 @@ function backtickCodeBlock(data) {
       }
     }
 
+    // PR #3765
     const endOfStart = start.split('\n').pop();
     if (endOfStart && endOfStart.includes('>')) {
       const depth = endOfStart.split('>').length - 1;

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -3,7 +3,7 @@
 const stripIndent = require('strip-indent');
 const { highlight } = require('hexo-util');
 
-const rBacktick = /(\s*)(`{3,}|~{3,}) *(.*) *\n([\s\S]+?)\s*\2(\n+|$)/g;
+const rBacktick = /^((?:\s*>){0,3}\s*)(`{3,}|~{3,}) *(.*) *\n([\s\S]+?)\s*\2(\n+|$)/gm;
 const rAllOptions = /([^\s]+)\s+(.+?)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/;
 const rLangCaption = /([^\s]+)\s*(.+)?/;
 
@@ -48,6 +48,14 @@ function backtickCodeBlock(data) {
           }
         }
       }
+    }
+
+    const endOfStart = start.split('\n').pop();
+    if (endOfStart && endOfStart.includes('>')) {
+      const depth = endOfStart.split('>').length - 1;
+      const regexp = new RegExp(`^(\\s*>){0,${depth}}\\s`, 'mg');
+      const paddingOnEnd = ' '; // complement uncaptured whitespaces at last line
+      content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
     }
 
     content = highlight(stripIndent(content), options)

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -739,4 +739,67 @@ describe('Post', () => {
       ].join('\n'));
     });
   });
+
+  // test for Issue #2969
+  it('render() - backtick cocde block in blockquote', () => {
+    const code = 'alert("Hello world")';
+    const highlighted = util.highlight(code);
+    const quotedContent = [
+      'This is a code-block',
+      '',
+      '```',
+      code,
+      '```'
+    ];
+
+    const content = [
+      'Hello',
+      '',
+      ...quotedContent.map(s => '> ' + s)
+    ].join('\n');
+
+    return post.render(null, {
+      content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql([
+        '<p>Hello</p>',
+        '<blockquote>',
+        '<p>This is a code-block</p>',
+        highlighted + '</blockquote>'
+      ].join('\n'));
+    });
+  });
+
+  // test derived from Issue #2969
+  it('render() - "lang=dos" backtick cocde block in blockquote', () => {
+    const code = '> dir';
+    const highlighted = util.highlight(code);
+    const quotedContent = [
+      'This is a code-block',
+      '',
+      '```',
+      code,
+      '```'
+    ];
+
+    const content = [
+      'Hello',
+      '',
+      ...quotedContent.map(s => '> ' + s)
+    ].join('\n');
+
+    return post.render(null, {
+      content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql([
+        '<p>Hello</p>',
+        '<blockquote>',
+        '<p>This is a code-block</p>',
+        highlighted + '</blockquote>'
+      ].join('\n'));
+    });
+  });
+
 });


### PR DESCRIPTION
## What does it do?

Fix #2969 

This patch makes the filter "backtick_code_block" to remove '>' characters at the head of each line.
How many '>' characters should be removed?
It is decided by the number of '>' characters at the first line.
This patch works well even if there are too few '>' characters at the head of a line.
(Simply removes all '>' characters less than or equal to the number of '>' characters at the first lines.)

Note that this patch works well for a "lang=dos" or "lang=cmd" code block.
The body of these code blocks is usually starting with '>' (DOS prompt).
This patch keeps it if it follows '>' characters which is the same number of the first line.

For example,

`````
> Hello
> 
> ```dos
> > dir
> ```
`````

is rendered to:

`````
<p>Hello</p>
<blockquote>
<pre><code>&gt; dir</code></pre>
</blockquote>
`````

This PR is an alternative of the PR hexojs/hexo-util#110

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
