### PR TITLE
fix(box): ignore node_modules/ & .git/ in themes

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -8,7 +8,7 @@ const fs = require('hexo-fs');
 const chalk = require('chalk');
 const { EventEmitter } = require('events');
 const micromatch = require('micromatch');
-const { ignore } = require('../hexo/default_config');
+const ignore = ['**/themes/*/node_modules/**', '**/themes/*/.git/**'];
 
 const defaultPattern = new Pattern(() => ({}));
 

--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -8,6 +8,7 @@ const fs = require('hexo-fs');
 const chalk = require('chalk');
 const { EventEmitter } = require('events');
 const micromatch = require('micromatch');
+const { ignore } = require('../hexo/default_config');
 
 const defaultPattern = new Pattern(() => ({}));
 
@@ -29,11 +30,14 @@ function Box(ctx, base, options) {
   this.watcher = null;
   this.Cache = ctx.model('Cache');
   this.File = this._createFileClass();
-  this.ignore = ctx.config.ignore;
+
+  let ignoreCfg = ignore;
   if (ctx.config.ignore) {
-    const targets = Array.isArray(ctx.config.ignore) ? ctx.config.ignore : [ctx.config.ignore];
-    this.options.ignored = (this.options.ignored || []).concat(targets.map(s => toRegExp(ctx, s)).filter(x => x));
+    if (ctx.config.ignore.length) ignoreCfg = ignoreCfg.concat(ctx.config.ignore);
   }
+  this.ignore = ignoreCfg;
+  const targets = ignoreCfg;
+  this.options.ignored = (this.options.ignored || []).concat(targets.map(s => toRegExp(ctx, s)).filter(x => x));
 }
 
 require('util').inherits(Box, EventEmitter);

--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -65,7 +65,7 @@ module.exports = {
   deploy: {},
 
   // ignore files from processing
-  ignore: ['**/themes/*/node_modules/**'],
+  ignore: ['**/themes/*/node_modules/**', '**/themes/*/.git/**'],
 
   // Category & Tag
   meta_generator: true

--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -65,7 +65,7 @@ module.exports = {
   deploy: {},
 
   // ignore files from processing
-  ignore: ['**/themes/*/node_modules/**', '**/themes/*/.git/**'],
+  ignore: [],
 
   // Category & Tag
   meta_generator: true

--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -65,9 +65,8 @@ module.exports = {
   deploy: {},
 
   // ignore files from processing
-  ignore: [],
+  ignore: ['**/themes/*/node_modules/**'],
 
   // Category & Tag
   meta_generator: true
 };
-


### PR DESCRIPTION
## What does it do?
Continuation of https://github.com/hexojs/hexo/pull/3797

Supersedes and closes https://github.com/hexojs/hexo-starter/pull/30 cc @dailyrandomphoto 

Related: https://github.com/hexojs/hexo/issues/3885 https://github.com/hexojs/hexo-server/issues/45 https://github.com/hexojs/hexo-server/issues/43
## How to test

cc @Shen-Yu 

1.
``` diff
package.json
-  "hexo": "^4.1.0",
+  "hexo": "curbengh/hexo#ignore-theme-node",
```

2. `rm -f package-lock.json && rm -rf node_modules/`
3. `npm install`
4. `hexo clean && hexo server`

Maintainers only:
```sh
git clone -b ignore-theme-node https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
