### PR TITLE
fix(meta_generator): handle multi-line head tag correctly

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,5 +13,8 @@
         "after": true
       }
     ]
+  },
+  "parserOptions": {
+    "ecmaVersion": 2018
   }
 }

--- a/lib/plugins/filter/after_render/meta_generator.js
+++ b/lib/plugins/filter/after_render/meta_generator.js
@@ -7,7 +7,7 @@ function hexoMetaGeneratorInject(data) {
 
   const hexoGeneratorTag = `<meta name="generator" content="Hexo ${this.version}">`;
 
-  return data.replace(/<head>(?!<\/head>).+?<\/head>/, (str) => str.replace('</head>', `${hexoGeneratorTag}</head>`));
+  return data.replace(/<head>(?!<\/head>).+?<\/head>/s, (str) => str.replace('</head>', `${hexoGeneratorTag}</head>`));
 }
 
 module.exports = hexoMetaGeneratorInject;

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "sinon": "^7.1.1"
   },
   "engines": {
-    "node": ">=8.6.0"
+    "node": ">=8.10.0"
   },
   "husky": {
     "hooks": {

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -65,4 +65,18 @@ describe('Meta Generator', () => {
     + '<head><link></head>';
     result.should.eql(expected);
   });
+
+  // Test for Issue #3777
+  it('multi-line head', () => {
+    const content = '<head>\n<link>\n</head>';
+    hexo.config.meta_generator = true;
+    const result = metaGenerator(content);
+
+    const $ = cheerio.load(result);
+    $('meta[name="generator"]').length.should.eql(1);
+
+    const expected = '<head>\n<link>\n<meta name="generator" content="Hexo ' + hexo.version + '"></head>';
+
+    result.should.eql(expected);
+  });
 });


### PR DESCRIPTION
## What does it do?
Fix https://github.com/hexojs/hexo/issues/3777
BREAKING CHANGE: requires Node >= 8.10
- https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/dotAll
- https://node.green/#ES2018-features

## How to test

```sh
git clone -b meta-gen-fix https://github.com/hexojs/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
