### PR TITLE
refactor(fragment_cache): reuse result

### DIFF
--- a/lib/plugins/helper/fragment_cache.js
+++ b/lib/plugins/helper/fragment_cache.js
@@ -9,8 +9,9 @@ module.exports = ctx => {
   return function fragmentCache(id, fn) {
     if (this.cache && cache[id] != null) return cache[id];
 
-    cache[id] = fn();
     const result = fn();
+
+    cache[id] = result;
     return result;
   };
 };


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fix a potential performance issue introduced by #3744: After #3744, the function passed to fragment_cache might be called twice instead of once.

A PoC can be viewed here: https://runkit.com/sukkaw/5df9e053e7c3d50019810e89

```js
const cache = {};
let called1 = 0;
let called2 = 0;

// This PR
const cacheFunc1 = (k, fn) => {
  if (cache[k] != null) return cache[k];
  
  const result = fn();
  cache[k] = result;
  
  return result;
}

// PR #3744
const cacheFunc2 = (k, fn) => {
  if (cache[k] != null) return cache[k];

  cache[k] = fn();
  const result = fn();
  return result;
}

cacheFunc1('1', () => { return called1++; });
cacheFunc1('1', () => { return called1++; });
cacheFunc1('1', () => { return called1++; });
cacheFunc2('2', () => { return called2++; });
cacheFunc2('2', () => { return called2++; });
cacheFunc2('2', () => { return called2++; });
console.log(called1, called2);
// 1 2
```

## How to test

```sh
git clone -b fragment_cache_resue https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
