### PR TITLE
test: comment out missing tests

### DIFF
--- a/test/scripts/console/deploy.js
+++ b/test/scripts/console/deploy.js
@@ -77,7 +77,7 @@ describe('deploy', () => {
     });
   });
 
-  // it('deployer not found');
+  // it('deployer not found'); missing-unit-test
 
   it('generate', () => fs.writeFile(pathFn.join(hexo.source_dir, 'test.txt'), 'test').then(() => deploy({generate: true})).then(() => fs.readFile(pathFn.join(hexo.public_dir, 'test.txt'))).then(content => {
     content.should.eql('test');

--- a/test/scripts/console/deploy.js
+++ b/test/scripts/console/deploy.js
@@ -77,7 +77,7 @@ describe('deploy', () => {
     });
   });
 
-  it('deployer not found');
+  // it('deployer not found');
 
   it('generate', () => fs.writeFile(pathFn.join(hexo.source_dir, 'test.txt'), 'test').then(() => deploy({generate: true})).then(() => fs.readFile(pathFn.join(hexo.public_dir, 'test.txt'))).then(content => {
     content.should.eql('test');

--- a/test/scripts/console/render.js
+++ b/test/scripts/console/render.js
@@ -76,7 +76,7 @@ describe('render', () => {
     });
   });
 
-  // it('output');
+  // it('output'); missing-unit-test
 
   it('engine', () => {
     const src = pathFn.join(hexo.base_dir, 'test');

--- a/test/scripts/console/render.js
+++ b/test/scripts/console/render.js
@@ -76,6 +76,8 @@ describe('render', () => {
     });
   });
 
+  // it('output');
+
   it('engine', () => {
     const src = pathFn.join(hexo.base_dir, 'test');
     const dest = pathFn.join(hexo.base_dir, 'result.json');

--- a/test/scripts/helpers/list_archives.js
+++ b/test/scripts/helpers/list_archives.js
@@ -178,5 +178,20 @@ describe('list_archives', () => {
     ].join(''));
   });
 
-  it('timezone');
+  it('timezone', () => {
+    ctx.config.timezone = 'Asia/Tokyo';
+    const result = listArchives({
+      format: 'YYYY MM ZZ'
+    });
+
+    result.should.eql([
+      '<ul class="archive-list">',
+      '<li class="archive-list-item"><a class="archive-list-link" href="/archives/2014/02/">2014 02 +0900</a><span class="archive-list-count">1</span></li>',
+      '<li class="archive-list-item"><a class="archive-list-link" href="/archives/2013/10/">2013 10 +0900</a><span class="archive-list-count">1</span></li>',
+      '<li class="archive-list-item"><a class="archive-list-link" href="/archives/2013/06/">2013 06 +0900</a><span class="archive-list-count">2</span></li>',
+      '</ul>'
+    ].join(''));
+
+    ctx.config.timezone = '';
+  });
 });

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -138,7 +138,7 @@ describe('Hexo', () => {
     });
   });
 
-  it('model()');
+  // it('model()');
 
   it('_showDrafts()', () => {
     hexo._showDrafts().should.be.false;
@@ -188,7 +188,7 @@ describe('Hexo', () => {
 
   it('watch() - theme', () => testWatch(pathFn.join(hexo.theme_dir, 'source')));
 
-  it('unwatch()');
+  // it('unwatch()');
 
   it('exit()', () => {
     const hook = sinon.spy();

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -138,7 +138,7 @@ describe('Hexo', () => {
     });
   });
 
-  // it('model()');
+  // it('model()'); missing-unit-test
 
   it('_showDrafts()', () => {
     hexo._showDrafts().should.be.false;
@@ -188,7 +188,7 @@ describe('Hexo', () => {
 
   it('watch() - theme', () => testWatch(pathFn.join(hexo.theme_dir, 'source')));
 
-  // it('unwatch()');
+  // it('unwatch()'); missing-unit-test
 
   it('exit()', () => {
     const hook = sinon.spy();

--- a/test/scripts/hexo/load_database.js
+++ b/test/scripts/hexo/load_database.js
@@ -52,10 +52,10 @@ describe('Load database', () => {
 
   // I don't know why this test case can't pass on Windows
   // It always throws EPERM error
-  it.skip('database load failed', () => fs.writeFile(dbPath, '{1423432: 324').then(() => loadDatabase(hexo)).then(() => {
-    hexo._dbLoaded.should.be.false;
-    return fs.exists(dbPath);
-  }).then(exist => {
-    exist.should.be.false;
-  }));
+  // it('database load failed', () => fs.writeFile(dbPath, '{1423432: 324').then(() => loadDatabase(hexo)).then(() => {
+  //   hexo._dbLoaded.should.be.false;
+  //   return fs.exists(dbPath);
+  // }).then(exist => {
+  //   exist.should.be.false;
+  // }));
 });

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -23,7 +23,7 @@ describe('Category', () => {
     });
   });
 
-  // it('parent - reference');
+  // it('parent - reference'); missing-unit-test
 
   it('slug - virtual', () => Category.insert({
     name: 'foo'

--- a/test/scripts/models/category.js
+++ b/test/scripts/models/category.js
@@ -23,7 +23,7 @@ describe('Category', () => {
     });
   });
 
-  it.skip('parent - reference');
+  // it('parent - reference');
 
   it('slug - virtual', () => Category.insert({
     name: 'foo'


### PR DESCRIPTION
## What does it do?
Not very keen on 'x pending' message at the end of unit test.
I added "missing-unit-test" to the comment. We can mention it in the [roadmap](https://github.com/hexojs/hexo/issues/2492), and contributor can simply search for the keyword to locate missing tests.

Add a missing test for list_archives helper.
load_database test is being worked on #3975 

Revert #3742 

## How to test

```sh
git clone -b test-missing https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
