### PR TITLE
feat: add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:current-alpine
 
-RUN apk update && apk add bash git
+RUN apk update && apk --no-cache add git
 RUN npm install -g hexo-cli
 
 
-CMD ["/bin/bash"]
+CMD ["/bin/ash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM node:10
+FROM node:current-alpine
 
+RUN apk update && apk add bash git
 RUN npm install -g hexo-cli
 
-CMD ["/bin/bash","-c","hexo"]
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:10
+
+RUN npm install -g hexo-cli
+
+CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM node:10
 
 RUN npm install -g hexo-cli
 
-CMD ["/bin/bash"]
+CMD ["/bin/bash","-c","hexo"]

--- a/hexod
+++ b/hexod
@@ -3,4 +3,5 @@ docker run \
   --interactive --tty --rm \
   --volume "$PWD":/hexosite \
   --workdir /hexosite \
+  -p 4000:4000 \
   bestony/hexojs:latest "$@"

--- a/hexod
+++ b/hexod
@@ -1,7 +1,7 @@
 #!/bin/sh
 docker run \
   --interactive --tty --rm \
-  --volume "$PWD":/hexosite \
-  --workdir /hexosite \
+  --volume "$PWD":/app \
+  --workdir /app \
   -p 4000:4000 \
-  bestony/hexojs:latest "$@"
+  bestony/hexojs:latest "hexo" "$@"

--- a/hexod
+++ b/hexod
@@ -1,0 +1,6 @@
+#!/bin/sh
+docker run \
+  --interactive --tty --rm \
+  --volume "$PWD":/hexosite \
+  --workdir /hexosite \
+  bestony/hexojs:latest "$@"


### PR DESCRIPTION
# What does it do?
add Docker Support for Hexo Cli.


## How to test
1. install Docker
2.
```sh
git clone -b add-dockerfile https://github.com/bestony/hexo.git
cd hexo
./hexod # use this to show hexo info 
./hexod init testdocker
```

## Other info 
1. About hexo in Docker Hub

is [hexo](https://hub.docker.com/u/hexo) belongs to hexo?

Now, i push the image to my docker hub account, If this belongs to Hexo Official, I can push image to Hexo Organization.

## Screenshots

![image](https://user-images.githubusercontent.com/13283837/69882837-8cbdb680-130c-11ea-82d7-3f45d0c2dd0d.png)

![image](https://user-images.githubusercontent.com/13283837/69882870-a101b380-130c-11ea-8a2f-88a59c234f5b.png)


## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
