### PR TITLE
Disable fs.watch() for dirs/files specified by "ignore" option

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -30,6 +30,10 @@ function Box(ctx, base, options) {
   this.Cache = ctx.model('Cache');
   this.File = this._createFileClass();
   this.ignore = ctx.config.ignore;
+  if (ctx.config.ignore) {
+    const targets = Array.isArray(ctx.config.ignore) ? ctx.config.ignore : [ctx.config.ignore];
+    this.options.ignored = (this.options.ignored || []).concat(targets.map(s => toRegExp(ctx, s)).filter(x => x));
+  }
 }
 
 require('util').inherits(Box, EventEmitter);
@@ -50,6 +54,20 @@ function getHash(path) {
       })
       .on('error', reject);
   });
+}
+
+function toRegExp(ctx, arg) {
+  if (!arg) return null;
+  if (typeof arg !== 'string') {
+    ctx.log.warn('A value of "ignore:" section in "_config.yml" is not invalid (not a string)');
+    return null;
+  }
+  const result = micromatch.makeRe(arg);
+  if (!result) {
+    ctx.log.warn('A value of "ignore:" section in "_config.yml" can not be converted to RegExp:' + arg);
+    return null;
+  }
+  return result;
 }
 
 Box.prototype._createFileClass = function() {


### PR DESCRIPTION
# What does it do?

Disable `fs.watch()` for dirs/files which are specified by `ignore` option in `_config.yml`.

This patch is supplement to #2631.

Fix #2179, #1316, hexojs/hexo-server#45.
And also, maybe mitigate #2090, hexojs/hexo-server#21.

## How to test

```sh
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
