### PR TITLE
fix(toc_helper): escape class name and handle null id

### DIFF
--- a/lib/plugins/helper/toc.js
+++ b/lib/plugins/helper/toc.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { tocObj } = require('hexo-util');
+const { htmlTag, tocObj } = require('hexo-util');
 
 function tocHelper(str, options = {}) {
   options = Object.assign({
@@ -17,7 +17,7 @@ function tocHelper(str, options = {}) {
   const className = options.class;
   const listNumber = options.list_number;
 
-  let result = `<ol class="${className}">`;
+  let result = htmlTag('ol', { class: className });
   const lastNumber = [0, 0, 0, 0, 0, 0];
   let firstLevel = 0;
   let lastLevel = 0;
@@ -25,6 +25,7 @@ function tocHelper(str, options = {}) {
   for (let i = 0, len = data.length; i < len; i++) {
     const el = data[i];
     const { level, id, text } = el;
+    const href = id ? `#${id}` : id;
 
     lastNumber[level - 1]++;
 
@@ -38,7 +39,7 @@ function tocHelper(str, options = {}) {
       }
 
       if (level > lastLevel) {
-        result += `<ol class="${className}-child">`;
+        result += htmlTag('ol', { class: `${className}-child` });
       } else {
         result += '</li>';
       }
@@ -46,11 +47,11 @@ function tocHelper(str, options = {}) {
       firstLevel = level;
     }
 
-    result += `<li class="${className}-item ${className}-level-${level}">`;
-    result += `<a class="${className}-link" href="#${id}">`;
+    result += htmlTag('li', { class: `${className}-item ${className}-level-${level}` });
+    result += htmlTag('a', { class: `${className}-link`, href });
 
     if (listNumber) {
-      result += `<span class="${className}-number">`;
+      result += htmlTag('span', { class: `${className}-number` });
 
       for (let i = firstLevel - 1; i < level; i++) {
         result += `${lastNumber[i]}.`;
@@ -59,7 +60,7 @@ function tocHelper(str, options = {}) {
       result += '</span> ';
     }
 
-    result += `<span class="${className}-text">${text}</span></a>`;
+    result += htmlTag('span', { class: `${className}-text` }, text) + '</a>';
 
     lastLevel = level;
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "hexo-fs": "^2.0.0",
     "hexo-i18n": "^1.0.0",
     "hexo-log": "^1.0.0",
-    "hexo-util": "^1.8.0",
+    "hexo-util": "^1.8.1",
     "js-yaml": "^3.12.0",
     "lodash": "^4.17.11",
     "micromatch": "^4.0.2",

--- a/test/scripts/helpers/toc.js
+++ b/test/scripts/helpers/toc.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { encodeURL, escapeHTML } = require('hexo-util');
+
 describe('toc', () => {
   const toc = require('../../../lib/plugins/helper/toc');
 
@@ -360,5 +362,76 @@ describe('toc', () => {
     ].join('');
 
     toc(html, { min_depth: 2 }).should.eql(expected);
+  });
+
+  it('No id attribute', () => {
+    const className = 'f';
+    const input = [
+      '<h1>foo</h1>',
+      '<h1 id="">bar</h1>'
+    ].join('');
+
+    const expected = [
+      `<ol class="${className}">`,
+      `<li class="${className}-item ${className}-level-1">`,
+      `<a class="${className}-link"><span class="${className}-text">foo</span></a>`,
+      '</li>',
+      `<li class="${className}-item ${className}-level-1">`,
+      `<a class="${className}-link"><span class="${className}-text">bar</span></a>`,
+      '</li></ol>'
+    ].join('');
+
+    toc(input, { list_number: false, class: className }).should.eql(expected);
+  });
+
+  it('non-ASCII id', () => {
+    const className = 'f';
+    const zh = '这是-H1-标题';
+    const zhs = zh.replace(/-/g, ' ');
+    const de = 'Ich-♥-Deutsch';
+    const des = de.replace(/-/g, ' ');
+    const ru = 'Я-люблю-русский';
+    const rus = ru.replace(/-/g, ' ');
+    const input = [
+      `<h1 id="${zh}">${zhs}</h1>`,
+      `<h1 id="${de}">${des}</h1>`,
+      `<h1 id="${ru}">${rus}</h1>`
+    ].join('');
+
+    const expected = [
+      `<ol class="${className}">`,
+      `<li class="${className}-item ${className}-level-1">`,
+      `<a class="${className}-link" href="#${encodeURL(zh)}"><span class="${className}-text">${zhs}</span></a>`,
+      '</li>',
+      `<li class="${className}-item ${className}-level-1">`,
+      `<a class="${className}-link" href="#${encodeURL(de)}"><span class="${className}-text">${des}</span></a>`,
+      '</li>',
+      `<li class="${className}-item ${className}-level-1">`,
+      `<a class="${className}-link" href="#${encodeURL(ru)}"><span class="${className}-text">${rus}</span></a>`,
+      '</li></ol>'
+    ].join('');
+
+    toc(input, { list_number: false, class: className }).should.eql(expected);
+  });
+
+  it('escape unsafe class name', () => {
+    const className = 'f"b';
+    const esClass = escapeHTML(className);
+    const input = '<h1>bar</h1>';
+
+    const expected = [
+      `<ol class="${esClass}">`,
+      `<li class="${esClass}-item ${esClass}-level-1">`,
+      `<a class="${esClass}-link"><span class="${esClass}-text">bar</span></a>`,
+      '</li></ol>'
+    ].join('');
+
+    toc(input, { list_number: false, class: className }).should.eql(expected);
+  });
+
+  it('invalid input', () => {
+    const input = '<h9000>bar</h9000>';
+
+    toc(input).should.eql('');
   });
 });


### PR DESCRIPTION
## What does it do?

- To support headings without `id` attribute, after https://github.com/hexojs/hexo-util/pull/166
  * Instead of `<a href="#null">text</a>`, it becomes `<a>text</a>`
- Use [`htmlTag()`](https://github.com/hexojs/hexo-util#htmltagtag-attrs-text-escape)
  * so that unsafe class name is escaped
  * this also means `href` is percent-encoded (e.g. `#标题` -> `#%E6%A0%87%E9%A2%98`
    * **However**, even if the `href` is not encoded, browser automatically encodes it when you copy the link (at least in Firefox).
  * text in `<a>text</a>` is html-escaped. [`tocObj()`](https://github.com/hexojs/hexo-util#tocobjstr-options) parses only the text inside heading, leaving out the markup.
    ``` js
    tocObj('<h1 id="hello"><b>hello</b></h1>')
    // [ { text: 'hello', id: 'hello', level: 1 } ]
    ```
    - this means even when the text is not escaped (possible to disable), toc helper still can't show the markup, because markup is not passed down to this helper.
- In relation to https://github.com/theme-next/hexo-theme-next/issues/1168, this PR means toc helper still can show toc even when id attribute is missing.


## How to test

```sh
git clone -b toc-null-id https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
