### PR TITLE
feat(load_theme_config): support alternate theme config

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -231,6 +231,7 @@ class Hexo {
     return Promise.each([
       'update_package', // Update package.json
       'load_config', // Load config
+      'load_theme_config', // Load alternate theme config
       'load_plugins' // Load external plugins & scripts
     ], name => require(`./${name}`)(this)).then(() => this.execFilter('after_init', null, {context: this})).then(() => {
       // Ready to go!
@@ -357,6 +358,7 @@ class Hexo {
     const ctx = { config: { url: this.config.url } };
     const localsObj = this.locals.toObject();
 
+    // config.theme_config has "_config.[theme].yml" merged in load_theme_config.js
     if (config.theme_config) {
       theme.config = deepMerge(theme.config, config.theme_config);
     }

--- a/lib/hexo/load_theme_config.js
+++ b/lib/hexo/load_theme_config.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const { join, parse } = require('path');
+const tildify = require('tildify');
+const { exists, readdir } = require('hexo-fs');
+const { magenta } = require('chalk');
+const { deepMerge } = require('hexo-util');
+
+module.exports = ctx => {
+  if (!ctx.env.init) return;
+  if (!ctx.config.theme) return;
+
+  let configPath = join(ctx.base_dir, `_config.${String(ctx.config.theme)}.yml`);
+
+  return exists(configPath).then(exist => {
+    return exist ? configPath : findConfigPath(configPath);
+  }).then(path => {
+    if (!path) return;
+
+    configPath = path;
+    return ctx.render.render({ path });
+  }).then(config => {
+    if (!config || typeof config !== 'object') return;
+
+    ctx.log.debug('Second Theme Config loaded: %s', magenta(tildify(configPath)));
+
+    // ctx.config.theme_config should have highest piority
+    // If ctx.config.theme_config exists, then merge it with _config.[theme].yml
+    // If ctx.config.theme_config doesn't exist, set it to _config.[theme].yml
+    ctx.config.theme_config = ctx.config.theme_config
+      ? deepMerge(config, ctx.config.theme_config) : config;
+  });
+};
+
+function findConfigPath(path) {
+  const { dir, name } = parse(path);
+
+  return readdir(dir).then(files => {
+    const item = files.find(item => item.startsWith(name));
+    if (item != null) return join(dir, item);
+  });
+}

--- a/test/scripts/hexo/index.js
+++ b/test/scripts/hexo/index.js
@@ -5,6 +5,7 @@ describe('Core', () => {
   require('./load_config');
   require('./load_database');
   require('./load_plugins');
+  require('./load_theme_config');
   require('./locals');
   require('./multi_config_path');
   require('./post');

--- a/test/scripts/hexo/load_theme_config.js
+++ b/test/scripts/hexo/load_theme_config.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const { join } = require('path');
+const { mkdirs, unlink, writeFile, rmdir } = require('hexo-fs');
+
+describe('Load alternate theme config', () => {
+  const Hexo = require('../../../lib/hexo');
+  const hexo = new Hexo(join(__dirname, 'config_test'), {silent: true});
+  const loadThemeConfig = require('../../../lib/hexo/load_theme_config');
+
+  hexo.env.init = true;
+
+  before(() => mkdirs(hexo.base_dir).then(() => hexo.init()));
+
+  after(() => rmdir(hexo.base_dir));
+
+  beforeEach(() => {
+    hexo.config.theme_config = { foo: { bar: 'ahhhhhh' } };
+    hexo.config.theme = 'test_theme';
+  });
+
+  it('_config.[theme].yml does not exist', () => loadThemeConfig(hexo).then(() => {
+    hexo.config.theme_config = {};
+  }));
+
+  it('_config.[theme].yml exists', () => {
+    const configPath = join(hexo.base_dir, '_config.test_theme.yml');
+
+    return writeFile(configPath, 'bar: 1').then(() => loadThemeConfig(hexo)).then(() => {
+      hexo.config.theme_config.bar.should.eql(1);
+    }).finally(() => unlink(configPath));
+  });
+
+  it('_config.[theme].json exists', () => {
+    const configPath = join(hexo.base_dir, '_config.test_theme.json');
+
+    return writeFile(configPath, '{"baz": 3}').then(() => loadThemeConfig(hexo)).then(() => {
+      hexo.config.theme_config.baz.should.eql(3);
+    }).finally(() => unlink(configPath));
+  });
+
+  it('_config.[theme].txt exists', () => {
+    const configPath = join(hexo.base_dir, '_config.test_theme.txt');
+
+    return writeFile(configPath, 'qux: 1').then(() => loadThemeConfig(hexo)).then(() => {
+      should.not.exist(hexo.config.theme_config.qux);
+    }).finally(() => unlink(configPath));
+  });
+
+  it('merge config', () => {
+    const configPath = join(hexo.base_dir, '_config.test_theme.yml');
+
+    const content = [
+      'foo:',
+      '  bar: yoooo',
+      '  baz: true'
+    ].join('\n');
+
+    return writeFile(configPath, content).then(() => loadThemeConfig(hexo)).then(() => {
+      hexo.config.theme_config.foo.baz.should.eql(true);
+      hexo.config.theme_config.foo.bar.should.eql('ahhhhhh');
+      hexo.config.theme_config.foo.bar.should.not.eql('yoooo');
+    }).finally(() => unlink(configPath));
+  });
+});


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The part of #3890

> `theme_config` in `_config.yml` looks good, but it is better to have a separate theme config. We could introduce `_config.[name].yml`. Currently, `theme_config` has higher priority than `_config.yml` under theme directories. After bring up `_config.[name].yml`, I suggest the `theme_config in _config.yml > _config.[name].yml > _config.yml under theme directories` which will retain highest priority for `theme_config`.

## How to test

```sh
git clone -b theme-config-dedicated https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
