### PR TITLE
Enable to use "ignore:" option for individual files (fix #3873)

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -120,12 +120,17 @@ Box.prototype._readDir = function(base, fn, prefix = '') {
   const { ignore } = this;
 
   if (base && ignore && ignore.length && micromatch.isMatch(base, ignore)) {
-    return Promise.resolve('Ignoring dir.');
+    return Promise.resolve([]);
   }
 
   return fs.readdir(base).map(path => fs.stat(join(base, path)).then(stats => {
+    const fullpath = join(base, path);
     if (stats.isDirectory()) {
-      return this._readDir(join(base, path), fn, `${prefix + path}/`);
+      return this._readDir(fullpath, fn, `${prefix + path}/`);
+    }
+
+    if (ignore && ignore.length && micromatch.isMatch(fullpath, ignore)) {
+      return Promise.resolve([]);
     }
 
     return this._checkFileStatus(prefix + path).then(file => fn(file).thenReturn(file));


### PR DESCRIPTION
## What does it do?

Fix issue #3873

When an individual (non-directory) file matches the glob in `ignore:` option,
it will be ignored (not process, not copy to `publish/` folder).

`fs.watch()` already ignores it by the PR #3797.
But Hexo still processes it.

This patch fixes this behavior.


## How to test

```sh
git clone -b feature/enable_ignore_option_for_individual_file https://github.com/seaoak/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
