### PR TITLE
test(benchmark): skip checking completion time in hot processing

### DIFF
--- a/test/benchmark.sh
+++ b/test/benchmark.sh
@@ -27,14 +27,16 @@ LOG_TABLE () {
     total_time=$(_SUBSTRUCTION $time_database_saved $time_begin | xargs -0 printf "%.0f")
     line_number=$(wc -l build.log | cut -d" " -f1)
 
-    if [ $total_time -lt 10 ] || ([ $line_number -lt 300 ] && [ $1 != "HOT" ]); then
-        echo "--------------------------------------------"
-        echo -e '\033[41;37m !! Build failed !! \033[0m'
-        head -n 400 build.log
-        exit 1
+    if [ "$1" != "HOT" ]; then
+        if [ "$total_time" -lt 10 ] || [ "$line_number" -lt 300 ]; then
+            echo "--------------------------------------------"
+            echo -e '\033[41;37m !! Build failed !! \033[0m'
+            head -n 400 build.log
+            exit 1
+        fi
     fi
 
-    if [ $total_time -gt 40 ]; then
+    if [ "$total_time" -gt 40 ]; then
         echo "--------------------------------------------"
         echo -e '\033[41;37m !! Performance regression detected !! \033[0m'
         exit 1


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
After https://github.com/hexojs/hexo/pull/3991, the CI on master branch is failing because the hot processing takes less than 10 seconds.

This PR skips completion time and line number checking in hot processing.


## How to test

```sh
git clone -b benchmark-hot-processing https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
