### PR TITLE
perf(meta_generator.js): Do not check if meta_generator has been injected before.

### DIFF
--- a/lib/plugins/filter/after_render/meta_generator.js
+++ b/lib/plugins/filter/after_render/meta_generator.js
@@ -1,13 +1,16 @@
 'use strict';
 
+let hexoGeneratorTag;
 function hexoMetaGeneratorInject(data) {
   const { config } = this;
-  if (!config.meta_generator
-    || data.match(/<meta([\s]+|[\s]+[^<>]+[\s]+)name=['|"]?generator['|"]?/i)) return;
+  if (!config.meta_generator) {
+    this.extend.filter.unregister('after_route_render', hexoMetaGeneratorInject);
+    return;
+  }
 
-  const hexoGeneratorTag = `<meta name="generator" content="Hexo ${this.version}">`;
+  hexoGeneratorTag = hexoGeneratorTag || `<meta name="generator" content="Hexo ${this.version}"></head>`;
 
-  return data.replace(/<head>(?!<\/head>).+?<\/head>/s, str => str.replace('</head>', `${hexoGeneratorTag}</head>`));
+  return data.replace('</head>', hexoGeneratorTag);
 }
 
 module.exports = hexoMetaGeneratorInject;

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -24,7 +24,7 @@ describe('Meta Generator', () => {
     resultType.should.eql('undefined');
   });
 
-  it('no duplicate generator tag', () => {
+  it.skip('no duplicate generator tag', () => {
     hexo.config.meta_generator = true;
     const resultType = str => typeof metaGenerator(str);
 
@@ -32,7 +32,7 @@ describe('Meta Generator', () => {
     resultType('<head><link><meta content="foo" name="generator"></head>').should.eql('undefined');
   });
 
-  it('ignore empty head tag', () => {
+  it.skip('ignore empty head tag', () => {
     const content = '<head></head><head><link></head><head></head>';
     hexo.config.meta_generator = true;
     const result = metaGenerator(content);
@@ -45,7 +45,7 @@ describe('Meta Generator', () => {
     result.should.eql(expected);
   });
 
-  it('apply to first non-empty head tag only', () => {
+  it.skip('apply to first non-empty head tag only', () => {
     const content = '<head></head><head><link></head><head><link></head>';
     hexo.config.meta_generator = true;
     const result = metaGenerator(content);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fix #4056 . Related #4070, #3129, #3315, #4051, #4048.

- Change 1:
```diff
-  if (!config.meta_generator
-    || data.match(/<meta([\s]+|[\s]+[^<>]+[\s]+)name=['|"]?generator['|"]?/i))
+  if (!config.meta_generator) {
```
`meta_generator.js` was introduced in #3129.
**Why do we need to check if meta_generator has been injected before?**
Because while generating an HTML, the `after_render:html` filter will be executed many times at rendering .md file, partial files, so generator meta tag will be injected multiple times. (See #4048.)

Another filter, `after_route_render`, was introduced in #4051, which ensures that the meta_generator is executed once per HTML. Therefore, this check is no longer needed, and performance is improved without it.


**How about if `meta_generator()` helper was used?**
Set `meta_generator: false` in `_config.yml`.

- Change 2:
```diff
-  return data.replace(/<head>(?!<\/head>).+?<\/head>/s, str => str.replace('</head>', `${hexoGeneratorTag}</head>`));
+  return data.replace('</head>', hexoGeneratorTag);
```
The previous regex was introduced in #3697 which [ignores empty <head> tags](https://github.com/hexojs/hexo/pull/3315). 
The `empty <head> tags` appears because `cheerio` and `after_render:html` filter are used.
The `after_render:html` filter makes rendered results of partial files processed by `meta_generator.js`, and when a third-party plugin uses cheerio 1.0.0-rc.1+, `<html><head><body>` are automatically added to the rendered results of partials.
```html
<html><head></head><body>rendered results of partial file</body></html>
```

As the use of `after_route_render` and removal of `cheerio`, `empty <head> tags` no longer need to be considered.

Commit history of [`meta_generator.js`](https://github.com/hexojs/hexo/blob/master/lib/plugins/filter/after_render/meta_generator.js): [part 1](https://github.com/hexojs/hexo/commits/master/lib/plugins/filter/meta_generator.js) [part 2](https://github.com/hexojs/hexo/commits/master/lib/plugins/filter/after_render/meta_generator.js)


## How to test

```sh
git clone -b perf-meta_generator-filter https://github.com/dailyrandomphoto/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
