### PR TITLE
refactor(theme/view): simplify assignIn

### DIFF
--- a/lib/theme/view.js
+++ b/lib/theme/view.js
@@ -4,23 +4,18 @@ const { dirname, extname, join } = require('path');
 const yfm = require('hexo-front-matter');
 const Promise = require('bluebird');
 
-const assignIn = (...args) => {
-  const length = args.length;
-  const obj = args[0];
+const assignIn = (target, ...sources) => {
+  const length = sources.length;
 
-  if (length < 2 || obj == null) return obj;
-  for (let index = 1; index < length; index++) {
-    const source = args[index];
-    const keys = [];
-    for (const key in source) keys.push(key);
+  if (length < 1 || target == null) return target;
+  for (let i = 0; i < length; i++) {
+    const source = sources[i];
 
-    const l = keys.length;
-    for (let i = 0; i < l; i++) {
-      const key = keys[i];
-      obj[key] = source[key];
+    for (const key in source) {
+      target[key] = source[key];
     }
   }
-  return obj;
+  return target;
 };
 
 function View(path, data) {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The continuation of #3969 (#3753).

`underscore.js` has a `createAssigner()` which is a internal function for `_.extend`, `_.defaults` & `_.assign`:

```js
_.extend = createAssigner(_.allKeys);
_.assign = createAssigner(_.keys);
_.defaults = createAssigner(_.allKeys, true);
```

When bring up #3969, I just simply merge and rewrite `createAssigner(_.allKeys)`:

```js
// Below is a part of _.allKeys which is unnecessary for assignIn itself
const keys = [];
for (const key in source) keys.push(key);

// Iterate Object from keys
const l = keys.length;	
for (let i = 0; i < l; i++) {
  const key = keys[i];
  obj[key] = source[key];
}
```

This PR simplify the `assignIn()` by directly iterating Object.

## How to test

```sh
git clone -b simplify-assignIn https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
