### PR TITLE
feat(permalink): pretty_urls.trailing_html

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -14,7 +14,8 @@ module.exports = {
   permalink: ':year/:month/:day/:title/',
   permalink_defaults: {},
   pretty_urls: {
-    trailing_index: true
+    trailing_index: true,
+    trailing_html: true
   },
   // Directory
   source_dir: 'source',

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -40,8 +40,12 @@ module.exports = ctx => {
 
   Category.virtual('permalink').get(function() {
     const { config } = ctx;
+    const indexPattern = /index\.html$/;
     let url = full_url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    if (config.pretty_urls.trailing_index === false) url = url.replace(indexPattern, '');
+    if (config.pretty_urls.trailing_html === false && !indexPattern.test(url)) {
+      url = url.replace(/\.html$/, '/');
+    }
     return url;
   });
 

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -34,8 +34,12 @@ module.exports = ctx => {
 
   Page.virtual('permalink').get(function() {
     const { config } = ctx;
+    const indexPattern = /index\.html$/;
     let url = full_url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    if (config.pretty_urls.trailing_index === false) url = url.replace(indexPattern, '');
+    if (config.pretty_urls.trailing_html === false && !indexPattern.test(url)) {
+      url = url.replace(/\.html$/, '/');
+    }
     return url;
   });
 

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -52,8 +52,12 @@ module.exports = ctx => {
 
   Post.virtual('permalink').get(function() {
     const { config } = ctx;
+    const indexPattern = /index\.html$/;
     let url = full_url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    if (config.pretty_urls.trailing_index === false) url = url.replace(indexPattern, '');
+    if (config.pretty_urls.trailing_html === false && !indexPattern.test(url)) {
+      url = url.replace(/\.html$/, '/');
+    }
     return url;
   });
 

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -31,8 +31,12 @@ module.exports = ctx => {
 
   Tag.virtual('permalink').get(function() {
     const { config } = ctx;
+    const indexPattern = /index\.html$/;
     let url = full_url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    if (config.pretty_urls.trailing_index === false) url = url.replace(indexPattern, '');
+    if (config.pretty_urls.trailing_html === false && !indexPattern.test(url)) {
+      url = url.replace(/\.html$/, '/');
+    }
     return url;
   });
 

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -116,6 +116,17 @@ describe('Category', () => {
     });
   });
 
+  it('permalink - trailing_html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Category.insert({
+      name: 'foo'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/\.html$/, '/'));
+      hexo.config.pretty_urls.trailing_html = true;
+      return Category.removeById(data._id);
+    });
+  });
+
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
     return Category.insert({

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -73,6 +73,30 @@ describe('Page', () => {
     });
   });
 
+  it('permalink - trailing_html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Page.insert({
+      source: 'foo.md',
+      path: 'bar/foo.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/\.html$/, '/'));
+      hexo.config.pretty_urls.trailing_html = true;
+      return Page.removeById(data._id);
+    });
+  });
+
+  it('permalink - trailing_html - index.html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Page.insert({
+      source: 'foo.md',
+      path: 'bar/index.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path);
+      hexo.config.pretty_urls.trailing_html = true;
+      return Page.removeById(data._id);
+    });
+  });
+
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
     const path = 'bár';

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -140,10 +140,34 @@ describe('Post', () => {
     hexo.config.pretty_urls.trailing_index = false;
     return Post.insert({
       source: 'foo.md',
-      slug: 'bar'
+      slug: 'bar/index.html'
     }).then(data => {
       data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
       hexo.config.pretty_urls.trailing_index = true;
+      return Post.removeById(data._id);
+    });
+  });
+
+  it('permalink - trailing_html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bar/foo.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/\.html$/, '/'));
+      hexo.config.pretty_urls.trailing_html = true;
+      return Post.removeById(data._id);
+    });
+  });
+
+  it('permalink - trailing_html - index.html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bar/index.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path);
+      hexo.config.pretty_urls.trailing_html = true;
       return Post.removeById(data._id);
     });
   });

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -101,6 +101,17 @@ describe('Tag', () => {
     });
   });
 
+  it('permalink - trailing_html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Tag.insert({
+      name: 'foo'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/\.html$/, '/'));
+      hexo.config.pretty_urls.trailing_html = true;
+      return Tag.removeById(data._id);
+    });
+  });
+
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
     return Tag.insert({


### PR DESCRIPTION
## What does it do?
Continuation of https://github.com/hexojs/hexo/pull/3691

When `pretty_urls.trailing_html` is disabled, permalink like `example.com/foo/bar.html` is transformed into `example.com/foo/bar/`. Trailing slash is appended for now, `pretty_urls.trailing_slash` can be introduced in later PR.

The option doesn't apply to url with trailing `index.html`, e.g. `example.com/foo/bar/index.html`. I don't think `example.com/foo/bar/index/` is valid.


## How to test

```sh
git clone -b trailing-html https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
