### PR TITLE
fix(open_graph-helper): pass all pretty_urls options

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -1,14 +1,9 @@
 'use strict';
 
-<<<<<<< HEAD
 const { parse, resolve } = require('url');
 const { isMoment, isDate } = require('moment');
-const { encodeURL, htmlTag, stripHTML, escapeHTML } = require('hexo-util');
-=======
-const urlFn = require('url');
-const moment = require('moment');
-const { htmlTag, prettyUrls, stripHTML, escapeHTML } = require('hexo-util');
->>>>>>> fix(open_graph-helper): pass all pretty_urls options
+const { prettyUrls, htmlTag, stripHTML, escapeHTML } = require('hexo-util');
+
 const localeMap = {
   'en': 'en_US',
   'de': 'de_DE',
@@ -50,7 +45,7 @@ function openGraphHelper(options = {}) {
   let keywords = page.keywords || (page.tags && page.tags.length ? page.tags : undefined) || config.keywords;
   const title = options.title || page.title || config.title;
   const type = options.type || (this.is_post() ? 'article' : 'website');
-  const url = prettyUrls(options.url || this.url || config.url, config.pretty_urls);
+  const url = prettyUrls(options.url || this.url, config.pretty_urls);
   const siteName = options.site_name || config.title;
   const twitterCard = options.twitter_card || 'summary';
   const date = options.date !== false ? options.date || page.date : false;

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -1,8 +1,14 @@
 'use strict';
 
+<<<<<<< HEAD
 const { parse, resolve } = require('url');
 const { isMoment, isDate } = require('moment');
 const { encodeURL, htmlTag, stripHTML, escapeHTML } = require('hexo-util');
+=======
+const urlFn = require('url');
+const moment = require('moment');
+const { htmlTag, prettyUrls, stripHTML, escapeHTML } = require('hexo-util');
+>>>>>>> fix(open_graph-helper): pass all pretty_urls options
 const localeMap = {
   'en': 'en_US',
   'de': 'de_DE',
@@ -44,7 +50,7 @@ function openGraphHelper(options = {}) {
   let keywords = page.keywords || (page.tags && page.tags.length ? page.tags : undefined) || config.keywords;
   const title = options.title || page.title || config.title;
   const type = options.type || (this.is_post() ? 'article' : 'website');
-  let url = options.url || this.url;
+  const url = prettyUrls(options.url || this.url || config.url, config.pretty_urls);
   const siteName = options.site_name || config.title;
   const twitterCard = options.twitter_card || 'summary';
   const date = options.date !== false ? options.date || page.date : false;
@@ -82,12 +88,6 @@ function openGraphHelper(options = {}) {
   result += og('og:type', type);
   result += og('og:title', title);
 
-  if (url) {
-    if (config.pretty_urls.trailing_index === false) {
-      url = url.replace(/index\.html$/, '');
-    }
-    url = encodeURL(url);
-  }
   result += og('og:url', url);
 
   result += og('og:site_name', siteName);

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -34,7 +34,7 @@ describe('open_graph', () => {
       }).should.eql([
         meta({property: 'og:type', content: 'website'}),
         meta({property: 'og:title', content: hexo.config.title}),
-        meta({property: 'og:url', content: escapeHTML(hexo.config.url)}),
+        meta({property: 'og:url'}),
         meta({property: 'og:site_name', content: hexo.config.title}),
         meta({property: 'og:locale', content: 'en_US'}),
         meta({property: 'article:published_time', content: post.date.toISOString()}),

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -2,7 +2,7 @@
 
 const moment = require('moment');
 const cheerio = require('cheerio');
-const { escapeHTML } = require('hexo-util');
+const { encodeURL } = require('hexo-util');
 
 describe('open_graph', () => {
   const Hexo = require('../../../lib/hexo');
@@ -179,7 +179,7 @@ describe('open_graph', () => {
 
     const result = openGraph.call(ctx);
 
-    result.should.contain(meta({property: 'og:url', content: escapeHTML(ctx.url)}));
+    result.should.contain(meta({property: 'og:url', content: encodeURL(ctx.url)}));
   });
 
   it('images - content', () => {


### PR DESCRIPTION
- by utilizing [`prettyUrls()`](https://github.com/hexojs/hexo-util#prettyurlsurl-options) of hexo-util
- to support pretty_urls.trailing_html


## How to test

```sh
git clone -b og-pretty-urls https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
