### PR TITLE
ci: add node 13 and updating caching option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,7 @@ addons:
     - time
 
 cache:
-  apt: true
-  directories:
-    - node_modules
+  npm: true
 
 node_js:
   - "8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ cache:
 node_js:
   - "8"
   - "10"
-  - "node"
+  - "12"
+  - "13"
 
 script:
   - npm run eslint


### PR DESCRIPTION
##  What does it do?
[Node 13](https://github.com/nodejs/Release) is released a few days ago. Specify versions for clarity.

Use newer syntax for npm caching. The option is retained so that it's easy to disable, even though it's enabled [by default](https://docs.travis-ci.com/user/caching/#npm-cache).

Alternative syntax is `cache: npm`, but having a boolean is clearer.

## How to test

```sh
git clone -b ci-node-13 https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
