### PR TITLE
refactor(external_link): optimize regex pattern

### DIFF
--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -19,7 +19,7 @@ function externalLinkFilter(data) {
   const exclude = Array.isArray(config.external_link.exclude) ? config.external_link.exclude
     : [config.external_link.exclude];
 
-  data.content = data.content.replace(/<a.*?(href=['"](.*?)['"]).*?>/gi, (str, hrefStr, href) => {
+  data.content = data.content.replace(/<a .*?(href=['"](.+?)['"]).*?>/gi, (str, hrefStr, href) => {
     if (/target=/gi.test(str) || !isExternalLink(href, config.url, exclude)) return str;
 
     if (/rel=/gi.test(str)) {

--- a/lib/plugins/filter/after_render/external_link.js
+++ b/lib/plugins/filter/after_render/external_link.js
@@ -19,7 +19,7 @@ function externalLinkFilter(data) {
   const exclude = Array.isArray(config.external_link.exclude) ? config.external_link.exclude
     : [config.external_link.exclude];
 
-  data = data.replace(/<a.*?(href=['"](.*?)['"]).*?>/gi, (str, hrefStr, href) => {
+  data = data.replace(/<a .*?(href=['"](.+?)['"]).*?>/gi, (str, hrefStr, href) => {
     if (/target=/gi.test(str) || !isExternalLink(href, config.url, exclude)) return str;
 
     if (/rel=/gi.test(str)) {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Optimize the regexp used in external_link filter. The new regexp will avoid edge cases like `a` prefixed tag `<article>`, and it is faster ([benchmark](https://repl.it/repls/StableVioletMonotone) shows it is 18% faster).

## How to test

```sh
git clone -b external_link_regex https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
