### PR TITLE
ci: delete distribution version at travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,3 @@ script:
 after_script:
   - npm install coveralls
   - nyc report --reporter=text-lcov | coveralls
-
-dist: trusty


### PR DESCRIPTION
## What does it do?

Current [.travis.yml](https://github.com/hexojs/hexo/blob/52adf3913ac7eab26607722b6edca6685f184567/.travis.yml) are specified which distribution should use. And it's `ubuntu 14.04 (Xenial)`. It's too old.

Now, the TravisCI uses [Ubuntu 16.04(Xenial)](https://docs.travis-ci.com/user/reference/overview/#linux) by default.

I prefer to use the latest `18.04 (bionic)`. But, it very costally for us if we specify all repo's `.travis.yml` dist version. IMHO we should use the default to save our maintain time.

> [travis.yml list of specified dist](https://github.com/search?l=YAML&q=org%3Ahexojs+dist&type=Code)

## How to test

Nothing

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
