### PR TITLE
test(load-database): fix EPERM error in windows

### DIFF
--- a/test/scripts/hexo/load_database.js
+++ b/test/scripts/hexo/load_database.js
@@ -57,8 +57,20 @@ describe('Load database', () => {
 
     await unlink(dbPath);
   });
+});
+
+// #3975 workaround for Windows
+// Clean-up is not necessary (unlike the above tests),
+// because the db file is already removed if invalid
+describe('Load database - load failed', () => {
+  const Hexo = require('../../../lib/hexo');
+  const hexo = new Hexo(join(__dirname), {silent: true});
+  const loadDatabase = require('../../../lib/hexo/load_database');
+  const dbPath = hexo.database.options.path;
 
   it('database load failed', async () => {
+    hexo._dbLoaded = false;
+
     await writeFile(dbPath, '{1423432: 324');
     await loadDatabase(hexo);
     hexo._dbLoaded.should.eql(false);

--- a/test/scripts/theme_processors/source.js
+++ b/test/scripts/theme_processors/source.js
@@ -27,7 +27,7 @@ describe('source', () => {
       mkdirs(themeDir),
       writeFile(hexo.config_path, 'theme: test')
     ]);
-    hexo.init();
+    await hexo.init();
   });
 
   after(() => rmdir(hexo.base_dir));


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Continuation of https://github.com/hexojs/hexo/pull/3975

Add workarounds for more reliable unit testing on Windows in CI env.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
