### PR TITLE
docs: add compatibility with Node.js

### DIFF
--- a/docs/nodejs-compatiblility.md
+++ b/docs/nodejs-compatiblility.md
@@ -1,0 +1,17 @@
+# Node.js compatibility
+
+Hexo runs on the [Node.js](https://nodejs.org). Sometimes we may drop compatibility with old Node.js, to use new features of Node.js and keep up to date of dependencies.
+
+## Compatibility with Node.js
+
+Following is a list of minimum required Node.js version in each version of Hexo.
+
+|Hexo version|Minimum required Node.js version|
+|---|---|
+|4.x|8.6|
+|3.6.x - 3.9.x|6.9|
+|0.0.1 - 3.5.x|-|
+
+## References
+
+> [Node.js release](https://github.com/nodejs/Release)


### PR DESCRIPTION
## What does it do?

Currently, we have to update `ISSUE_TEMPLATE` and [site requirements section](https://hexo.io/docs/#Requirements) whenever we drop older Node.js support.

I suggest create compatibility document and that `ISSUE_TEMPLATE` and [site requirements section](https://hexo.io/docs/#Requirements) refers to it.

It may help users. Users will be able to know what version they need.

---

Engines option introduce [this commit](https://github.com/hexojs/hexo/commit/5a9a76efe9d1e59fe4509d0516bcc332a02f3948). And it's released `3.6.0`.

## How to test

Nothing

## Screenshots

Nothing

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
