### PR TITLE
fix(tag/category): transform case on name

### DIFF
--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -25,7 +25,8 @@ module.exports = ctx => {
     const map = ctx.config.category_map || {};
 
     name = map[name] || name;
-    str += slugize(name, {transform: ctx.config.filename_case});
+    this.name = slugize(name, { transform: ctx.config.filename_case });
+    str += this.name;
 
     return str;
   });

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -19,7 +19,8 @@ module.exports = ctx => {
       name = map[name] || name;
     }
 
-    return slugize(name, {transform: ctx.config.filename_case});
+    this.name = slugize(name, { transform: ctx.config.filename_case });
+    return this.name;
   });
 
   Tag.virtual('path').get(function() {

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -49,6 +49,7 @@ describe('Category', () => {
   it('slug - filename_case: 0', () => Category.insert({
     name: 'WahAHa'
   }).then(data => {
+    data.name.should.eql('WahAHa');
     data.slug.should.eql('WahAHa');
     return Category.removeById(data._id);
   }));
@@ -59,6 +60,7 @@ describe('Category', () => {
     return Category.insert({
       name: 'WahAHa'
     }).then(data => {
+      data.name.should.eql('wahaha');
       data.slug.should.eql('wahaha');
       hexo.config.filename_case = 0;
       return Category.removeById(data._id);
@@ -71,6 +73,7 @@ describe('Category', () => {
     return Category.insert({
       name: 'WahAHa'
     }).then(data => {
+      data.name.should.eql('WAHAHA');
       data.slug.should.eql('WAHAHA');
       hexo.config.filename_case = 0;
       return Category.removeById(data._id);

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -48,6 +48,7 @@ describe('Tag', () => {
   it('slug - filename_case: 0', () => Tag.insert({
     name: 'WahAHa'
   }).then(data => {
+    data.name.should.eql('WahAHa');
     data.slug.should.eql('WahAHa');
     return Tag.removeById(data._id);
   }));
@@ -58,6 +59,7 @@ describe('Tag', () => {
     return Tag.insert({
       name: 'WahAHa'
     }).then(data => {
+      data.name.should.eql('wahaha');
       data.slug.should.eql('wahaha');
       hexo.config.filename_case = 0;
       return Tag.removeById(data._id);
@@ -70,6 +72,7 @@ describe('Tag', () => {
     return Tag.insert({
       name: 'WahAHa'
     }).then(data => {
+      data.name.should.eql('WAHAHA');
       data.slug.should.eql('WAHAHA');
       hexo.config.filename_case = 0;
       return Tag.removeById(data._id);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Fixes #3875 
[`filename_case`](https://hexo.io/docs/configuration#Writing) currently applies to slug only, this PR makes it transform the tag/category name itself as well.



## How to test

cc @RobotWuYun @dailyrandomphoto 

1. 
``` diff
package.json
-  "hexo": "^4.0.0",
+  "hexo": "curbengh/hexo#tag-case",
```

2. `rm -rf node_modules/`
3. `rm package-lock.json`
4. `npm i`
5. `hexo clean && hexo s`

Maintainers only:
```sh
git clone -b tag-case https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
