### PR TITLE
fix(new): omit 'p:', 's:', 'r:' properties in fromt-matter

### DIFF
--- a/lib/plugins/console/new.js
+++ b/lib/plugins/console/new.js
@@ -8,8 +8,10 @@ const reservedKeys = {
   title: true,
   layout: true,
   slug: true,
+  s: true,
   path: true,
   replace: true,
+  r: true,
   // Global options
   config: true,
   debug: true,

--- a/lib/plugins/console/new.js
+++ b/lib/plugins/console/new.js
@@ -10,6 +10,7 @@ const reservedKeys = {
   slug: true,
   s: true,
   path: true,
+  p: true,
   replace: true,
   r: true,
   // Global options

--- a/test/scripts/console/new.js
+++ b/test/scripts/console/new.js
@@ -87,7 +87,7 @@ describe('new', () => {
     });
   });
 
-  it('slug(2)', () => {
+  it('slug - s', () => {
     const date = moment(now);
     const path = pathFn.join(hexo.source_dir, '_posts', 'foo.md');
     const body = [
@@ -126,7 +126,7 @@ describe('new', () => {
     });
   });
 
-  it('path (2)', () => {
+  it('path - p', () => {
     const date = moment(now);
     const path = pathFn.join(hexo.source_dir, '_posts', 'bar.md');
     const body = [
@@ -185,7 +185,7 @@ describe('new', () => {
     }).finally(() => fs.unlink(path));
   });
 
-  it('replace existing files (2)', () => {
+  it('replace existing files - r', () => {
     const date = moment(now);
     const path = pathFn.join(hexo.source_dir, '_posts', 'Hello-World.md');
     const body = [

--- a/test/scripts/console/new.js
+++ b/test/scripts/console/new.js
@@ -87,6 +87,25 @@ describe('new', () => {
     });
   });
 
+  it('slug(2)', () => {
+    const date = moment(now);
+    const path = pathFn.join(hexo.source_dir, '_posts', 'foo.md');
+    const body = [
+      'title: Hello World',
+      'date: ' + date.format('YYYY-MM-DD HH:mm:ss'),
+      'tags:',
+      '---'
+    ].join('\n') + '\n';
+
+    return n({
+      _: ['Hello World'],
+      s: 'foo'
+    }).then(() => fs.readFile(path)).then(content => {
+      content.should.eql(body);
+      return fs.unlink(path);
+    });
+  });
+
   it('path', () => {
     const date = moment(now);
     const path = pathFn.join(hexo.source_dir, '_posts', 'bar.md');
@@ -125,7 +144,14 @@ describe('new', () => {
   });
 
   it('replace existing files', () => {
+    const date = moment(now);
     const path = pathFn.join(hexo.source_dir, '_posts', 'Hello-World.md');
+    const body = [
+      'title: Hello World',
+      'date: ' + date.format('YYYY-MM-DD HH:mm:ss'),
+      'tags:',
+      '---'
+    ].join('\n') + '\n';
 
     return post.create({
       title: 'Hello World'
@@ -134,8 +160,31 @@ describe('new', () => {
       replace: true
     })).then(() => fs.exists(pathFn.join(hexo.source_dir, '_posts', 'Hello-World-1.md'))).then(exist => {
       exist.should.be.false;
-      return fs.unlink(path);
-    });
+    }).then(() => fs.readFile(path)).then(content => {
+      content.should.eql(body);
+    }).finally(() => fs.unlink(path));
+  });
+
+  it('replace existing files (2)', () => {
+    const date = moment(now);
+    const path = pathFn.join(hexo.source_dir, '_posts', 'Hello-World.md');
+    const body = [
+      'title: Hello World',
+      'date: ' + date.format('YYYY-MM-DD HH:mm:ss'),
+      'tags:',
+      '---'
+    ].join('\n') + '\n';
+
+    return post.create({
+      title: 'Hello World'
+    }).then(() => n({
+      _: ['Hello World'],
+      r: true
+    })).then(() => fs.exists(pathFn.join(hexo.source_dir, '_posts', 'Hello-World-1.md'))).then(exist => {
+      exist.should.be.false;
+    }).then(() => fs.readFile(path)).then(content => {
+      content.should.eql(body);
+    }).finally(() => fs.unlink(path));
   });
 
   it('extra data', () => {

--- a/test/scripts/console/new.js
+++ b/test/scripts/console/new.js
@@ -126,6 +126,26 @@ describe('new', () => {
     });
   });
 
+  it('path (2)', () => {
+    const date = moment(now);
+    const path = pathFn.join(hexo.source_dir, '_posts', 'bar.md');
+    const body = [
+      'title: Hello World',
+      'date: ' + date.format('YYYY-MM-DD HH:mm:ss'),
+      'tags:',
+      '---'
+    ].join('\n') + '\n';
+
+    return n({
+      _: ['Hello World'],
+      slug: 'foo',
+      p: 'bar'
+    }).then(() => fs.readFile(path)).then(content => {
+      content.should.eql(body);
+      return fs.unlink(path);
+    });
+  });
+
   it('rename if target existed', () => {
     const path = pathFn.join(hexo.source_dir, '_posts', 'Hello-World-1.md');
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
When use `hexo new` command with `-p`, `-s` or `-r` options, unexpected properties('s:', 'r:') are generated in the front-matter.
e.g.
```sh
hexo new "Hello" -s "test" 
hexo new "Hello" -r
hexo new "Hello" -s "test" -r
```
<img width="235" alt="2019110501" src="https://user-images.githubusercontent.com/51783821/68136341-15407580-ff60-11e9-8110-9a9c50cf79fa.png">

It should generate the same as when using `--slug`, `--replace` options.
e.g.
```sh
hexo new "Hello" --slug "test" 
hexo new "Hello" --replace
hexo new "Hello" --slug "test" --replace
```
<img width="211" alt="2019110502" src="https://user-images.githubusercontent.com/51783821/68136757-c3e4b600-ff60-11e9-83a9-7b355fca7f4d.png">


## How to test
Make new a hexo site for test.
e.g.
```sh
git clone https://github.com/hexojs/site.git
cd site
vi package.json
```

Change the version of hexo.
```diff
- "hexo": "hexojs/hexo"
+ "hexo": "dailyrandomphoto/hexo#fix-create-new-post"
```
```sh
npm install
```

The two commands should generate the same properties in the front-matter.
```sh
hexo new "Hello1" --slug "test1" --replace
hexo new "Hello2" -s "test2" -r
```



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
