### PR TITLE
ci(benchmark): generate flamegraph

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,9 +17,17 @@ node_js:
 script:
   - npm run eslint
   - npm run test-cov
-  - npm install 0x -g
+  - npm install 0x
   - ./test/benchmark.sh
 
 after_script:
   - npm install coveralls
   - nyc report --reporter=text-lcov | coveralls
+
+deploy:
+  provider: surge
+  project: ./0x/
+  skip_cleanup: true
+  domain: "${TRAVIS_COMMIT}-${TRAVIS_NODE_VERSION}-hexo.surge.sh"
+  on:
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ node_js:
 script:
   - npm run eslint
   - npm run test-cov
+  - npm install 0x -g
   - ./test/benchmark.sh
 
 after_script:

--- a/test/benchmark.sh
+++ b/test/benchmark.sh
@@ -87,14 +87,7 @@ npx --no-install hexo clean > build.log
 echo ""
 echo "- Generating flamegraph..."
 
-0x -- node ./node_modules/.bin/hexo g > build.log 2>&1 ;
-
-flamegraph_dir=$(ls | grep *.0x)
-
-mkdir -p "${TRAVIS_BUILD_DIR}/0x"
-cp -r -f $flamegraph_dir "${TRAVIS_BUILD_DIR}/0x"
-
-echo "- Flamegraph is generated under ${TRAVIS_BUILD_DIR}/0x"
+0x --output-dir "${TRAVIS_BUILD_DIR}/0x" -- node ./node_modules/.bin/hexo g > build.log 2>&1 ;
 
 rm -rf build.log
 cd $TRAVIS_BUILD_DIR

--- a/test/benchmark.sh
+++ b/test/benchmark.sh
@@ -87,7 +87,9 @@ npx --no-install hexo clean > build.log
 echo ""
 echo "- Generating flamegraph..."
 
-0x --output-dir "${TRAVIS_BUILD_DIR}/0x" -- node ./node_modules/.bin/hexo g > build.log 2>&1 ;
+node ./node_modules/.bin/0x --output-dir "${TRAVIS_BUILD_DIR}/0x" -- node ./node_modules/.bin/hexo g > build.log 2>&1 ;
+
+echo "Flamegraph will be deployed to: https://${TRAVIS_COMMIT}-${TRAVIS_NODE_VERSION}-hexo.surge.sh/flamegraph.html"
 
 rm -rf build.log
 cd $TRAVIS_BUILD_DIR

--- a/test/benchmark.sh
+++ b/test/benchmark.sh
@@ -66,6 +66,7 @@ rm -rf node_modules/hexo
 ln -sf $TRAVIS_BUILD_DIR node_modules/hexo
 
 echo "- Start test run"
+echo ""
 
 echo "------------- Cold processing --------------"
 { /usr/bin/time -v npx --no-install hexo g --debug > build.log 2>&1 ; } 2> build.log
@@ -81,6 +82,19 @@ npx --no-install hexo clean > build.log
 LOG_TABLE
 
 echo "--------------------------------------------"
-rm -rf build.log
+npx --no-install hexo clean > build.log
 
+echo ""
+echo "- Generating flamegraph..."
+
+0x -- node ./node_modules/.bin/hexo g > build.log 2>&1 ;
+
+flamegraph_dir=$(ls | grep *.0x)
+
+mkdir -p "${TRAVIS_BUILD_DIR}/0x"
+cp -r -f $flamegraph_dir "${TRAVIS_BUILD_DIR}/0x"
+
+echo "- Flamegraph is generated under ${TRAVIS_BUILD_DIR}/0x"
+
+rm -rf build.log
 cd $TRAVIS_BUILD_DIR


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Use `0x` to generate a human readable flamegraph after benchmark. The flamegraph directory will be under `${TRAVIS_BUILD_DIR}/0x`.

Before we could find a way to deploy the flamegraph, I will leave this PR as a draft.

## How to test

```sh
git clone -b 0x-flamegraph https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

The directory structure should like this:

```
0x
├── flamegraph.html
├── isolate-0x5af5020-1756-1756-v8.log
├── isolate-0x5af5020-1756-1756-v8.log.json
├── isolate-0x5af5020-1756-1756-v8.log.preprocess-ready
└── meta.json

0 directories, 5 files
```

And the flamegraph looks like this:

![image](https://user-images.githubusercontent.com/40715044/71304736-72f02a80-2405-11ea-8673-8a0d381d3259.png)


## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
