### PR TITLE
feat(filter): add after_route_render filter

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -56,13 +56,18 @@ const createLoadThemeRoute = function(generatorResult, locals, ctx) {
 
       if (view) {
         log.debug(`Rendering HTML ${name}: ${magenta(path)}`);
-        return view.render(locals).tap(result => {
-          if (useCache) {
-            routeCache.set(generatorResult, result);
-          }
-        }).tapCatch(err => {
-          log.error({ err }, `Render HTML failed: ${magenta(path)}`);
-        });
+        return view.render(locals)
+          .then(result => ctx.execFilter('after_route_render', result, {
+            context: ctx,
+            args: [locals]
+          }))
+          .tap(result => {
+            if (useCache) {
+              routeCache.set(generatorResult, result);
+            }
+          }).tapCatch(err => {
+            log.error({ err }, `Render HTML failed: ${magenta(path)}`);
+          });
       }
     }
 

--- a/lib/plugins/filter/after_render/index.js
+++ b/lib/plugins/filter/after_render/index.js
@@ -3,6 +3,6 @@
 module.exports = ctx => {
   const { filter } = ctx.extend;
 
-  filter.register('after_render:html', require('./external_link'));
-  filter.register('after_render:html', require('./meta_generator'));
+  filter.register('after_route_render', require('./external_link'));
+  filter.register('after_route_render', require('./meta_generator'));
 };

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -419,15 +419,15 @@ describe('Hexo', () => {
   });
 
   it('_generate() - after_route_render filter', () => {
-    const hook = sinon.spy(result => result.replace('</head>', 'content</head>'));
+    const hook = sinon.spy(result => '1');
     hexo.extend.filter.register('after_route_render', hook);
-    hexo.theme.setView('test.swig', '<head></head>');
+    hexo.theme.setView('test.swig', '0');
     hexo.extend.generator.register('test', () => ({
       path: 'test',
       layout: 'test'
     }));
     return hexo._generate()
-      .then(() => checkStream(route.get('test'), '<head>content</head>'))
+      .then(() => checkStream(route.get('test'), '1'))
       .then(() => hook.called.should.be.true);
   });
 

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -419,15 +419,15 @@ describe('Hexo', () => {
   });
 
   it('_generate() - after_route_render filter', () => {
-    const hook = sinon.spy(result => '1');
+    const hook = sinon.spy(result => result.replace('foo', 'bar'));
     hexo.extend.filter.register('after_route_render', hook);
-    hexo.theme.setView('test.swig', '0');
+    hexo.theme.setView('test.swig', 'foo');
     hexo.extend.generator.register('test', () => ({
       path: 'test',
       layout: 'test'
     }));
     return hexo._generate()
-      .then(() => checkStream(route.get('test'), '1'))
+      .then(() => checkStream(route.get('test'), 'bar'))
       .then(() => hook.called.should.be.true);
   });
 

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -418,6 +418,19 @@ describe('Hexo', () => {
     });
   });
 
+  it('_generate() - after_route_render filter', () => {
+    const hook = sinon.spy(result => result.replace('</head>', 'content</head>'));
+    hexo.extend.filter.register('after_route_render', hook);
+    hexo.theme.setView('test.swig', '<head></head>');
+    hexo.extend.generator.register('test', () => ({
+      path: 'test',
+      layout: 'test'
+    }));
+    return hexo._generate()
+      .then(() => checkStream(route.get('test'), '<head>content</head>'))
+      .then(() => hook.called.should.be.true);
+  });
+
   it('_generate() - return nothing in generator', () => {
     hexo.extend.generator.register('test_nothing', () => {
       //


### PR DESCRIPTION

## What does it do?

#4048 See discussion here, add `after_route_render` implement it.

## How to test

```sh
git clone -b filter https://github.com/jiangtj/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
