### PR TITLE
feat(backtick): support 'wrap' option

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -43,7 +43,8 @@ module.exports = {
     enable: true,
     auto_detect: false,
     line_number: true,
-    tab_replace: ''
+    tab_replace: '',
+    wrap: true
   },
   // Category & Tag
   default_category: 'uncategorized',

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -17,7 +17,8 @@ function backtickCodeBlock(data) {
       hljs: config.hljs,
       autoDetect: config.auto_detect,
       gutter: config.line_number,
-      tab: config.tab_replace
+      tab: config.tab_replace,
+      wrap: config.wrap
     };
 
     if (options.gutter) {

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -384,5 +384,7 @@ describe('Backtick code block', () => {
 
     codeBlock(data);
     data.content.should.eql('<escape>' + highlight(code, { lang: 'js', wrap: false }) + '</escape>');
+
+    hexo.config.highlight.wrap = true;
   });
 });

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -370,4 +370,19 @@ describe('Backtick code block', () => {
     codeBlock(data);
     data.content.should.eql('<escape>' + expected + '</escape>');
   });
+
+  it('wrap', () => {
+    hexo.config.highlight.wrap = false;
+
+    const data = {
+      content: [
+        '``` js',
+        code,
+        '```'
+      ].join('\n')
+    };
+
+    codeBlock(data);
+    data.content.should.eql('<escape>' + highlight(code, { lang: 'js', wrap: false }) + '</escape>');
+  });
 });


### PR DESCRIPTION
## What does it do?
Continuation of https://github.com/hexojs/hexo-util/pull/112.
Alternative (less breaking than`hljs: true`) approach to https://github.com/hexojs/hexo/issues/3766

`wrap` is currently enabled by default, so codeblock is wrapped in `<table>`; disable it for simpler/shorter `<pre><code>`.

All credit to @seaoak 

## How to test

```sh
git clone -b highlight-wrap https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
