### PR TITLE
refactor(open_graph): utilize escapeHTML()

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -2,7 +2,7 @@
 
 const urlFn = require('url');
 const moment = require('moment');
-const { encodeURL, htmlTag, stripHTML } = require('hexo-util');
+const { encodeURL, htmlTag, stripHTML, escapeHTML } = require('hexo-util');
 
 function meta(name, content) {
   return `${htmlTag('meta', {
@@ -38,14 +38,9 @@ function openGraphHelper(options = {}) {
   if (!Array.isArray(images)) images = [images];
 
   if (description) {
-    description = stripHTML(description).substring(0, 200)
+    description = escapeHTML(stripHTML(description).substring(0, 200)
       .trim() // Remove prefixing/trailing spaces
-      .replace(/</g, '&lt;')
-      .replace(/>/g, '&gt;')
-      .replace(/&/g, '&amp;')
-      .replace(/"/g, '&quot;')
-      .replace(/'/g, '&apos;')
-      .replace(/\n/g, ' '); // Replace new lines by spaces
+    ).replace(/\n/g, ' '); // Replace new lines by spaces
   }
 
   if (!images.length && content) {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -355,7 +355,7 @@ describe('open_graph', () => {
     };
 
     const result = openGraph.call(ctx);
-    const escaped = 'Important! Today is &quot;not&quot; &apos;Xmas&apos;!';
+    const escaped = 'Important! Today is &quot;not&quot; &#39;Xmas&#39;!';
 
     result.should.contain(meta({name: 'description', content: escaped}));
     result.should.contain(meta({property: 'og:description', content: escaped}));


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Utilize hexo-util's `escapeHTML()`, and deprecate obsoluted `&apos;`.

## How to test

```sh
git clone -b open_graph_escape https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
