### PR TITLE
feat(cache): option for cache rendered content

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -62,6 +62,9 @@ module.exports = {
   pagination_dir: 'page',
   // Extensions
   theme: 'landscape',
+  server: {
+    cache: false
+  },
   // Deployment
   deploy: {},
 

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -311,7 +311,11 @@ class Hexo {
 
   watch(callback) {
     let useCache = false;
-    if (this.env.cmd.startsWith('s')) {
+    const { cache } = Object.assign({
+      cache: false
+    }, this.config.server);
+
+    if (this.env.cmd.startsWith('s') && cache) {
       // enable cache when run hexo server
       useCache = true;
     }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

In #3756, @dailyrandomphoto disabled `cache rendered content` for `generate` and enabled for `hexo s`.

Enabling cache rendered content for `hexo s` will respond more quickly from second requests which is helpful when use `hexo-server` in production, but it also makes more difficult when developing theme or previewing other changes. So the `config.server.cache` is introduced in this PR. The documents for `hexo-server` will be updated after this PR is merged and released with `hexo@4.3`.

## How to test

```sh
git clone -b server-development https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
