### PR TITLE
test: compatibility with hexo-util@1.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "hexo-fs": "^2.0.0",
     "hexo-i18n": "^1.0.0",
     "hexo-log": "^1.0.0",
-    "hexo-util": "^1.4.0",
+    "hexo-util": "^1.5.0",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",
     "micromatch": "^4.0.2",

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -2,6 +2,7 @@
 
 const moment = require('moment');
 const cheerio = require('cheerio');
+const { encodeURL } = require('hexo-util');
 
 describe('open_graph', () => {
   const Hexo = require('../../../lib/hexo');
@@ -141,7 +142,7 @@ describe('open_graph', () => {
 
     const result = openGraph.call(ctx);
 
-    result.should.contain(meta({property: 'og:url', content: 'https://xn--fo-9ja.com/b%C3%A1r'}));
+    result.should.contain(meta({property: 'og:url', content: encodeURL(ctx.url)}));
   });
 
   it('images - content', () => {

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -6,6 +6,7 @@ const Promise = require('bluebird');
 const sinon = require('sinon');
 const sep = pathFn.sep;
 const testUtil = require('../../util');
+const { full_url_for } = require('hexo-util');
 
 describe('Hexo', () => {
   const base_dir = pathFn.join(__dirname, 'hexo_test');
@@ -427,17 +428,18 @@ describe('Hexo', () => {
   });
 
   it('_generate() - should encode url', () => {
+    const path = 'bár';
     hexo.config.url = 'http://fôo.com';
 
     hexo.theme.setView('test.swig', '{{ url }}');
 
     hexo.extend.generator.register('test', () => ({
-      path: 'bár',
+      path,
       layout: 'test'
     }));
 
-    return hexo._generate().then(() => checkStream(route.get('bár'),
-      'http://xn--fo-8ja.com/b%C3%A1r'));
+    return hexo._generate().then(() => checkStream(route.get(path),
+      full_url_for.call(hexo, path)));
   });
 
   it('_generate() - do nothing if it\'s generating', () => {

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -2,6 +2,7 @@
 
 const sinon = require('sinon');
 const Promise = require('bluebird');
+const { full_url_for } = require('hexo-util');
 
 describe('Category', () => {
   const Hexo = require('../../../lib/hexo');
@@ -118,9 +119,9 @@ describe('Category', () => {
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
     return Category.insert({
-      name: 'bár'
+      name: '字'
     }).then(data => {
-      data.permalink.should.eql('http://xn--fo-8ja.com/' + data.path);
+      data.permalink.should.eql(full_url_for.call(hexo, data.path));
       hexo.config.url = 'http://yoursite.com';
       return Category.removeById(data._id);
     });

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -2,6 +2,7 @@
 
 const sinon = require('sinon');
 const pathFn = require('path');
+const { full_url_for } = require('hexo-util');
 
 describe('Page', () => {
   const Hexo = require('../../../lib/hexo');
@@ -74,11 +75,12 @@ describe('Page', () => {
 
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
+    const path = 'bár';
     return Page.insert({
       source: 'foo',
-      path: 'bár'
+      path
     }).then(data => {
-      data.permalink.should.eql('http://xn--fo-8ja.com/b%C3%A1r');
+      data.permalink.should.eql(full_url_for.call(hexo, data.path));
       hexo.config.url = 'http://yoursite.com';
       return Page.removeById(data._id);
     });

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -3,6 +3,7 @@
 const sinon = require('sinon');
 const pathFn = require('path');
 const Promise = require('bluebird');
+const { full_url_for } = require('hexo-util');
 
 describe('Post', () => {
   const Hexo = require('../../../lib/hexo');
@@ -85,12 +86,13 @@ describe('Post', () => {
   });
 
   it('permalink - should be encoded', () => {
+    const slug = 'bár';
     hexo.config.url = 'http://fôo.com';
     return Post.insert({
       source: 'foo.md',
-      slug: 'bár'
+      slug
     }).then(data => {
-      data.permalink.should.eql('http://xn--fo-8ja.com/b%C3%A1r');
+      data.permalink.should.eql(full_url_for.call(hexo, slug));
       hexo.config.url = 'http://yoursite.com';
       return Post.removeById(data._id);
     });

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -2,6 +2,7 @@
 
 const sinon = require('sinon');
 const Promise = require('bluebird');
+const { full_url_for } = require('hexo-util');
 
 describe('Tag', () => {
   const Hexo = require('../../../lib/hexo');
@@ -103,9 +104,9 @@ describe('Tag', () => {
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
     return Tag.insert({
-      name: 'bár'
+      name: '字'
     }).then(data => {
-      data.permalink.should.eql('http://xn--fo-8ja.com/' + data.path);
+      data.permalink.should.eql(full_url_for.call(hexo, data.path));
       hexo.config.url = 'http://yoursite.com';
       return Tag.removeById(data._id);
     });


### PR DESCRIPTION
## What does it do?

- IDN now always output in unicode, regardless the source is unicode or punycode, after https://github.com/hexojs/hexo-util/pull/116
- category and tag uses chinese word because diacritic is [escaped](https://github.com/hexojs/hexo-util/blob/71bbcc49cafdfce094c226a0612de5895d576848/lib/slugize.js#L15) by default (`á` -> `a`); once escaped, it's not percent-encoded anymore so couldn't cover the url encoding test.
- expected result now uses dynamic result of encodeURL()/full_url_for() instead of hardcoded, this allows compatibility with any changes in `encodeURL()`.


## How to test

```sh
git clone -b hexo-util_1.5 https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
