### PR TITLE
refactor: drop lodash for lib/hexo/index.js

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -28,7 +28,7 @@ const resolve = require('resolve');
 const full_url_for = require('../plugins/helper/full_url_for');
 const { inherits } = require('util');
 
-const { cloneDeep, debounce } = _;
+const { debounce } = _;
 
 const libDir = dirname(__dirname);
 const dbVersion = 1;
@@ -109,7 +109,7 @@ class Hexo {
       tag: new extend.Tag()
     };
 
-    this.config = cloneDeep(defaultConfig);
+    this.config = Object.assign({}, defaultConfig);
 
     this.log = logger(this.env);
 

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -28,8 +28,6 @@ const resolve = require('resolve');
 const full_url_for = require('../plugins/helper/full_url_for');
 const { inherits } = require('util');
 
-const { debounce } = _;
-
 const libDir = dirname(__dirname);
 const dbVersion = 1;
 
@@ -72,6 +70,20 @@ const createLoadThemeRoute = function(generatorResult, locals, ctx) {
     log.warn(`No layout: ${chalk.magenta(path)}`);
   };
 };
+
+function debounce(func, wait, immediate) {
+  let timeout;
+  return function() {
+    const context = this;
+    const args = arguments;
+    clearTimeout(timeout);
+    timeout = setTimeout(() => {
+      timeout = null;
+      if (!immediate) func.apply(context, args);
+    }, wait);
+    if (immediate && !timeout) func.apply(context, args);
+  };
+}
 
 class Hexo {
   constructor(base = process.cwd(), args = {}) {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

This PR is part of #3753 

This PR only replace `cloneDeep` and `debounce` with native while `lodash` itself retains exposed to global.

## How to test

```sh
git clone -b drop-lodash-for-index https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

The performance is more or less the same after this PR.

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
