### PR TITLE
Keep blank lines in backtick code block on blockquote (fix #3769)

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -3,7 +3,7 @@
 const stripIndent = require('strip-indent');
 const { highlight } = require('hexo-util');
 
-const rBacktick = /^((?:\s*>){0,3}\s*)(`{3,}|~{3,}) *(.*) *\n([\s\S]+?)\s*\2(\n+|$)/gm;
+const rBacktick = /^((?:[^\S\r\n]*>){0,3}[^\S\r\n]*)(`{3,}|~{3,}) *(.*) *\n([\s\S]+?)\s*\2(\n+|$)/gm;
 const rAllOptions = /([^\s]+)\s+(.+?)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/;
 const rLangCaption = /([^\s]+)\s*(.+)?/;
 
@@ -51,10 +51,9 @@ function backtickCodeBlock(data) {
     }
 
     // PR #3765
-    const endOfStart = start.split('\n').pop();
-    if (endOfStart && endOfStart.includes('>')) {
-      const depth = endOfStart.split('>').length - 1;
-      const regexp = new RegExp(`^(\\s*>){0,${depth}}\\s`, 'mg');
+    if (start.includes('>')) {
+      const depth = start.split('>').length - 1;
+      const regexp = new RegExp(`^([^\\S\\r\\n]*>){0,${depth}}([^\\S\\r\\n]|$)`, 'mg');
       const paddingOnEnd = ' '; // complement uncaptured whitespaces at last line
       content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
     }

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -837,4 +837,55 @@ describe('Post', () => {
     });
   });
 
+  // test for Issue #3769
+  it('render() - blank lines in backtick cocde block in blockquote', () => {
+    const code = [
+      '',
+      '',
+      '',
+      '{',
+      '  "test": 123',
+      '',
+      '',
+      '}',
+      ''
+    ];
+    const highlighted = util.highlight(code.join('\n'));
+    const addQuote = s => '>' + (s ? ` ${s}` : '');
+    const code2 = code.map((s, i) => {
+      if (i === 0 || i === 2 || i === 6) return addQuote(s);
+      return s;
+    });
+    const quotedContent = [
+      'This is a code-block',
+      '',
+      '> ```',
+      ...code2,
+      '```',
+      '',
+      'This is a following paragraph'
+    ];
+    const content = [
+      'Hello',
+      '',
+      ...quotedContent.map(addQuote)
+    ].join('\n');
+
+    return post.render(null, {
+      content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql([
+        '<p>Hello</p>',
+        '<blockquote>',
+        '<p>This is a code-block</p>',
+        '<blockquote>',
+        highlighted.replace('{', '&#123;').replace('}', '&#125;'),
+        '</blockquote>',
+        '<p>This is a following paragraph</p>',
+        '</blockquote>'
+      ].join('\n'));
+    });
+  });
+
 });


### PR DESCRIPTION
## What does it do?

fix #3769

Blank lines in backtick code block on blockquote should be kept.
But `backtick_code_block.js` removes them.
This patch fixes this behavior.

This bug is introduced by the PR #3765

## How to test

```sh
npm test
```

## Pull request tasks

- [X] Add test cases for the changes.
- [ ] Passed the CI test.
