### PR TITLE
fix(save_database): should not clear database when use 'hexo new', 'hexo --help', etc.

### DIFF
--- a/lib/plugins/filter/before_exit/save_database.js
+++ b/lib/plugins/filter/before_exit/save_database.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function saveDatabaseFilter() {
-  if (!this.env.init) return;
+  if (!this.env.init || !this._dbLoaded) return;
 
   return this.database.save().then(() => {
     this.log.debug('Database saved');

--- a/test/scripts/filters/save_database.js
+++ b/test/scripts/filters/save_database.js
@@ -11,6 +11,7 @@ describe('Save database', () => {
 
   it('default', () => {
     hexo.env.init = true;
+    hexo._dbLoaded = true;
 
     return saveDatabase().then(() => fs.exists(dbPath)).then(exist => {
       exist.should.be.true;
@@ -20,6 +21,16 @@ describe('Save database', () => {
 
   it('do nothing if hexo is not initialized', () => {
     hexo.env.init = false;
+    hexo._dbLoaded = true;
+
+    return saveDatabase().then(() => fs.exists(dbPath)).then(exist => {
+      exist.should.be.false;
+    });
+  });
+
+  it('do nothing if database is not loaded', () => {
+    hexo.env.init = true;
+    hexo._dbLoaded = false;
 
     return saveDatabase().then(() => fs.exists(dbPath)).then(exist => {
       exist.should.be.false;


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

After run `hexo` commands such as `hexo --version`, `hexo new`, 
the content of `db.json' file was cleared.
It is inconvenient for a site with a lot of posts.

This PR fixes this issue by saving the database only when the database was loaded.

## How to test

```sh
git clone -b fix-save-database https://github.com/dailyrandomphoto/hexo.git
cd hexo
npm install
npm test
```

```sh
git clone https://github.com/hexojs/site.git
cd site
vi package.json
```
Change the version of hexo.
```diff
- "hexo": "hexojs/hexo"
+ "hexo": "dailyrandomphoto/hexo#fix-save-database"
```
Install and generate site.
```sh
npm install
npm run build
```
Check out the `db.json` file.
```
hexo --version
# or 
hexo new page "somepage"
```
Check out the `db.json` file.
The content of `db.json` should not be cleared.


## Screenshots

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
