### PR TITLE
fix(open_graph): locale must in language_TERRITORY format

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -32,7 +32,7 @@ function openGraphHelper(options = {}) {
   const twitterCard = options.twitter_card || 'summary';
   const date = options.date !== false ? options.date || page.date : false;
   const updated = options.updated !== false ? options.updated || page.updated : false;
-  const language = options.language || page.lang || page.language || config.language;
+  let language = options.language || page.lang || page.language || config.language;
   const author = options.author || config.author;
 
   if (!Array.isArray(images)) images = [images];
@@ -84,7 +84,9 @@ function openGraphHelper(options = {}) {
   }
 
   if (language) {
-    result += og('og:locale', language);
+    language = language.replace('-', '_');
+
+    if (language.length === 5) result += og('og:locale', language);
   }
 
   images = images.map(path => {

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -86,8 +86,9 @@ function openGraphHelper(options = {}) {
   if (language) {
     if (language.length === 5) {
       const territory = language.slice(-2);
+      const territoryRegex = new RegExp(territory.concat('$'), 'i');
 
-      language = language.replace('-', '_').replace(territory, territory.toUpperCase());
+      language = language.replace('-', '_').replace(territoryRegex, territory.toUpperCase());
 
       result += og('og:locale', language);
     }

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -84,9 +84,13 @@ function openGraphHelper(options = {}) {
   }
 
   if (language) {
-    language = language.replace('-', '_');
+    if (language.length === 5) {
+      const territory = language.slice(-2);
 
-    if (language.length === 5) result += og('og:locale', language);
+      language = language.replace('-', '_').replace(territory, territory.toUpperCase());
+
+      result += og('og:locale', language);
+    }
   }
 
   images = images.map(path => {

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -86,7 +86,7 @@ function openGraphHelper(options = {}) {
   if (language) {
     if (language.length === 5) {
       const territory = language.slice(-2);
-      const territoryRegex = new RegExp(territory.concat('$'), 'i');
+      const territoryRegex = new RegExp(territory.concat('$'));
 
       language = language.replace('-', '_').replace(territoryRegex, territory.toUpperCase());
 

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -613,7 +613,7 @@ describe('open_graph', () => {
       is_post: isPost
     }, {language: 'es-cr'});
 
-    result.should.contain(meta({property: 'og:locale', content: 'es_cr'}));
+    result.should.contain(meta({property: 'og:locale', content: 'es_CR'}));
   });
 
   it('og:locale - page.lang', () => {
@@ -623,7 +623,7 @@ describe('open_graph', () => {
       is_post: isPost
     });
 
-    result.should.contain(meta({property: 'og:locale', content: 'es_mx'}));
+    result.should.contain(meta({property: 'og:locale', content: 'es_MX'}));
   });
 
   it('og:locale - page.language', () => {
@@ -633,7 +633,7 @@ describe('open_graph', () => {
       is_post: isPost
     });
 
-    result.should.contain(meta({property: 'og:locale', content: 'es_gt'}));
+    result.should.contain(meta({property: 'og:locale', content: 'es_GT'}));
   });
 
   it('og:locale - config.language', () => {
@@ -645,7 +645,7 @@ describe('open_graph', () => {
       is_post: isPost
     });
 
-    result.should.contain(meta({property: 'og:locale', content: 'es_pa'}));
+    result.should.contain(meta({property: 'og:locale', content: 'es_PA'}));
   });
 
   it('og:locale - no language set', () => {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -648,6 +648,18 @@ describe('open_graph', () => {
     result.should.contain(meta({property: 'og:locale', content: 'es_PA'}));
   });
 
+  it('og:locale - convert territory to uppercase', () => {
+    hexo.config.language = 'fr-fr';
+
+    const result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    });
+
+    result.should.contain(meta({property: 'og:locale', content: 'fr_FR'}));
+  });
+
   it('og:locale - no language set', () => {
     const result = openGraph.call({
       page: {},

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -35,7 +35,6 @@ describe('open_graph', () => {
         meta({property: 'og:title', content: hexo.config.title}),
         meta({property: 'og:url'}),
         meta({property: 'og:site_name', content: hexo.config.title}),
-        meta({property: 'og:locale', content: 'en'}),
         meta({property: 'article:published_time', content: post.date.toISOString()}),
         meta({property: 'article:modified_time', content: post.updated.toISOString()}),
         meta({property: 'article:author', content: hexo.config.author}),
@@ -614,7 +613,7 @@ describe('open_graph', () => {
       is_post: isPost
     }, {language: 'es-cr'});
 
-    result.should.contain(meta({property: 'og:locale', content: 'es-cr'}));
+    result.should.contain(meta({property: 'og:locale', content: 'es_cr'}));
   });
 
   it('og:locale - page.lang', () => {
@@ -624,7 +623,7 @@ describe('open_graph', () => {
       is_post: isPost
     });
 
-    result.should.contain(meta({property: 'og:locale', content: 'es-mx'}));
+    result.should.contain(meta({property: 'og:locale', content: 'es_mx'}));
   });
 
   it('og:locale - page.language', () => {
@@ -634,7 +633,7 @@ describe('open_graph', () => {
       is_post: isPost
     });
 
-    result.should.contain(meta({property: 'og:locale', content: 'es-gt'}));
+    result.should.contain(meta({property: 'og:locale', content: 'es_gt'}));
   });
 
   it('og:locale - config.language', () => {
@@ -646,10 +645,22 @@ describe('open_graph', () => {
       is_post: isPost
     });
 
-    result.should.contain(meta({property: 'og:locale', content: 'es-pa'}));
+    result.should.contain(meta({property: 'og:locale', content: 'es_pa'}));
   });
 
   it('og:locale - no language set', () => {
+    const result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    });
+
+    result.should.not.contain(meta({property: 'og:locale'}));
+  });
+
+  it('og:locale - language is not in lang-territory format', () => {
+    hexo.config.language = 'en';
+
     const result = openGraph.call({
       page: {},
       config: hexo.config,


### PR DESCRIPTION
##  What does it do?
Recently tested hexo.io against [facebook linter](https://developers.facebook.com/tools/debug/og/object/). Apparently, the value for "og:locale" must be in [`language_TERRITORY`](https://ogp.me/#optional) format, so "en" is invalid. Here is a list of [valid values](https://developers.facebook.com/docs/messenger-platform/messenger-profile/supported-locales/).

If `og:locale` is not specified, fb defaults to "**en_US**".

(The following note is only applicable if you're not using en-US locale. It's optional for en-US users.)

If the `language` value (regardless from config or front matter) is not in `language-TERRITORY` format, "og:locale" **will not be added**.

If the language value in _config is just two characters (e.g. "en", "fr"), then you need to append territory value, e.g. "en-GB", "fr-CA". you also need to update the filename of the language file (e.g. "en.yml" -> "en-GB.yml") of your theme.

Alternatively, you could also set `<%- open_graph({language: 'en-GB'}) %>` in your theme layout.

## How to test

```sh
git clone -b ogp-locale https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
