### PR TITLE
fix(moment.locale): avoid lookup repeatedly with the wrong names.

### DIFF
--- a/lib/models/types/moment.js
+++ b/lib/models/types/moment.js
@@ -1,7 +1,7 @@
 'use strict';
 
-const moment = require('moment-timezone');
 const { SchemaType } = require('warehouse');
+const { moment, toMomentLocale } = require('../../plugins/helper/date');
 
 class SchemaTypeMoment extends SchemaType {
   constructor(name, options = {}) {
@@ -23,7 +23,7 @@ SchemaTypeMoment.prototype.cast = function(value, data) {
   const { options } = this;
   value = toMoment(value);
 
-  if (options.language) value = value.locale(options.language);
+  if (options.language) value = value.locale(toMomentLocale(options.language));
   if (options.timezone) value = value.tz(options.timezone);
 
   return value;

--- a/lib/plugins/helper/date.js
+++ b/lib/plugins/helper/date.js
@@ -3,16 +3,13 @@
 const moment = require('moment-timezone');
 const { isMoment } = moment;
 
-const isDate = value => {
-  if (typeof value === 'object') {
-    if (value instanceof Date) return !isNaN(value.getTime());
-  }
-  return false;
-};
+const isDate = value =>
+  typeof value === 'object' && value instanceof Date && !isNaN(value.getTime());
 
 function getMoment(date, lang, timezone) {
   if (date == null) date = moment();
   if (!isMoment(date)) date = moment(isDate(date) ? date : new Date(date));
+  lang = toMomentLocale(lang);
 
   if (lang) date = date.locale(lang);
   if (timezone) date = date.tz(timezone);
@@ -68,6 +65,27 @@ function getLanguage(ctx) {
   return ctx.page.lang || ctx.page.language || ctx.config.language;
 }
 
+/**
+ * Convert Hexo language code to Moment locale code.
+ * examples:
+ *   default => en
+ *   zh-CN => zh-cn
+ *
+ * Moment defined locales: https://github.com/moment/moment/tree/master/locale
+ */
+function toMomentLocale(lang) {
+  if (lang === undefined) {
+    return undefined;
+  }
+
+  // moment.locale('') equals moment.locale('en')
+  // moment.locale(null) equals moment.locale('en')
+  if (!lang || lang === 'en' || lang === 'default') {
+    return 'en';
+  }
+  return lang.toLowerCase().replace('_', '-');
+}
+
 exports.date = dateHelper;
 exports.date_xml = toISOString;
 exports.time = timeHelper;
@@ -75,3 +93,4 @@ exports.full_date = fullDateHelper;
 exports.relative_date = relativeDateHelper;
 exports.time_tag = timeTagHelper;
 exports.moment = moment;
+exports.toMomentLocale = toMomentLocale;

--- a/lib/plugins/helper/list_archives.js
+++ b/lib/plugins/helper/list_archives.js
@@ -1,10 +1,12 @@
 'use strict';
 
+const { toMomentLocale } = require('./date');
+
 function listArchivesHelper(options = {}) {
   const { config } = this;
   const archiveDir = config.archive_dir;
   const { timezone } = config;
-  const lang = this.page.lang || this.page.language || config.language;
+  const lang = toMomentLocale(this.page.lang || this.page.language || config.language);
   let { format } = options;
   const type = options.type || 'monthly';
   const { style = 'list', transform, separator = ', ' } = options;

--- a/test/scripts/helpers/date.js
+++ b/test/scripts/helpers/date.js
@@ -224,4 +224,16 @@ describe('date', () => {
     timeTag(Date.now(), 'LLL').should.eql('<time datetime="' + moment().toISOString() + '">' + moment().tz('UTC').format('LLL') + '</time>');
     ctx.config.timezone = '';
   });
+
+  it('toMomentLocale', () => {
+    const toMomentLocale = dateHelper.toMomentLocale;
+
+    (toMomentLocale(undefined) === undefined).should.eql(true);
+    toMomentLocale(null).should.eql('en');
+    toMomentLocale('').should.eql('en');
+    toMomentLocale('en').should.eql('en');
+    toMomentLocale('default').should.eql('en');
+    toMomentLocale('zh-CN').should.eql('zh-cn');
+    toMomentLocale('zh_CN').should.eql('zh-cn');
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Hexo language code is different with `Moment.js`.
If we set language like this,
```yml
# _config.yml
language:
timezone:
```
or
```yml
# _config.yml
language: zh-CN
timezone:
```
then `default` or `zh-CN` will pass to `moment.locale(lang)`.
```js
const lang = this.page.lang || this.page.language || config.language;
...
if (lang) date = date.locale(lang); // lang = 'default' or 'zh-CN'
```
Whenever `.locale (lang)` is called, it causes `moment` to find the locale file repeatedly.
<img width="1229" alt="2019122402" src="https://user-images.githubusercontent.com/51783821/71408248-750def80-2678-11ea-89a4-152cc5785492.png">


This PR adds `toMomentLocale()` to convert lang code, avoid lookup repeatedly with the wrong names.


## How to test

```sh
git clone -b fix-moment-locale https://github.com/dailyrandomphoto/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
