### PR TITLE
ci(travis): remove Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - windows
 
 language: node_js
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,10 +8,10 @@ image:
 # Test against these versions of Node.js.
 environment:
   matrix:
-    - nodejs_version: "8"
-    - nodejs_version: "10"
-    - nodejs_version: "12"
     - nodejs_version: "13"
+    - nodejs_version: "12"
+    - nodejs_version: "10"
+    - nodejs_version: "8"
     
 matrix:
   fast_finish: true


### PR DESCRIPTION
##  What does it do?
The workarounds #3975 #4069 still don't work reliably in Travis' Windows.
I also reverse the order of Node version in Appveyor, to prioritize newer Node (Appveyor starts the tests sequentially). This is to avoid the issue experienced in https://github.com/hexojs/hexo-fs/pull/50.


## How to test

```sh
git clone -b travis-disable-windows https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
