### PR TITLE
fix(postPermalinkFilter): permalink_defaults should not overwrite values

### DIFF
--- a/lib/plugins/filter/post_permalink.js
+++ b/lib/plugins/filter/post_permalink.js
@@ -6,18 +6,19 @@ let permalink;
 
 function postPermalinkFilter(data) {
   const { config } = this;
+  const { id, _id, slug, title, date } = data;
   const meta = {
-    id: data.id || data._id,
-    title: data.slug,
-    name: typeof data.slug === 'string' ? basename(data.slug) : '',
-    post_title: slugize(data.title, {transform: 1}),
-    year: data.date.format('YYYY'),
-    month: data.date.format('MM'),
-    day: data.date.format('DD'),
-    hour: data.date.format('HH'),
-    minute: data.date.format('mm'),
-    i_month: data.date.format('M'),
-    i_day: data.date.format('D')
+    id: id || _id,
+    title: slug,
+    name: typeof slug === 'string' ? basename(slug) : '',
+    post_title: slugize(title, {transform: 1}),
+    year: date.format('YYYY'),
+    month: date.format('MM'),
+    day: date.format('DD'),
+    hour: date.format('HH'),
+    minute: date.format('mm'),
+    i_month: date.format('M'),
+    i_day: date.format('D')
   };
 
   if (!permalink || permalink.rule !== config.permalink) {
@@ -42,7 +43,15 @@ function postPermalinkFilter(data) {
     Object.defineProperty(meta, key, Object.getOwnPropertyDescriptor(data, key));
   }
 
-  return permalink.stringify(Object.assign(meta, config.permalink_defaults));
+  const keys2 = Object.keys(config.permalink_defaults);
+
+  for (const key of keys2) {
+    if (Object.prototype.hasOwnProperty.call(meta, key)) continue;
+
+    meta[key] = config.permalink_defaults[key];
+  }
+
+  return permalink.stringify(meta);
 }
 
 module.exports = postPermalinkFilter;

--- a/test/scripts/filters/post_permalink.js
+++ b/test/scripts/filters/post_permalink.js
@@ -125,4 +125,28 @@ describe('post_permalink', () => {
       return Post.removeById(post._id);
     });
   });
+
+  it('permalink_defaults', () => {
+    hexo.config.permalink = 'posts/:lang/:title/';
+    const orgPermalinkDefaults = hexo.config.permalink_defaults;
+    hexo.config.permalink_defaults = {lang: 'en'};
+
+    return Post.insert([{
+      source: 'my-new-post.md',
+      slug: 'my-new-post',
+      title: 'My New Post1'
+    }, {
+      source: 'my-new-fr-post.md',
+      slug: 'my-new-fr-post',
+      title: 'My New Post2',
+      lang: 'fr'
+    }]).then(posts => {
+      postPermalink(posts[0]).should.eql('posts/en/my-new-post/');
+      postPermalink(posts[1]).should.eql('posts/fr/my-new-fr-post/');
+
+      hexo.config.permalink = PERMALINK;
+      hexo.config.permalink_defaults = orgPermalinkDefaults;
+      return Promise.all(posts.map(post => Post.removeById(post._id)));
+    }).then();
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

`permalink_defaults` option does not work correctly from 4.1.0.
According https://hexo.io/docs/permalinks, set `_config.yml` as
```yaml
permalink: :lang/:title/
permalink_defaults:
  lang: en
```

```
$ hexo new "Hello World" --lang tw
```
and the URL will be:
```
# expected is
http://localhost:4000/tw/hello-world/

# but actual is 
http://localhost:4000/en/hello-world/
```

Compare v4.0.0 and v4.1.0,
I found the related change is https://github.com/hexojs/hexo/commit/e0f2478ef431cccb1d30d92d2d0c47d6f195675b#diff-dbb03cb234189f8e709e7c5f9921aa67L45  (#3790) 
```diff
- return permalink.stringify(defaults(meta, config.permalink_defaults));
+ return permalink.stringify(Object.assign(meta, config.permalink_defaults));
```

If change to
```js
Object.assign([], config.permalink_defaults, meta)
```
it causes "Maximum call stack size exceeded" error, so use for loop to copy values.

## How to test

```sh
git clone -b fix-permalinkDefaults https://github.com/dailyrandomphoto/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
