### PR TITLE
Disable to insert extra new line character into the end of backtick code block (fix #3767)

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -63,7 +63,7 @@ function backtickCodeBlock(data) {
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;');
 
-    return `${start}<escape>${content}</escape>${end ? '\n\n' : ''}`;
+    return `${start}<escape>${content}</escape>${end}`;
   });
 }
 

--- a/test/fixtures/post_render.js
+++ b/test/fixtures/post_render.js
@@ -29,7 +29,7 @@ exports.content = content;
 exports.expected = [
   '<h1 id="Title"><a href="#Title" class="headerlink" title="Title"></a>Title</h1>',
   util.highlight(code, {lang: 'python'}),
-  '\n\n<p>some content</p>\n',
+  '\n<p>some content</p>\n',
   '<h2 id="Another-title"><a href="#Another-title" class="headerlink" title="Another title"></a>Another title</h2>',
   '<blockquote>',
   '<p>quote content</p>\n',
@@ -41,7 +41,7 @@ exports.expected = [
 exports.expected_disable_nunjucks = [
   '<h1 id="Title"><a href="#Title" class="headerlink" title="Title"></a>Title</h1>',
   util.highlight(code, {lang: 'python'}),
-  '\n\n<p>some content</p>\n',
+  '\n<p>some content</p>\n',
   '<h2 id="Another-title"><a href="#Another-title" class="headerlink" title="Another title"></a>Another title</h2>',
   '<p>{% blockquote %}<br>',
   'quote content<br>',

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -734,8 +734,7 @@ describe('Post', () => {
       content
     }).then(data => {
       data.content.trim().should.eql([
-        '<blockquote>' + highlighted,
-        '</blockquote>'
+        '<blockquote>' + highlighted + '</blockquote>'
       ].join('\n'));
     });
   });
@@ -798,6 +797,42 @@ describe('Post', () => {
         '<blockquote>',
         '<p>This is a code-block</p>',
         highlighted + '</blockquote>'
+      ].join('\n'));
+    });
+  });
+
+  // test for Issue #3767
+  it('render() - backtick cocde block (followed by a paragraph) in blockquote', () => {
+    const code = 'alert("Hello world")';
+    const highlighted = util.highlight(code);
+    const quotedContent = [
+      'This is a code-block',
+      '',
+      '```',
+      code,
+      '```',
+      '',
+      'This is a following paragraph'
+    ];
+
+    const content = [
+      'Hello',
+      '',
+      ...quotedContent.map(s => '> ' + s)
+    ].join('\n');
+
+    return post.render(null, {
+      content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql([
+        '<p>Hello</p>',
+        '<blockquote>',
+        '<p>This is a code-block</p>',
+        highlighted,
+        '',
+        '<p>This is a following paragraph</p>',
+        '</blockquote>'
       ].join('\n'));
     });
   });


### PR DESCRIPTION
## What does it do?

Fix #3767

A paragraph follows a backtick code block on a blockquote should be included same blcokquote block.
But the code block always terminates blockquote.
So the blockquote block splits two blocks.

This is caused by the implementation of `backtick_code_block.js`.
It inserts extra new line character into the end of backtick code block.

This patch disables this behavior.

## How to test

```sh
$ npm test
```

## Pull request tasks

- [X] Add test cases for the changes.
- [x] Passed the CI test.
