### PR TITLE
list_tags: custom class for each element

### DIFF
--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -12,6 +12,11 @@ function listTagsHelper(tags, options) {
   const { style = 'list', transform, separator = ', ', suffix = '' } = options;
   const showCount = Object.prototype.hasOwnProperty.call(options, 'show_count') ? options.show_count : true;
   const className = options.class || 'tag';
+  const classStyle = typeof style === 'string' ? `-${style}` : '';
+  const ulClass = options.class.ul || `${className}${classStyle}`;
+  const liClass = options.class.li || `${className}${classStyle}-item`;
+  const aClass = options.class.a || `${className}${classStyle}-link`;
+  const countClass = options.class.count || `${className}${classStyle}-count`;
   const orderby = options.orderby || 'name';
   const order = options.order || 1;
   let result = '';
@@ -26,17 +31,17 @@ function listTagsHelper(tags, options) {
   if (options.amount) tags = tags.limit(options.amount);
 
   if (style === 'list') {
-    result += `<ul class="${className}-list" itemprop="keywords">`;
+    result += `<ul class="${ulClass}" itemprop="keywords">`;
 
     tags.forEach(tag => {
-      result += `<li class="${className}-list-item">`;
+      result += `<li class="${liClass}">`;
 
-      result += `<a class="${className}-list-link" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
+      result += `<a class="${aClass}" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
       result += transform ? transform(tag.name) : tag.name;
       result += '</a>';
 
       if (showCount) {
-        result += `<span class="${className}-list-count">${tag.length}</span>`;
+        result += `<span class="${countClass}">${tag.length}</span>`;
       }
 
       result += '</li>';
@@ -47,11 +52,11 @@ function listTagsHelper(tags, options) {
     tags.forEach((tag, i) => {
       if (i) result += separator;
 
-      result += `<a class="${className}" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
+      result += `<a class="${aClass}" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
       result += transform ? transform(tag.name) : tag.name;
 
       if (showCount) {
-        result += `<span class="${className}-count">${tag.length}</span>`;
+        result += `<span class="${countClass}">${tag.length}</span>`;
       }
 
       result += '</a>';

--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -47,7 +47,7 @@ function listTagsHelper(tags, options) {
     tags.forEach((tag, i) => {
       if (i) result += separator;
 
-      result += `<a class="${className}-link" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
+      result += `<a class="${className}" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
       result += transform ? transform(tag.name) : tag.name;
 
       if (showCount) {

--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -13,10 +13,18 @@ function listTagsHelper(tags, options) {
   const showCount = Object.prototype.hasOwnProperty.call(options, 'show_count') ? options.show_count : true;
   const className = options.class || 'tag';
   const classStyle = typeof style === 'string' ? `-${style}` : '';
-  const ulClass = options.class.ul || `${className}${classStyle}`;
-  const liClass = options.class.li || `${className}${classStyle}-item`;
-  const aClass = options.class.a || `${className}${classStyle}-link`;
-  const countClass = options.class.count || `${className}${classStyle}-count`;
+  let ulClass, liClass, aClass; let countClass = '';
+  if (typeof options.class !== 'undefined') {
+    ulClass = options.class.ul || `${className}${classStyle}`;
+    liClass = options.class.li || `${className}${classStyle}-item`;
+    aClass = options.class.a || `${className}${classStyle}-link`;
+    countClass = options.class.count || `${className}${classStyle}-count`;
+  } else {
+    ulClass = `${className}${classStyle}`;
+    liClass = `${className}${classStyle}-item`;
+    aClass = `${className}${classStyle}-link`;
+    countClass = `${className}${classStyle}-count`;
+  }
   const orderby = options.orderby || 'name';
   const order = options.order || 1;
   let result = '';

--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -12,9 +12,14 @@ function listTagsHelper(tags, options) {
   const { style = 'list', transform, separator = ', ', suffix = '' } = options;
   const showCount = Object.prototype.hasOwnProperty.call(options, 'show_count') ? options.show_count : true;
   const classStyle = typeof style === 'string' ? `-${style}` : '';
-  let className, ulClass, liClass, aClass; let countClass = '';
+  let className, ulClass, liClass, aClass, countClass;
   if (typeof options.class !== 'undefined') {
-    if (typeof options.class === 'string') { className = options.class; } else { className = 'tag'; }
+    if (typeof options.class === 'string') {
+      className = options.class;
+    } else {
+      className = 'tag';
+    }
+
     ulClass = options.class.ul || `${className}${classStyle}`;
     liClass = options.class.li || `${className}${classStyle}-item`;
     aClass = options.class.a || `${className}${classStyle}-link`;

--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -11,15 +11,16 @@ function listTagsHelper(tags, options) {
 
   const { style = 'list', transform, separator = ', ', suffix = '' } = options;
   const showCount = Object.prototype.hasOwnProperty.call(options, 'show_count') ? options.show_count : true;
-  const className = options.class || 'tag';
   const classStyle = typeof style === 'string' ? `-${style}` : '';
-  let ulClass, liClass, aClass; let countClass = '';
+  let className, ulClass, liClass, aClass; let countClass = '';
   if (typeof options.class !== 'undefined') {
+    if (typeof options.class === 'string') { className = options.class; } else { className = 'tag'; }
     ulClass = options.class.ul || `${className}${classStyle}`;
     liClass = options.class.li || `${className}${classStyle}-item`;
     aClass = options.class.a || `${className}${classStyle}-link`;
     countClass = options.class.count || `${className}${classStyle}-count`;
   } else {
+    className = 'tag';
     ulClass = `${className}${classStyle}`;
     liClass = `${className}${classStyle}-item`;
     aClass = `${className}${classStyle}-link`;

--- a/test/scripts/helpers/list_tags.js
+++ b/test/scripts/helpers/list_tags.js
@@ -104,15 +104,16 @@ describe('list_tags', () => {
       class: {
         ul: 'lorem',
         li: 'ipsum',
-        a: 'tempor'
+        a: 'tempor',
+        count: 'dolor'
       }
     });
 
     result.should.eql([
       '<ul class="lorem" itemprop="keywords">',
-      '<li class="ipsum"><a class="tempor" href="/tags/bar/" rel="tag">bar</a><span class="tag-list-count">1</span></li>',
-      '<li class="ipsum"><a class="tempor" href="/tags/baz/" rel="tag">baz</a><span class="tag-list-count">2</span></li>',
-      '<li class="ipsum"><a class="tempor" href="/tags/foo/" rel="tag">foo</a><span class="tag-list-count">1</span></li>',
+      '<li class="ipsum"><a class="tempor" href="/tags/bar/" rel="tag">bar</a><span class="dolor">1</span></li>',
+      '<li class="ipsum"><a class="tempor" href="/tags/baz/" rel="tag">baz</a><span class="dolor">2</span></li>',
+      '<li class="ipsum"><a class="tempor" href="/tags/foo/" rel="tag">foo</a><span class="dolor">1</span></li>',
       '</ul>'
     ].join(''));
   });

--- a/test/scripts/helpers/list_tags.js
+++ b/test/scripts/helpers/list_tags.js
@@ -99,6 +99,24 @@ describe('list_tags', () => {
     ].join(''));
   });
 
+  it('custom class', () => {
+    const result = listTags({
+      class: {
+        ul: 'lorem',
+        li: 'ipsum',
+        a: 'tempor'
+      }
+    });
+
+    result.should.eql([
+      '<ul class="lorem" itemprop="keywords">',
+      '<li class="ipsum"><a class="tempor" href="/tags/bar/" rel="tag">bar</a><span class="tag-list-count">1</span></li>',
+      '<li class="ipsum"><a class="tempor" href="/tags/baz/" rel="tag">baz</a><span class="tag-list-count">2</span></li>',
+      '<li class="ipsum"><a class="tempor" href="/tags/foo/" rel="tag">foo</a><span class="tag-list-count">1</span></li>',
+      '</ul>'
+    ].join(''));
+  });
+
   it('orderby', () => {
     const result = listTags({
       orderby: 'length'


### PR DESCRIPTION
When the style `list` is not used, don't append `-link` to the class name, it prevents to fully control class name and so css framework to work correctly.

fix https://github.com/hexojs/hexo/issues/4058

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?



## How to test

```sh
git clone -b patch-1 https://github.com/noraj/hexo.git
cd hexo
npm install
npm test
```

Init a new test site:

```
hexo init test
cd test
```

Replace `themes/landscape/layout/_widget/tag.ejs` with:

```ejs
<% if (site.tags.length){ %>
  <div class="widget-wrap">
    <h3 class="widget-title"><%= __('tags') %></h3>
    <div class="widget">
      <%- list_tags(site.tags, {class: 'classtest', style: false, separator: ' + '}) %>
      <hr>
      <%- list_tags(site.tags, {class: 'classtest', style: 'list'}) %>
      <hr>
      <%- list_tags(site.tags, {class: {ul: 'ululul', li: 'lilili', a: 'aaa', count: 'ccc'}, style: false, separator: ' + '}) %>
      <hr>
      <%- list_tags(site.tags, {class: {ul: 'ululul', li: 'lilili', a: 'aaa', count: 'ccc'}, style: 'list'}) %>
    </div>
  </div>
<% } %>
```


## Screenshots



## Pull request tasks

- [ ] Modify test cases for the changes.
- [ ] Passed the CI test.
- [x] Add documentation.
