### PR TITLE
Add lazyload to iframe related tags

### DIFF
--- a/lib/plugins/tag/iframe.js
+++ b/lib/plugins/tag/iframe.js
@@ -12,7 +12,7 @@ function iframeTag(args, content) {
   const width = args[1] && args[1] !== 'default' ? args[1] : '100%';
   const height = args[2] && args[2] !== 'default' ? args[2] : '300';
 
-  return `<iframe src="${url}" width="${width}" height="${height}" frameborder="0" allowfullscreen></iframe>`;
+  return `<iframe src="${url}" width="${width}" height="${height}" frameborder="0" loading="lazy" allowfullscreen></iframe>`;
 }
 
 module.exports = iframeTag;

--- a/lib/plugins/tag/jsfiddle.js
+++ b/lib/plugins/tag/jsfiddle.js
@@ -14,7 +14,7 @@ function jsfiddleTag(args, content) {
   const width = args[3] && args[3] !== 'default' ? args[3] : '100%';
   const height = args[4] && args[4] !== 'default' ? args[4] : '300';
 
-  return `<iframe scrolling="no" width="${width}" height="${height}" src="//jsfiddle.net/${id}/embedded/${tabs}/${skin}" frameborder="0" allowfullscreen></iframe>`;
+  return `<iframe scrolling="no" width="${width}" height="${height}" src="//jsfiddle.net/${id}/embedded/${tabs}/${skin}" frameborder="0" loading="lazy" allowfullscreen></iframe>`;
 }
 
 module.exports = jsfiddleTag;

--- a/lib/plugins/tag/vimeo.js
+++ b/lib/plugins/tag/vimeo.js
@@ -10,7 +10,7 @@
 function vimeoTag(args, content) {
   const id = args[0];
 
-  return `<div class="video-container"><iframe src="//player.vimeo.com/video/${id}" frameborder="0" allowfullscreen></iframe></div>`;
+  return `<div class="video-container"><iframe src="//player.vimeo.com/video/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
 }
 
 module.exports = vimeoTag;

--- a/lib/plugins/tag/youtube.js
+++ b/lib/plugins/tag/youtube.js
@@ -10,7 +10,7 @@
 function youtubeTag(args, content) {
   const id = args[0];
 
-  return `<div class="video-container"><iframe src="//www.youtube.com/embed/${id}" frameborder="0" allowfullscreen></iframe></div>`;
+  return `<div class="video-container"><iframe src="//www.youtube.com/embed/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
 }
 
 module.exports = youtubeTag;

--- a/test/scripts/tags/iframe.js
+++ b/test/scripts/tags/iframe.js
@@ -13,6 +13,7 @@ describe('iframe', () => {
     $('iframe').attr('height').should.eql('300');
     $('iframe').attr('frameborder').should.eql('0');
     $('iframe').attr('allowfullscreen').should.eql('');
+    $('iframe').attr('loading').should.eql('lazy');
   });
 
   it('width', () => {
@@ -23,6 +24,7 @@ describe('iframe', () => {
     $('iframe').attr('height').should.eql('300');
     $('iframe').attr('frameborder').should.eql('0');
     $('iframe').attr('allowfullscreen').should.eql('');
+    $('iframe').attr('loading').should.eql('lazy');
   });
 
   it('height', () => {
@@ -33,5 +35,6 @@ describe('iframe', () => {
     $('iframe').attr('height').should.eql('600');
     $('iframe').attr('frameborder').should.eql('0');
     $('iframe').attr('allowfullscreen').should.eql('');
+    $('iframe').attr('loading').should.eql('lazy');
   });
 });

--- a/test/scripts/tags/vimeo.js
+++ b/test/scripts/tags/vimeo.js
@@ -12,5 +12,6 @@ describe('vimeo', () => {
     $('iframe').attr('src').should.eql('//player.vimeo.com/video/foo');
     $('iframe').attr('frameborder').should.eql('0');
     $('iframe').attr('allowfullscreen').should.eql('');
+    $('iframe').attr('loading').should.eql('lazy');
   });
 });

--- a/test/scripts/tags/youtube.js
+++ b/test/scripts/tags/youtube.js
@@ -12,5 +12,6 @@ describe('youtube', () => {
     $('iframe').attr('src').should.eql('//www.youtube.com/embed/foo');
     $('iframe').attr('frameborder').should.eql('0');
     $('iframe').attr('allowfullscreen').should.eql('');
+    $('iframe').attr('loading').should.eql('lazy');
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Add `loading="lazy"` to iframe to enable native lazyload which is already supported by Chrome.
See https://github.com/scott-little/lazyload .

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
