### PR TITLE
feat(load_config): support theme_dir in node_modules

### DIFF
--- a/lib/hexo/load_config.js
+++ b/lib/hexo/load_config.js
@@ -4,64 +4,60 @@ const { sep, resolve, join, parse } = require('path');
 const tildify = require('tildify');
 const Theme = require('../theme');
 const Source = require('./source');
-const { exists, readdir, existsSync } = require('hexo-fs');
+const { exists, readdir } = require('hexo-fs');
 const { magenta } = require('chalk');
 const { deepMerge } = require('hexo-util');
 
-module.exports = ctx => {
+module.exports = async ctx => {
   if (!ctx.env.init) return;
 
   const baseDir = ctx.base_dir;
   let configPath = ctx.config_path;
 
-  return exists(configPath).then(exist => {
-    return exist ? configPath : findConfigPath(configPath);
-  }).then(path => {
-    if (!path) return;
+  const path = await exists(configPath) ? configPath : await findConfigPath(configPath);
+  if (!path) return;
+  configPath = path;
 
-    configPath = path;
-    return ctx.render.render({path});
-  }).then(config => {
-    if (!config || typeof config !== 'object') return;
+  let config = await ctx.render.render({ path });
+  if (!config || typeof config !== 'object') return;
 
-    ctx.log.debug('Config loaded: %s', magenta(tildify(configPath)));
+  ctx.log.debug('Config loaded: %s', magenta(tildify(configPath)));
 
-    ctx.config = deepMerge(ctx.config, config);
-    config = ctx.config;
+  ctx.config = deepMerge(ctx.config, config);
+  config = ctx.config;
 
-    ctx.config_path = configPath;
+  ctx.config_path = configPath;
 
-    config.root = config.root.replace(/\/*$/, '/');
-    config.url = config.url.replace(/\/+$/, '');
+  config.root = config.root.replace(/\/*$/, '/');
+  config.url = config.url.replace(/\/+$/, '');
 
-    ctx.public_dir = resolve(baseDir, config.public_dir) + sep;
-    ctx.source_dir = resolve(baseDir, config.source_dir) + sep;
-    ctx.source = new Source(ctx);
+  ctx.public_dir = resolve(baseDir, config.public_dir) + sep;
+  ctx.source_dir = resolve(baseDir, config.source_dir) + sep;
+  ctx.source = new Source(ctx);
 
-    if (!config.theme) return;
+  if (!config.theme) return;
 
-    const theme = config.theme.toString();
-    config.theme = theme;
+  const theme = config.theme.toString();
+  config.theme = theme;
 
-    const themeDirFromThemes = join(baseDir, 'themes', theme) + sep; // base_dir/themes/[config.theme]/
-    const themeDirFromNodeModules = join(ctx.plugin_dir, 'hexo-theme-' + theme) + sep; // base_dir/node_modules/hexo-theme-[config.theme]/
+  const themeDirFromThemes = join(baseDir, 'themes', theme) + sep; // base_dir/themes/[config.theme]/
+  const themeDirFromNodeModules = join(ctx.plugin_dir, 'hexo-theme-' + theme) + sep; // base_dir/node_modules/hexo-theme-[config.theme]/
 
-    // themeDirFromThemes has higher priority than themeDirFromNodeModules
-    if (existsSync(themeDirFromThemes)) {
-      ctx.theme_dir = themeDirFromThemes;
-    } else if (existsSync(themeDirFromNodeModules)) {
-      ctx.theme_dir = themeDirFromNodeModules;
-    }
-    ctx.theme_script_dir = join(ctx.theme_dir, 'scripts') + sep;
-    ctx.theme = new Theme(ctx);
-  });
+  // themeDirFromThemes has higher priority than themeDirFromNodeModules
+  if (await exists(themeDirFromThemes)) {
+    ctx.theme_dir = themeDirFromThemes;
+  } else if (await exists(themeDirFromNodeModules)) {
+    ctx.theme_dir = themeDirFromNodeModules;
+  }
+  ctx.theme_script_dir = join(ctx.theme_dir, 'scripts') + sep;
+  ctx.theme = new Theme(ctx);
+
 };
 
-function findConfigPath(path) {
+async function findConfigPath(path) {
   const { dir, name } = parse(path);
 
-  return readdir(dir).then(files => {
-    const item = files.find(item => item.startsWith(name));
-    if (item != null) return join(dir, item);
-  });
+  const files = await readdir(dir);
+  const item = files.find(item => item.startsWith(name));
+  if (item != null) return join(dir, item);
 }

--- a/lib/hexo/load_config.js
+++ b/lib/hexo/load_config.js
@@ -4,7 +4,7 @@ const { sep, resolve, join, parse } = require('path');
 const tildify = require('tildify');
 const Theme = require('../theme');
 const Source = require('./source');
-const { exists, readdir } = require('hexo-fs');
+const { exists, readdir, existsSync } = require('hexo-fs');
 const { magenta } = require('chalk');
 const { deepMerge } = require('hexo-util');
 
@@ -40,8 +40,18 @@ module.exports = ctx => {
 
     if (!config.theme) return;
 
-    config.theme = config.theme.toString();
-    ctx.theme_dir = join(baseDir, 'themes', config.theme) + sep;
+    const theme = config.theme.toString();
+    config.theme = theme;
+
+    const themeDirFromThemes = join(baseDir, 'themes', theme) + sep; // base_dir/themes/[config.theme]/
+    const themeDirFromNodeModules = join(ctx.plugin_dir, 'hexo-theme-' + theme) + sep; // base_dir/node_modules/hexo-theme-[config.theme]/
+
+    // themeDirFromThemes has higher priority than themeDirFromNodeModules
+    if (existsSync(themeDirFromThemes)) {
+      ctx.theme_dir = themeDirFromThemes;
+    } else if (existsSync(themeDirFromNodeModules)) {
+      ctx.theme_dir = themeDirFromNodeModules;
+    }
     ctx.theme_script_dir = join(ctx.theme_dir, 'scripts') + sep;
     ctx.theme = new Theme(ctx);
   });

--- a/test/scripts/hexo/load_config.js
+++ b/test/scripts/hexo/load_config.js
@@ -5,7 +5,7 @@ const fs = require('hexo-fs');
 
 describe('Load config', () => {
   const Hexo = require('../../../lib/hexo');
-  const hexo = new Hexo(pathFn.join(__dirname, 'config_test'), {silent: true});
+  const hexo = new Hexo(pathFn.join(__dirname, 'config_test'), { silent: true });
   const loadConfig = require('../../../lib/hexo/load_config');
   const defaultConfig = require('../../../lib/hexo/default_config');
 
@@ -92,12 +92,39 @@ describe('Load config', () => {
     hexo.source_dir.should.eql(pathFn.resolve(hexo.base_dir, 'bar') + pathFn.sep);
   }).finally(() => fs.unlink(hexo.config_path)));
 
-  it('custom theme', () => fs.writeFile(hexo.config_path, 'theme: test').then(() => loadConfig(hexo)).then(() => {
-    hexo.config.theme.should.eql('test');
-    hexo.theme_dir.should.eql(pathFn.join(hexo.base_dir, 'themes', 'test') + pathFn.sep);
-    hexo.theme_script_dir.should.eql(pathFn.join(hexo.theme_dir, 'scripts') + pathFn.sep);
-    hexo.theme.base.should.eql(hexo.theme_dir);
-  }).finally(() => fs.unlink(hexo.config_path)));
+  it('custom theme - default theme_dir', () => fs.writeFile(hexo.config_path, 'theme: test')
+    .then(() => loadConfig(hexo)).then(() => {
+      hexo.config.theme.should.eql('test');
+      hexo.theme_dir.should.eql(pathFn.join(hexo.base_dir, 'themes', 'landscape') + pathFn.sep);
+      hexo.theme_script_dir.should.eql(pathFn.join(hexo.theme_dir, 'scripts') + pathFn.sep);
+      hexo.theme.base.should.eql(hexo.theme_dir);
+    }).finally(() => fs.unlink(hexo.config_path)));
+
+  it('custom theme - base_dir/themes/[theme]', () => fs.writeFile(hexo.config_path, 'theme: test')
+    .then(() => {
+      fs.mkdirs(pathFn.join(hexo.base_dir, 'themes', 'test'));
+    }).then(() => loadConfig(hexo)).then(() => {
+      hexo.config.theme.should.eql('test');
+      hexo.theme_dir.should.eql(pathFn.join(hexo.base_dir, 'themes', 'test') + pathFn.sep);
+      hexo.theme_script_dir.should.eql(pathFn.join(hexo.theme_dir, 'scripts') + pathFn.sep);
+      hexo.theme.base.should.eql(hexo.theme_dir);
+    }).finally(() => {
+      fs.rmdir(pathFn.join(hexo.base_dir, 'themes', 'test'));
+      fs.unlink(hexo.config_path);
+    }));
+
+  it('custom theme - base_dir/node_modules/hexo-theme-[theme]', () => fs.writeFile(hexo.config_path, 'theme: test')
+    .then(() => {
+      fs.mkdirs(pathFn.join(hexo.plugin_dir, 'hexo-theme-test'));
+    }).then(() => loadConfig(hexo)).then(() => {
+      hexo.config.theme.should.eql('test');
+      hexo.theme_dir.should.eql(pathFn.join(hexo.plugin_dir, 'hexo-theme-test') + pathFn.sep);
+      hexo.theme_script_dir.should.eql(pathFn.join(hexo.theme_dir, 'scripts') + pathFn.sep);
+      hexo.theme.base.should.eql(hexo.theme_dir);
+    }).finally(() => {
+      fs.rmdir(pathFn.join(hexo.plugin_dir, 'hexo-theme-test'));
+      fs.unlink(hexo.config_path);
+    }));
 
   it('merge config', () => {
     const content = [


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The part of #3890

> Hexo will read themes/[name] directory first, then search hexo-theme-[name] directory under node_modules. It means the theme under themes directory should have higher priority. In this way no extra theme_from_npm: true configuration is needed.

## How to test

```sh
git clone -b theme_dir_load https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
