### PR TITLE
Enable "exclude:" and "include:" options for files in asset folder (fix #3881)

### DIFF
--- a/lib/plugins/processor/asset.js
+++ b/lib/plugins/processor/asset.js
@@ -108,11 +108,7 @@ module.exports = ctx => {
 
   return {
     pattern: new Pattern(path => {
-      if (common.isTmpFile(path) || common.isMatch(path, ctx.config.exclude)) return;
-
-      if (common.isHiddenFile(path) && !common.isMatch(path, ctx.config.include)) {
-        return;
-      }
+      if (common.isExcludedFile(path, ctx.config)) return;
 
       return {
         renderable: ctx.render.isRenderable(path) && !common.isMatch(path, ctx.config.skip_render)

--- a/lib/plugins/processor/common.js
+++ b/lib/plugins/processor/common.js
@@ -6,6 +6,12 @@ const micromatch = require('micromatch');
 
 const DURATION_MINUTE = 1000 * 60;
 
+function isMatch(path, patterns) {
+  if (!patterns) return false;
+
+  return micromatch.isMatch(path, patterns);
+}
+
 function isTmpFile(path) {
   const last = path[path.length - 1];
   return last === '%' || last === '~';
@@ -15,6 +21,13 @@ function isHiddenFile(path) {
   return /(^|\/)[_.]/.test(path);
 }
 
+function isExcludedFile(path, config) {
+  if (isTmpFile(path)) return true;
+  if (isMatch(path, config.exclude)) return true;
+  if (isHiddenFile(path) && !isMatch(path, config.include)) return true;
+  return false;
+}
+
 exports.ignoreTmpAndHiddenFile = new Pattern(path => {
   if (isTmpFile(path) || isHiddenFile(path)) return false;
   return true;
@@ -22,6 +35,7 @@ exports.ignoreTmpAndHiddenFile = new Pattern(path => {
 
 exports.isTmpFile = isTmpFile;
 exports.isHiddenFile = isHiddenFile;
+exports.isExcludedFile = isExcludedFile;
 
 exports.toDate = date => {
   if (!date || moment.isMoment(date)) return date;
@@ -46,8 +60,4 @@ exports.timezone = (date, timezone) => {
   return new Date(ms - diff);
 };
 
-exports.isMatch = (path, patterns) => {
-  if (!patterns) return false;
-
-  return micromatch.isMatch(path, patterns);
-};
+exports.isMatch = isMatch;

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -159,7 +159,7 @@ module.exports = ctx => {
     }).catch(err => {
       if (err.cause && err.cause.code === 'ENOENT') return [];
       throw err;
-    }).filter(item => !common.isTmpFile(item) && !common.isHiddenFile(item)).map(item => {
+    }).filter(item => !common.isExcludedFile(item, ctx.config)).map(item => {
       const id = join(assetDir, item).substring(baseDirLength).replace(/\\/g, '/');
       const asset = PostAsset.findById(id);
       if (asset) return undefined;


### PR DESCRIPTION
## What does it do?

Fix #3881

`exlucde:` option and `include:` option in `_config.yml` is no effect for files in Asset Folder.
These are only effect for files outside of `source/_post/`
(such as `source/foo.jpg`, `source/foo/bar.jpg`).

This behavior does not match its document.
https://hexo.io/docs/configuration#Include-Exclude-Files-or-Folders

This patch fixes this behavior.


## How to test

```sh
git clone -b feature/enable-exclude-and-include-options-for-files-in-asset-folder https://github.com/seaoak/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
