### PR TITLE
refactor(iframe_tags): utilize htmlTag function

### DIFF
--- a/lib/plugins/tag/iframe.js
+++ b/lib/plugins/tag/iframe.js
@@ -10,14 +10,14 @@ const { htmlTag } = require('hexo-util');
 */
 
 function iframeTag(args) {
-  const url = args[0];
+  const src = args[0];
   const width = args[1] && args[1] !== 'default' ? args[1] : '100%';
   const height = args[2] && args[2] !== 'default' ? args[2] : '300';
 
   const attrs = {
-    src: url,
-    width: width,
-    height: height,
+    src,
+    width,
+    height,
     frameborder: '0',
     loading: 'lazy',
     allowfullscreen: true

--- a/lib/plugins/tag/iframe.js
+++ b/lib/plugins/tag/iframe.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { htmlTag } = require('hexo-util');
+
 /**
 * Iframe tag
 *
@@ -12,7 +14,16 @@ function iframeTag(args) {
   const width = args[1] && args[1] !== 'default' ? args[1] : '100%';
   const height = args[2] && args[2] !== 'default' ? args[2] : '300';
 
-  return `<iframe src="${url}" width="${width}" height="${height}" frameborder="0" loading="lazy" allowfullscreen></iframe>`;
+  const attrs = {
+    src: url,
+    width: width,
+    height: height,
+    frameborder: '0',
+    loading: 'lazy',
+    allowfullscreen: true
+  };
+
+  return htmlTag('iframe', attrs, '');
 }
 
 module.exports = iframeTag;

--- a/lib/plugins/tag/iframe.js
+++ b/lib/plugins/tag/iframe.js
@@ -7,7 +7,7 @@
 *   {% iframe url [width] [height] %}
 */
 
-function iframeTag(args, content) {
+function iframeTag(args) {
   const url = args[0];
   const width = args[1] && args[1] !== 'default' ? args[1] : '100%';
   const height = args[2] && args[2] !== 'default' ? args[2] : '300';

--- a/lib/plugins/tag/jsfiddle.js
+++ b/lib/plugins/tag/jsfiddle.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { htmlTag } = require('hexo-util');
+
 /**
 * jsFiddle tag
 *
@@ -14,7 +16,19 @@ function jsfiddleTag(args) {
   const width = args[3] && args[3] !== 'default' ? args[3] : '100%';
   const height = args[4] && args[4] !== 'default' ? args[4] : '300';
 
-  return `<iframe scrolling="no" width="${width}" height="${height}" src="https://jsfiddle.net/${id}/embedded/${tabs}/${skin}" frameborder="0" loading="lazy" allowfullscreen></iframe>`;
+  const url = `https://jsfiddle.net/${id}/embedded/${tabs}/${skin}`;
+
+  const attrs = {
+    scrolling: 'no',
+    width: width,
+    height: height,
+    src: url,
+    frameborder: '0',
+    loading: 'lazy',
+    allowfullscreen: true
+  };
+
+  return htmlTag('iframe', attrs, '');
 }
 
 module.exports = jsfiddleTag;

--- a/lib/plugins/tag/jsfiddle.js
+++ b/lib/plugins/tag/jsfiddle.js
@@ -7,7 +7,7 @@
 *   {% jsfiddle shorttag [tabs] [skin] [height] [width] %}
 */
 
-function jsfiddleTag(args, content) {
+function jsfiddleTag(args) {
   const id = args[0];
   const tabs = args[1] && args[1] !== 'default' ? args[1] : 'js,resources,html,css,result';
   const skin = args[2] && args[2] !== 'default' ? args[2] : 'light';

--- a/lib/plugins/tag/jsfiddle.js
+++ b/lib/plugins/tag/jsfiddle.js
@@ -15,14 +15,13 @@ function jsfiddleTag(args) {
   const skin = args[2] && args[2] !== 'default' ? args[2] : 'light';
   const width = args[3] && args[3] !== 'default' ? args[3] : '100%';
   const height = args[4] && args[4] !== 'default' ? args[4] : '300';
-
-  const url = `https://jsfiddle.net/${id}/embedded/${tabs}/${skin}`;
+  const src = `https://jsfiddle.net/${id}/embedded/${tabs}/${skin}`;
 
   const attrs = {
     scrolling: 'no',
-    width: width,
-    height: height,
-    src: url,
+    width,
+    height,
+    src,
     frameborder: '0',
     loading: 'lazy',
     allowfullscreen: true

--- a/lib/plugins/tag/jsfiddle.js
+++ b/lib/plugins/tag/jsfiddle.js
@@ -14,7 +14,7 @@ function jsfiddleTag(args, content) {
   const width = args[3] && args[3] !== 'default' ? args[3] : '100%';
   const height = args[4] && args[4] !== 'default' ? args[4] : '300';
 
-  return `<iframe scrolling="no" width="${width}" height="${height}" src="//jsfiddle.net/${id}/embedded/${tabs}/${skin}" frameborder="0" loading="lazy" allowfullscreen></iframe>`;
+  return `<iframe scrolling="no" width="${width}" height="${height}" src="https://jsfiddle.net/${id}/embedded/${tabs}/${skin}" frameborder="0" loading="lazy" allowfullscreen></iframe>`;
 }
 
 module.exports = jsfiddleTag;

--- a/lib/plugins/tag/vimeo.js
+++ b/lib/plugins/tag/vimeo.js
@@ -7,9 +7,7 @@
 *   {% vimeo video_id %}
 */
 
-function vimeoTag(args, content) {
-  const id = args[0];
-
+function vimeoTag(id) {
   return `<div class="video-container"><iframe src="https://player.vimeo.com/video/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
 }
 

--- a/lib/plugins/tag/vimeo.js
+++ b/lib/plugins/tag/vimeo.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { htmlTag } = require('hexo-util');
+
 /**
 * Vimeo tag
 *
@@ -8,7 +10,16 @@
 */
 
 function vimeoTag(id) {
-  return `<div class="video-container"><iframe src="https://player.vimeo.com/video/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
+  const url = 'https://player.vimeo.com/video/' + id;
+
+  const iframeTag = htmlTag('iframe', {
+    src: url,
+    frameborder: '0',
+    loading: 'lazy',
+    allowfullscreen: true
+  }, '');
+
+  return htmlTag('div', { class: 'video-container' }, iframeTag, false);
 }
 
 module.exports = vimeoTag;

--- a/lib/plugins/tag/vimeo.js
+++ b/lib/plugins/tag/vimeo.js
@@ -10,10 +10,10 @@ const { htmlTag } = require('hexo-util');
 */
 
 function vimeoTag(id) {
-  const url = 'https://player.vimeo.com/video/' + id;
+  const src = 'https://player.vimeo.com/video/' + id;
 
   const iframeTag = htmlTag('iframe', {
-    src: url,
+    src,
     frameborder: '0',
     loading: 'lazy',
     allowfullscreen: true

--- a/lib/plugins/tag/vimeo.js
+++ b/lib/plugins/tag/vimeo.js
@@ -10,7 +10,7 @@
 function vimeoTag(args, content) {
   const id = args[0];
 
-  return `<div class="video-container"><iframe src="//player.vimeo.com/video/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
+  return `<div class="video-container"><iframe src="https://player.vimeo.com/video/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
 }
 
 module.exports = vimeoTag;

--- a/lib/plugins/tag/youtube.js
+++ b/lib/plugins/tag/youtube.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { htmlTag } = require('hexo-util');
+
 /**
 * Youtube tag
 *
@@ -8,7 +10,16 @@
 */
 
 function youtubeTag(id) {
-  return `<div class="video-container"><iframe src="https://www.youtube.com/embed/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
+  const url = 'https://www.youtube.com/embed/' + id;
+
+  const iframeTag = htmlTag('iframe', {
+    src: url,
+    frameborder: '0',
+    loading: 'lazy',
+    allowfullscreen: true
+  }, '');
+
+  return htmlTag('div', { class: 'video-container' }, iframeTag, false);
 }
 
 module.exports = youtubeTag;

--- a/lib/plugins/tag/youtube.js
+++ b/lib/plugins/tag/youtube.js
@@ -10,10 +10,10 @@ const { htmlTag } = require('hexo-util');
 */
 
 function youtubeTag(id) {
-  const url = 'https://www.youtube.com/embed/' + id;
+  const src = 'https://www.youtube.com/embed/' + id;
 
   const iframeTag = htmlTag('iframe', {
-    src: url,
+    src,
     frameborder: '0',
     loading: 'lazy',
     allowfullscreen: true

--- a/lib/plugins/tag/youtube.js
+++ b/lib/plugins/tag/youtube.js
@@ -10,7 +10,7 @@
 function youtubeTag(args, content) {
   const id = args[0];
 
-  return `<div class="video-container"><iframe src="//www.youtube.com/embed/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
+  return `<div class="video-container"><iframe src="https://www.youtube.com/embed/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
 }
 
 module.exports = youtubeTag;

--- a/lib/plugins/tag/youtube.js
+++ b/lib/plugins/tag/youtube.js
@@ -7,9 +7,7 @@
 *   {% youtube video_id %}
 */
 
-function youtubeTag(args, content) {
-  const id = args[0];
-
+function youtubeTag(id) {
   return `<div class="video-container"><iframe src="https://www.youtube.com/embed/${id}" frameborder="0" loading="lazy" allowfullscreen></iframe></div>`;
 }
 

--- a/test/scripts/tags/iframe.js
+++ b/test/scripts/tags/iframe.js
@@ -8,7 +8,7 @@ describe('iframe', () => {
   it('url', () => {
     const $ = cheerio.load(iframe(['https://zespia.tw']));
 
-    $('iframe').attr('src').should.eql('https://zespia.tw');
+    $('iframe').attr('src').should.eql('https://zespia.tw/');
     $('iframe').attr('width').should.eql('100%');
     $('iframe').attr('height').should.eql('300');
     $('iframe').attr('frameborder').should.eql('0');
@@ -19,7 +19,7 @@ describe('iframe', () => {
   it('width', () => {
     const $ = cheerio.load(iframe(['https://zespia.tw', '500']));
 
-    $('iframe').attr('src').should.eql('https://zespia.tw');
+    $('iframe').attr('src').should.eql('https://zespia.tw/');
     $('iframe').attr('width').should.eql('500');
     $('iframe').attr('height').should.eql('300');
     $('iframe').attr('frameborder').should.eql('0');
@@ -30,7 +30,7 @@ describe('iframe', () => {
   it('height', () => {
     const $ = cheerio.load(iframe(['https://zespia.tw', '500', '600']));
 
-    $('iframe').attr('src').should.eql('https://zespia.tw');
+    $('iframe').attr('src').should.eql('https://zespia.tw/');
     $('iframe').attr('width').should.eql('500');
     $('iframe').attr('height').should.eql('600');
     $('iframe').attr('frameborder').should.eql('0');

--- a/test/scripts/tags/jsfiddle.js
+++ b/test/scripts/tags/jsfiddle.js
@@ -8,27 +8,27 @@ describe('jsfiddle', () => {
   it('id', () => {
     const $ = cheerio.load(jsfiddle(['foo']));
 
-    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
+    $('iframe').attr('src').should.eql('https://jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
   });
 
   it('tabs', () => {
     let $ = cheerio.load(jsfiddle(['foo', 'default']));
 
-    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
+    $('iframe').attr('src').should.eql('https://jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
 
     $ = cheerio.load(jsfiddle(['foo', 'html,css']));
 
-    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/html,css/light');
+    $('iframe').attr('src').should.eql('https://jsfiddle.net/foo/embedded/html,css/light');
   });
 
   it('skin', () => {
     let $ = cheerio.load(jsfiddle(['foo', 'default', 'default']));
 
-    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
+    $('iframe').attr('src').should.eql('https://jsfiddle.net/foo/embedded/js,resources,html,css,result/light');
 
     $ = cheerio.load(jsfiddle(['foo', 'default', 'dark']));
 
-    $('iframe').attr('src').should.eql('//jsfiddle.net/foo/embedded/js,resources,html,css,result/dark');
+    $('iframe').attr('src').should.eql('https://jsfiddle.net/foo/embedded/js,resources,html,css,result/dark');
   });
 
   it('width', () => {

--- a/test/scripts/tags/vimeo.js
+++ b/test/scripts/tags/vimeo.js
@@ -9,7 +9,7 @@ describe('vimeo', () => {
     const $ = cheerio.load(vimeo(['foo']));
 
     $('.video-container').html().should.be.ok;
-    $('iframe').attr('src').should.eql('//player.vimeo.com/video/foo');
+    $('iframe').attr('src').should.eql('https://player.vimeo.com/video/foo');
     $('iframe').attr('frameborder').should.eql('0');
     $('iframe').attr('allowfullscreen').should.eql('');
     $('iframe').attr('loading').should.eql('lazy');

--- a/test/scripts/tags/youtube.js
+++ b/test/scripts/tags/youtube.js
@@ -9,7 +9,7 @@ describe('youtube', () => {
     const $ = cheerio.load(youtube(['foo']));
 
     $('.video-container').html().should.be.ok;
-    $('iframe').attr('src').should.eql('//www.youtube.com/embed/foo');
+    $('iframe').attr('src').should.eql('https://www.youtube.com/embed/foo');
     $('iframe').attr('frameborder').should.eql('0');
     $('iframe').attr('allowfullscreen').should.eql('');
     $('iframe').attr('loading').should.eql('lazy');


### PR DESCRIPTION
## What does it do?
1. Always use https for jsfiddle, vimeo and youtube
2. create tag using [`htmlTag()`](https://github.com/hexojs/hexo-util#htmltagtag-attrs-text-escape). A benefit is that it encodes url and escapes unsafe values by default.


## How to test

```sh
git clone -b https-frame https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
