### PR TITLE
Exclude some languages in code highlighting

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -46,6 +46,7 @@ module.exports = {
     line_number: true,
     tab_replace: '',
     wrap: true,
+    exclude_languages: [],
     hljs: false
   },
   prismjs: {

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -89,6 +89,13 @@ function backtickCodeBlock(data) {
         }
       }
 
+      if (Array.isArray(hljsCfg.exclude_languages) && hljsCfg.exclude_languages.includes(options.lang)) {
+        // Only wrap with <pre><code class="lang"></code></pre>
+        options.wrap = false;
+        options.gutter = false;
+        options.autoDetect = false;
+      }
+
       content = highlight(content, options);
     }
 

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -241,6 +241,26 @@ describe('Backtick code block', () => {
       data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
     });
 
+    it('only wrap with pre and code', () => {
+      hexo.config.highlight.exclude_languages = ['js'];
+      hexo.config.highlight.hljs = true;
+      const data = {
+        content: [
+          '``` js',
+          code,
+          '```'
+        ].join('\n')
+      };
+      const expected = highlight(code, {
+        lang: 'js',
+        gutter: false,
+        hljs: true,
+        wrap: false
+      });
+      codeBlock(data);
+      data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
+    });
+
     it('line number false, don`t care first_line_number inilne', () => {
       hexo.config.highlight.line_number = false;
       hexo.config.highlight.first_line_number = 'inilne';


### PR DESCRIPTION
Signed-off-by: corvofeng <corvofeng@gmail.com>

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Only wrap some languages' code with `<pre>` and `<code>`, and do no render all tags(span, and br) in content, so that user could process those languages ​​freely.

## How to test

```sh
git clone -b exclude_highlight_lang https://github.com/corvofeng/hexo.git
cd hexo
npm install
npm test
```

## How to use?

`config.yaml`:

```yaml
highlight:
  enable: true
  line_number: true
  auto_detect: false
  exclude_languages:
    - flowchartjs-code
```

Blog code:

\`\`\`flowchartjs-code
st=>start: Start:>http://www.bing.com[blank]
e=>end:>http://www.bing.com
op1=>operation: My Operation
sub1=>subroutine: My Subroutine
cond=>condition: Yes
or No?:>http://www.google.com
io=>inputoutput: catch something...
para=>parallel: parallel tasks

st->op1->cond
cond(yes)->io->e
cond(no)->para
para(path1, bottom)->sub1(right)->op1
para(path2, top)->op1
\`\`\`

You will get:

```html
<code class="highlight flowchartjs-code">st=&gt;start: Start:&gt;http://www.bing.com[blank]
e=&gt;end:&gt;http://www.bing.com
op1=&gt;operation: My Operation
sub1=&gt;subroutine: My Subroutine
cond=&gt;condition: Yes
or No?:&gt;http://www.google.com
io=&gt;inputoutput: catch something...
para=&gt;parallel: parallel tasks

st-&gt;op1-&gt;cond
cond(yes)-&gt;io-&gt;e
cond(no)-&gt;para
para(path1, bottom)-&gt;sub1(right)-&gt;op1
para(path2, top)-&gt;op1</code>
```


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
