### PR TITLE
test(load_database): enable 'database load failed'

### DIFF
--- a/test/scripts/hexo/load_database.js
+++ b/test/scripts/hexo/load_database.js
@@ -52,10 +52,10 @@ describe('Load database', () => {
 
   // I don't know why this test case can't pass on Windows
   // It always throws EPERM error
-  // it('database load failed', () => fs.writeFile(dbPath, '{1423432: 324').then(() => loadDatabase(hexo)).then(() => {
-  //   hexo._dbLoaded.should.be.false;
-  //   return fs.exists(dbPath);
-  // }).then(exist => {
-  //   exist.should.be.false;
-  // }));
+  it('database load failed', () => fs.writeFile(dbPath, '{1423432: 324').then(() => loadDatabase(hexo)).then(() => {
+    hexo._dbLoaded.should.be.false;
+    return fs.exists(dbPath);
+  }).then(exist => {
+    exist.should.be.false;
+  }));
 });

--- a/test/scripts/hexo/load_database.js
+++ b/test/scripts/hexo/load_database.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const pathFn = require('path');
-const fs = require('hexo-fs');
+const { join } = require('path');
+const { exists, mkdirs, rmdir, unlink, writeFile } = require('hexo-fs');
 
 describe('Load database', () => {
   const Hexo = require('../../../lib/hexo');
-  const hexo = new Hexo(pathFn.join(__dirname, 'db_test'), {silent: true});
+  const hexo = new Hexo(join(__dirname, 'db_test'), {silent: true});
   const loadDatabase = require('../../../lib/hexo/load_database');
   const dbPath = hexo.database.options.path;
 
@@ -23,46 +23,46 @@ describe('Load database', () => {
     }
   };
 
-  before(() => fs.mkdirs(hexo.base_dir));
+  before(() => mkdirs(hexo.base_dir));
 
   beforeEach(() => {
     hexo._dbLoaded = false;
   });
 
   after(async() => {
-    const exist = await fs.exists(dbPath);
-    if (exist) await fs.unlink(dbPath);
-    fs.rmdir(hexo.base_dir);
+    const exist = await exists(dbPath);
+    if (exist) await unlink(dbPath);
+    rmdir(hexo.base_dir);
   });
 
   it('database does not exist', () => loadDatabase(hexo));
 
   it('database load success', async() => {
-    await fs.writeFile(dbPath, JSON.stringify(fixture));
+    await writeFile(dbPath, JSON.stringify(fixture));
     await loadDatabase(hexo);
     hexo._dbLoaded.should.eql(true);
     hexo.model('Test').toArray({lean: true}).should.eql(fixture.models.Test);
     hexo.model('Test').destroy();
 
-    await fs.unlink(dbPath);
+    await unlink(dbPath);
   });
 
   it('don\'t load database if loaded', async() => {
     hexo._dbLoaded = true;
 
-    await fs.writeFile(dbPath, JSON.stringify(fixture));
+    await writeFile(dbPath, JSON.stringify(fixture));
     await loadDatabase(hexo);
 
     hexo.model('Test').length.should.eql(0);
 
-    await fs.unlink(dbPath);
+    await unlink(dbPath);
   });
 
   it('database load failed', async() => {
-    await fs.writeFile(dbPath, '{1423432: 324');
+    await writeFile(dbPath, '{1423432: 324');
     await loadDatabase(hexo);
     hexo._dbLoaded.should.eql(false);
-    const exist = await fs.exists(dbPath);
+    const exist = await exists(dbPath);
     exist.should.eql(false);
   });
 });

--- a/test/scripts/hexo/load_database.js
+++ b/test/scripts/hexo/load_database.js
@@ -29,7 +29,7 @@ describe('Load database', () => {
     hexo._dbLoaded = false;
   });
 
-  after(async() => {
+  after(async () => {
     const exist = await exists(dbPath);
     if (exist) await unlink(dbPath);
     rmdir(hexo.base_dir);
@@ -37,7 +37,7 @@ describe('Load database', () => {
 
   it('database does not exist', () => loadDatabase(hexo));
 
-  it('database load success', async() => {
+  it('database load success', async () => {
     await writeFile(dbPath, JSON.stringify(fixture));
     await loadDatabase(hexo);
     hexo._dbLoaded.should.eql(true);
@@ -47,7 +47,7 @@ describe('Load database', () => {
     await unlink(dbPath);
   });
 
-  it('don\'t load database if loaded', async() => {
+  it('don\'t load database if loaded', async () => {
     hexo._dbLoaded = true;
 
     await writeFile(dbPath, JSON.stringify(fixture));
@@ -58,7 +58,7 @@ describe('Load database', () => {
     await unlink(dbPath);
   });
 
-  it('database load failed', async() => {
+  it('database load failed', async () => {
     await writeFile(dbPath, '{1423432: 324');
     await loadDatabase(hexo);
     hexo._dbLoaded.should.eql(false);

--- a/test/scripts/hexo/load_database.js
+++ b/test/scripts/hexo/load_database.js
@@ -58,8 +58,6 @@ describe('Load database', () => {
     await fs.unlink(dbPath);
   });
 
-  // I don't know why this test case can't pass on Windows
-  // It always throws EPERM error
   it('database load failed', async() => {
     await fs.writeFile(dbPath, '{1423432: 324');
     await loadDatabase(hexo);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Added a workaround for the `EPERM error` in Windows.

Might as well refactor to async/await #3328.


## How to test

```sh
git clone -b db-load-windows https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
