### PR TITLE
chore(deps): bump warehouse from 3.0.1 to 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "text-table": "^0.2.0",
     "tildify": "^2.0.0",
     "titlecase": "^1.1.2",
-    "warehouse": "^3.0.1"
+    "warehouse": "^3.0.2"
   },
   "devDependencies": {
     "@easyops/git-exec-and-restage": "^1.0.4",


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Include performance fixes in warehouse@[3.0.2](https://github.com/hexojs/warehouse/releases/tag/3.0.2)

This is necessary to force CI to update the dependency.


## How to test

```sh
git clone -b warehouse-3.0.2 https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
