### PR TITLE
refactor(list_archives): Reduce calls to date.format()

### DIFF
--- a/lib/plugins/helper/list_archives.js
+++ b/lib/plugins/helper/list_archives.js
@@ -13,6 +13,10 @@ function listArchivesHelper(options = {}) {
   const showCount = Object.prototype.hasOwnProperty.call(options, 'show_count') ? options.show_count : true;
   const className = options.class || 'archive';
   const order = options.order || -1;
+  const compareFunc = type === 'monthly'
+    ? (yearA, monthA, yearB, monthB) => yearA === yearB && monthA === monthB
+    : (yearA, monthA, yearB, monthB) => yearA === yearB;
+
   let result = '';
 
   if (!format) {
@@ -30,14 +34,14 @@ function listArchivesHelper(options = {}) {
     let date = post.date.clone();
 
     if (timezone) date = date.tz(timezone);
-    if (lang) date = date.locale(lang);
 
     const year = date.year();
     const month = date.month() + 1;
-    const name = date.format(format);
     const lastData = data[length - 1];
 
-    if (!lastData || lastData.name !== name) {
+    if (!lastData || !compareFunc(lastData.year, lastData.month, year, month)) {
+      if (lang) date = date.locale(lang);
+      const name = date.format(format);
       length = data.push({
         name,
         year,

--- a/test/scripts/helpers/list_archives.js
+++ b/test/scripts/helpers/list_archives.js
@@ -93,6 +93,19 @@ describe('list_archives', () => {
     ].join(''));
   });
 
+  it('show_count + style: false', () => {
+    const result = listArchives({
+      style: false,
+      show_count: false
+    });
+
+    result.should.eql([
+      '<a class="archive-link" href="/archives/2014/02/">February 2014</a>',
+      '<a class="archive-link" href="/archives/2013/10/">October 2013</a>',
+      '<a class="archive-link" href="/archives/2013/06/">June 2013</a>'
+    ].join(', '));
+  });
+
   it('order', () => {
     const result = listArchives({
       order: 1
@@ -121,6 +134,21 @@ describe('list_archives', () => {
       '<li class="archive-list-item"><a class="archive-list-link" href="/archives/2013/06/">JUNE 2013</a><span class="archive-list-count">2</span></li>',
       '</ul>'
     ].join(''));
+  });
+
+  it('transform + style: false', () => {
+    const result = listArchives({
+      style: false,
+      transform(str) {
+        return str.toUpperCase();
+      }
+    });
+
+    result.should.eql([
+      '<a class="archive-link" href="/archives/2014/02/">FEBRUARY 2014<span class="archive-count">1</span></a>',
+      '<a class="archive-link" href="/archives/2013/10/">OCTOBER 2013<span class="archive-count">1</span></a>',
+      '<a class="archive-link" href="/archives/2013/06/">JUNE 2013<span class="archive-count">2</span></a>'
+    ].join(', '));
   });
 
   it('separator', () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Continuation of #4007.

`list_archives` will call `date.locale(lang)`, `date.format(format)` a lot of times, especial if set to `relative_link: true`. (fragment_cache was disabled)

This PR change makes `list_archives` call `date.locale(lang)`, `date.format(format)` once per group.

## How to test

```sh
git clone -b improve-list_archives https://github.com/dailyrandomphoto/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
