### PR TITLE
fix(open_graph): set default locales

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -3,6 +3,23 @@
 const urlFn = require('url');
 const moment = require('moment');
 const { encodeURL, htmlTag, stripHTML, escapeHTML } = require('hexo-util');
+const localeMap = {
+  'en': 'en_US',
+  'de': 'de_DE',
+  'es': 'es_ES',
+  'fr': 'fr_FR',
+  'hu': 'hu_HU',
+  'id': 'id_ID',
+  'it': 'it_IT',
+  'ja': 'ja_JP',
+  'ko': 'ko_KR',
+  'nl': 'nl_NL',
+  'ru': 'ru_RU',
+  'th': 'th_TH',
+  'tr': 'tr_TR',
+  'vi': 'vi_VN'
+};
+const localeRegex = new RegExp(Object.keys(localeMap).join('|'), 'i');
 
 function meta(name, content) {
   return `${htmlTag('meta', {
@@ -79,7 +96,10 @@ function openGraphHelper(options = {}) {
   }
 
   if (language) {
-    if (language.length === 5) {
+    if (language.length === 2) {
+      language = language.replace(localeRegex, str => localeMap[str]);
+      result += og('og:locale', language);
+    } else if (language.length === 5) {
       const territory = language.slice(-2);
       const territoryRegex = new RegExp(territory.concat('$'));
 

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -671,7 +671,7 @@ describe('open_graph', () => {
     result.should.not.contain(meta({property: 'og:locale'}));
   });
 
-  it('og:locale - language is not in lang-territory format', () => {
+  it('og:locale - language is not in lang-TERRITORY format', () => {
     hexo.config.language = 'en';
 
     const result = openGraph.call({
@@ -680,7 +680,7 @@ describe('open_graph', () => {
       is_post: isPost
     });
 
-    result.should.not.contain(meta({property: 'og:locale'}));
+    result.should.contain(meta({property: 'og:locale', content: 'en_US'}));
   });
 
   it('article:author - options.author', () => {


### PR DESCRIPTION
## What does it do?
https://github.com/hexojs/hexo/pull/3808 introduces a :chicken: :egg: issue; setting "language" (like "en") prevent `og:locale` from being inserted, setting "language-TERRITORY" (like "en-GB") breaks theme's multilingual/i8n support.

This PR fixes that by assuming default locales.
Based on Facebook's [official list](https://developers.facebook.com/docs/messenger-platform/messenger-profile/supported-locales/).


## How to test

```sh
git clone -b og-locale-backward https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
