### PR TITLE
feat(permalink): pretty_urls.trailing_html

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -14,7 +14,8 @@ module.exports = {
   permalink: ':year/:month/:day/:title/',
   permalink_defaults: {},
   pretty_urls: {
-    trailing_index: true
+    trailing_index: true,
+    trailing_html: true
   },
   // Directory
   source_dir: 'source',

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Schema } = require('warehouse');
-const { slugize } = require('hexo-util');
+const { prettyUrls, slugize } = require('hexo-util');
 const full_url_for = require('../plugins/helper/full_url_for');
 
 module.exports = ctx => {
@@ -41,7 +41,7 @@ module.exports = ctx => {
   Category.virtual('permalink').get(function() {
     const { config } = ctx;
     let url = full_url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    url = prettyUrls(url, config.pretty_urls);
     return url;
   });
 

--- a/lib/models/category.js
+++ b/lib/models/category.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Schema } = require('warehouse');
-const { prettyUrls, slugize } = require('hexo-util');
+const { slugize } = require('hexo-util');
 const full_url_for = require('../plugins/helper/full_url_for');
 
 module.exports = ctx => {
@@ -39,10 +39,7 @@ module.exports = ctx => {
   });
 
   Category.virtual('permalink').get(function() {
-    const { config } = ctx;
-    let url = full_url_for.call(ctx, this.path);
-    url = prettyUrls(url, config.pretty_urls);
-    return url;
+    return full_url_for.call(ctx, this.path);
   });
 
   Category.virtual('posts').get(function() {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -5,7 +5,6 @@ const { join } = require('path');
 const Moment = require('./types/moment');
 const moment = require('moment');
 const full_url_for = require('../plugins/helper/full_url_for');
-const { prettyUrls } = require('hexo-util');
 
 module.exports = ctx => {
   const Page = new Schema({
@@ -34,10 +33,7 @@ module.exports = ctx => {
   });
 
   Page.virtual('permalink').get(function() {
-    const { config } = ctx;
-    let url = full_url_for.call(ctx, this.path);
-    url = prettyUrls(url, config.pretty_urls);
-    return url;
+    return full_url_for.call(ctx, this.path);
   });
 
   Page.virtual('full_source').get(function() {

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -5,6 +5,7 @@ const { join } = require('path');
 const Moment = require('./types/moment');
 const moment = require('moment');
 const full_url_for = require('../plugins/helper/full_url_for');
+const { prettyUrls } = require('hexo-util');
 
 module.exports = ctx => {
   const Page = new Schema({
@@ -35,7 +36,7 @@ module.exports = ctx => {
   Page.virtual('permalink').get(function() {
     const { config } = ctx;
     let url = full_url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    url = prettyUrls(url, config.pretty_urls);
     return url;
   });
 

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -6,6 +6,7 @@ const { extname, join, sep } = require('path');
 const Promise = require('bluebird');
 const Moment = require('./types/moment');
 const full_url_for = require('../plugins/helper/full_url_for');
+const { prettyUrls } = require('hexo-util');
 
 function pickID(data) {
   return data._id;
@@ -53,7 +54,7 @@ module.exports = ctx => {
   Post.virtual('permalink').get(function() {
     const { config } = ctx;
     let url = full_url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    url = prettyUrls(url, config.pretty_urls);
     return url;
   });
 

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -6,7 +6,6 @@ const { extname, join, sep } = require('path');
 const Promise = require('bluebird');
 const Moment = require('./types/moment');
 const full_url_for = require('../plugins/helper/full_url_for');
-const { prettyUrls } = require('hexo-util');
 
 function pickID(data) {
   return data._id;
@@ -52,10 +51,7 @@ module.exports = ctx => {
   });
 
   Post.virtual('permalink').get(function() {
-    const { config } = ctx;
-    let url = full_url_for.call(ctx, this.path);
-    url = prettyUrls(url, config.pretty_urls);
-    return url;
+    return full_url_for.call(ctx, this.path);
   });
 
   Post.virtual('full_source').get(function() {

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Schema } = require('warehouse');
-const { prettyUrls, slugize } = require('hexo-util');
+const { slugize } = require('hexo-util');
 const { hasOwnProperty: hasOwn } = Object.prototype;
 const full_url_for = require('../plugins/helper/full_url_for');
 
@@ -30,10 +30,7 @@ module.exports = ctx => {
   });
 
   Tag.virtual('permalink').get(function() {
-    const { config } = ctx;
-    let url = full_url_for.call(ctx, this.path);
-    url = prettyUrls(url, config.pretty_urls);
-    return url;
+    return full_url_for.call(ctx, this.path);
   });
 
   Tag.virtual('posts').get(function() {

--- a/lib/models/tag.js
+++ b/lib/models/tag.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Schema } = require('warehouse');
-const { slugize } = require('hexo-util');
+const { prettyUrls, slugize } = require('hexo-util');
 const { hasOwnProperty: hasOwn } = Object.prototype;
 const full_url_for = require('../plugins/helper/full_url_for');
 
@@ -32,7 +32,7 @@ module.exports = ctx => {
   Tag.virtual('permalink').get(function() {
     const { config } = ctx;
     let url = full_url_for.call(ctx, this.path);
-    if (config.pretty_urls.trailing_index === false) url = url.replace(/index\.html$/, '');
+    url = prettyUrls(url, config.pretty_urls);
     return url;
   });
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "hexo-fs": "^2.0.0",
     "hexo-i18n": "^1.0.0",
     "hexo-log": "^1.0.0",
-    "hexo-util": "^1.6.1",
+    "hexo-util": "^1.7.0",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",
     "micromatch": "^4.0.2",

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -116,6 +116,17 @@ describe('Category', () => {
     });
   });
 
+  it('permalink - trailing_html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Category.insert({
+      name: 'foo'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/\.html$/, ''));
+      hexo.config.pretty_urls.trailing_html = true;
+      return Category.removeById(data._id);
+    });
+  });
+
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
     return Category.insert({

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -73,6 +73,30 @@ describe('Page', () => {
     });
   });
 
+  it('permalink - trailing_html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Page.insert({
+      source: 'foo.md',
+      path: 'bar/foo.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/\.html$/, ''));
+      hexo.config.pretty_urls.trailing_html = true;
+      return Page.removeById(data._id);
+    });
+  });
+
+  it('permalink - trailing_html - index.html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Page.insert({
+      source: 'foo.md',
+      path: 'bar/index.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path);
+      hexo.config.pretty_urls.trailing_html = true;
+      return Page.removeById(data._id);
+    });
+  });
+
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
     const path = 'bár';

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -140,10 +140,34 @@ describe('Post', () => {
     hexo.config.pretty_urls.trailing_index = false;
     return Post.insert({
       source: 'foo.md',
-      slug: 'bar'
+      slug: 'bar/index.html'
     }).then(data => {
       data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/index\.html$/, ''));
       hexo.config.pretty_urls.trailing_index = true;
+      return Post.removeById(data._id);
+    });
+  });
+
+  it('permalink - trailing_html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bar/foo.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/\.html$/, ''));
+      hexo.config.pretty_urls.trailing_html = true;
+      return Post.removeById(data._id);
+    });
+  });
+
+  it('permalink - trailing_html - index.html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Post.insert({
+      source: 'foo.md',
+      slug: 'bar/index.html'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path);
+      hexo.config.pretty_urls.trailing_html = true;
       return Post.removeById(data._id);
     });
   });

--- a/test/scripts/models/tag.js
+++ b/test/scripts/models/tag.js
@@ -101,6 +101,17 @@ describe('Tag', () => {
     });
   });
 
+  it('permalink - trailing_html', () => {
+    hexo.config.pretty_urls.trailing_html = false;
+    return Tag.insert({
+      name: 'foo'
+    }).then(data => {
+      data.permalink.should.eql(hexo.config.url + '/' + data.path.replace(/\.html$/, ''));
+      hexo.config.pretty_urls.trailing_html = true;
+      return Tag.removeById(data._id);
+    });
+  });
+
   it('permalink - should be encoded', () => {
     hexo.config.url = 'http://fôo.com';
     return Tag.insert({


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Continuation of https://github.com/hexojs/hexo/pull/3691.
Utilize `prettyUrls()` introduced in https://github.com/hexojs/hexo-util/pull/152 (credit @SukkaW)
Supersede #3893

When `pretty_urls.trailing_html` is disabled, permalink like `example.com/foo/bar.html` is transformed into `example.com/foo/bar`.

The option doesn't apply to url with trailing `index.html`, e.g. `example.com/foo/bar/index.html`. I don't think `example.com/foo/bar/index/` is valid.


## How to test

```sh
git clone -b pretty_urls-util https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
