### PR TITLE
chore(package): add funding

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
   ],
   "repository": "hexojs/hexo",
   "homepage": "https://hexo.io/",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/hexo"
+  },
   "keywords": [
     "website",
     "blog",


### PR DESCRIPTION
## What does it do?
Show funding info in `npm fund hexo`. `npm fund` is introduced in [npm 6.13](https://github.com/npm/cli/releases/tag/v6.13.0).

Ref: https://github.com/npm/cli/pull/273, [RFC](https://github.com/npm/rfcs/blob/2d2f00457ab19b3003eb6ac5ab3d250259fd5a81/accepted/0017-add-funding-support.md)


## How to test

```sh
git clone -b npm-fund https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
