### PR TITLE
fix(meta_generator): avoid an edge case

### DIFF
--- a/lib/plugins/filter/after_render/meta_generator.js
+++ b/lib/plugins/filter/after_render/meta_generator.js
@@ -3,7 +3,7 @@
 function hexoMetaGeneratorInject(data) {
   const { config } = this;
   if (!config.meta_generator
-    || data.match(/<meta\s+name=['|"]?generator['|"]?/i)) return;
+    || data.match(/<meta([\s]+|[\s]+[^<>]+[\s]+)name=['|"]?generator['|"]?/i)) return;
 
   const hexoGeneratorTag = `<meta name="generator" content="Hexo ${this.version}">`;
 

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -25,13 +25,11 @@ describe('Meta Generator', () => {
   });
 
   it('no duplicate generator tag', () => {
-    const content = '<head><link>'
-      + '<meta name="generator" content="foo"></head>';
     hexo.config.meta_generator = true;
-    const result = metaGenerator(content);
+    const resultType = str => typeof metaGenerator(str);
 
-    const resultType = typeof result;
-    resultType.should.eql('undefined');
+    resultType('<head><link><meta name="generator" content="foo"></head>').should.eql('undefined');
+    resultType('<head><link><meta content="foo" name="generator"></head>').should.eql('undefined');
   });
 
   it('ignore empty head tag', () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Current regex pattern will only matches `<meta name="generator" content="Hexo 4.2.0">` but not`<meta content="Hexo 4.2.0" name="generator">`,

## How to test

```sh
git clone -b meta_generator_fix https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
