### PR TITLE
fix(permalink_filter): handle null config

### DIFF
--- a/lib/plugins/filter/post_permalink.js
+++ b/lib/plugins/filter/post_permalink.js
@@ -43,13 +43,16 @@ function postPermalinkFilter(data) {
     Object.defineProperty(meta, key, Object.getOwnPropertyDescriptor(data, key));
   }
 
-  const keys2 = Object.keys(config.permalink_defaults);
+  if (config.permalink_defaults) {
+    const keys2 = Object.keys(config.permalink_defaults);
 
-  for (const key of keys2) {
-    if (Object.prototype.hasOwnProperty.call(meta, key)) continue;
+    for (const key of keys2) {
+      if (Object.prototype.hasOwnProperty.call(meta, key)) continue;
 
-    meta[key] = config.permalink_defaults[key];
+      meta[key] = config.permalink_defaults[key];
+    }
   }
+
 
   return permalink.stringify(meta);
 }

--- a/test/scripts/filters/post_permalink.js
+++ b/test/scripts/filters/post_permalink.js
@@ -147,6 +147,31 @@ describe('post_permalink', () => {
       hexo.config.permalink = PERMALINK;
       hexo.config.permalink_defaults = orgPermalinkDefaults;
       return Promise.all(posts.map(post => Post.removeById(post._id)));
-    }).then();
+    });
+  });
+
+  it('permalink_defaults - null', () => {
+    hexo.config.permalink = 'posts/:lang/:title/';
+    const orgPermalinkDefaults = hexo.config.permalink_defaults;
+    hexo.config.permalink_defaults = null;
+
+    return Post.insert([{
+      source: 'my-new-post.md',
+      slug: 'my-new-post',
+      title: 'My New Post1',
+      lang: 'en'
+    }, {
+      source: 'my-new-post-2.md',
+      slug: 'my-new-post-2',
+      title: 'My New Post2',
+      lang: 'fr'
+    }]).then(posts => {
+      postPermalink(posts[0]).should.eql('posts/en/my-new-post/');
+      postPermalink(posts[1]).should.eql('posts/fr/my-new-post-2/');
+
+      hexo.config.permalink = PERMALINK;
+      hexo.config.permalink_defaults = orgPermalinkDefaults;
+      return Promise.all(posts.map(post => Post.removeById(post._id)));
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Handle potential `null` for `config.permalink_defaults`.

## How to test

```sh
git clone -b permalink-filter-null https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
