### PR TITLE
perf(open_graph): avoid using htmlTag() and enhance cache

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -2,7 +2,7 @@
 
 const { parse, resolve } = require('url');
 const { isMoment, isDate } = require('moment');
-const { encodeURL, prettyUrls, htmlTag, stripHTML, escapeHTML } = require('hexo-util');
+const { encodeURL, prettyUrls, htmlTag, stripHTML, escapeHTML, Cache } = require('hexo-util');
 
 const localeMap = {
   'en': 'en_US',
@@ -21,6 +21,18 @@ const localeMap = {
   'vi': 'vi_VN'
 };
 const localeRegex = new RegExp(Object.keys(localeMap).join('|'), 'i');
+const localeCache = new Cache();
+
+const localeToTerritory = str => localeCache.apply(str, () => {
+  if (str.length === 2) return str.replace(localeRegex, str => localeMap[str]);
+
+  if (str.length === 5) {
+    const territory = str.slice(-2);
+    const territoryRegex = new RegExp(territory.concat('$'));
+
+    return str.replace('-', '_').replace(territoryRegex, territory.toUpperCase());
+  }
+});
 
 const meta = (name, content, escape) => {
   if (escape !== false && typeof content === 'string') {
@@ -54,7 +66,7 @@ function openGraphHelper(options = {}) {
   const twitterCard = options.twitter_card || 'summary';
   const date = options.date !== false ? options.date || page.date : false;
   const updated = options.updated !== false ? options.updated || page.updated : false;
-  let language = options.language || page.lang || page.language || config.language;
+  const language = options.language || page.lang || page.language || config.language;
   const author = options.author || config.author;
 
   if (!Array.isArray(images)) images = [images];
@@ -99,17 +111,7 @@ function openGraphHelper(options = {}) {
   }
 
   if (language) {
-    if (language.length === 2) {
-      language = language.replace(localeRegex, str => localeMap[str]);
-      result += og('og:locale', language, false);
-    } else if (language.length === 5) {
-      const territory = language.slice(-2);
-      const territoryRegex = new RegExp(territory.concat('$'));
-
-      language = language.replace('-', '_').replace(territoryRegex, territory.toUpperCase());
-
-      result += og('og:locale', language, false);
-    }
+    result += og('og:locale', localeToTerritory(language), false);
   }
 
   images = images.map(path => {
@@ -170,7 +172,7 @@ function openGraphHelper(options = {}) {
   }
 
   if (options.google_plus) {
-    result += `${htmlTag('link', {rel: 'publisher', href: options.google_plus})}\n`;
+    result += `${htmlTag('link', { rel: 'publisher', href: options.google_plus })}\n`;
   }
 
   if (options.fb_admins) {

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -20,17 +20,19 @@ const localeMap = {
   'tr': 'tr_TR',
   'vi': 'vi_VN'
 };
-const localeRegex = new RegExp(Object.keys(localeMap).join('|'), 'i');
 const localeCache = new Cache();
-
 const localeToTerritory = str => localeCache.apply(str, () => {
-  if (str.length === 2) return str.replace(localeRegex, str => localeMap[str]);
+  if (str.length === 2 && localeMap[str]) return localeMap[str];
 
   if (str.length === 5) {
-    const territory = str.slice(-2);
-    const territoryRegex = new RegExp(territory.concat('$'));
+    let territory = [];
+    if (str.includes('-')) {
+      territory = str.split('-');
+    } else {
+      territory = str.split('_');
+    }
 
-    return str.replace('-', '_').replace(territoryRegex, territory.toUpperCase());
+    if (territory.length === 2) return territory[0].toLowerCase() + '_' + territory[1].toUpperCase();
   }
 });
 

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -2,7 +2,7 @@
 
 const { parse, resolve } = require('url');
 const { isMoment, isDate } = require('moment');
-const { prettyUrls, htmlTag, stripHTML, escapeHTML } = require('hexo-util');
+const { encodeURL, prettyUrls, htmlTag, stripHTML, escapeHTML } = require('hexo-util');
 
 const localeMap = {
   'en': 'en_US',
@@ -22,19 +22,23 @@ const localeMap = {
 };
 const localeRegex = new RegExp(Object.keys(localeMap).join('|'), 'i');
 
-function meta(name, content) {
-  return `${htmlTag('meta', {
-    name,
-    content
-  })}\n`;
-}
+const meta = (name, content, escape) => {
+  if (escape !== false && typeof content === 'string') {
+    content = escapeHTML(content);
+  }
 
-function og(name, content) {
-  return `${htmlTag('meta', {
-    property: name,
-    content
-  })}\n`;
-}
+  if (content) return `<meta name="${name}" content="${content}">\n`;
+  return `<meta name="${name}">\n`;
+};
+
+const og = (name, content, escape) => {
+  if (escape !== false && typeof content === 'string') {
+    content = escapeHTML(content);
+  }
+
+  if (content) return `<meta property="${name}" content="${content}">\n`;
+  return `<meta property="${name}">\n`;
+};
 
 function openGraphHelper(options = {}) {
 
@@ -83,24 +87,28 @@ function openGraphHelper(options = {}) {
   result += og('og:type', type);
   result += og('og:title', title);
 
-  result += og('og:url', url);
+  if (url) {
+    result += og('og:url', encodeURL(url), false);
+  } else {
+    result += og('og:url');
+  }
 
   result += og('og:site_name', siteName);
   if (description) {
-    result += og('og:description', description);
+    result += og('og:description', description, false);
   }
 
   if (language) {
     if (language.length === 2) {
       language = language.replace(localeRegex, str => localeMap[str]);
-      result += og('og:locale', language);
+      result += og('og:locale', language, false);
     } else if (language.length === 5) {
       const territory = language.slice(-2);
       const territoryRegex = new RegExp(territory.concat('$'));
 
       language = language.replace('-', '_').replace(territoryRegex, territory.toUpperCase());
 
-      result += og('og:locale', language);
+      result += og('og:locale', language, false);
     }
   }
 
@@ -115,7 +123,7 @@ function openGraphHelper(options = {}) {
   });
 
   images.forEach(path => {
-    result += og('og:image', path);
+    result += og('og:image', path, false);
   });
 
   if (date) {
@@ -147,7 +155,7 @@ function openGraphHelper(options = {}) {
   result += meta('twitter:card', twitterCard);
 
   if (images.length) {
-    result += meta('twitter:image', images[0]);
+    result += meta('twitter:image', images[0], false);
   }
 
   if (options.twitter_id) {
@@ -158,7 +166,7 @@ function openGraphHelper(options = {}) {
   }
 
   if (options.twitter_site) {
-    result += meta('twitter:site', options.twitter_site);
+    result += meta('twitter:site', options.twitter_site, false);
   }
 
   if (options.google_plus) {

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -714,14 +714,25 @@ describe('open_graph', () => {
 
   it('og:locale - language is not in lang-TERRITORY format', () => {
     hexo.config.language = 'en';
-
-    const result = openGraph.call({
+    openGraph.call({
       page: {},
       config: hexo.config,
       is_post: isPost
-    });
+    }).should.contain(meta({property: 'og:locale', content: 'en_US'}));
 
-    result.should.contain(meta({property: 'og:locale', content: 'en_US'}));
+    hexo.config.language = 'Fr_fr';
+    openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    }).should.contain(meta({property: 'og:locale', content: 'fr_FR'}));
+
+    hexo.config.language = 'zh-CN';
+    openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    }).should.contain(meta({property: 'og:locale', content: 'zh_CN'}));
   });
 
   it('article:author - options.author', () => {


### PR DESCRIPTION
## What does it do?

In 8bd3439421e2b50799d13e1ba3f804d599c94962 @curbengh utilize `open_graph()` helper with new `htmlTag()` util.

However, [`htmlTag()`](https://github.com/hexojs/hexo-util/blob/7e084de7244a8f11ff8571fae8a5782936ea65b0/lib/html_tag.js) from hexo-util is a little over complicated, thus I bring up this PR with avoiding usage of `htmlTag()`. 

## How to test

```sh
git clone -b optimize-opengraph-helper https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

Benchmark Result after https://github.com/hexojs/hexo/pull/4125/commits/d13ab9a3c816b76ce092f83cd54ccbd96164fe68:

| | NodeJS 8 | NodeJS 10 | NodeJS 12 | NodeJS 13 |
|:---:|:---:|:---:|:---:|:---:|
| Current Master Branch | 17.87 | 14.83 | 15.91 | 14.77 |
| This PR | **16.18** | **14.32** | **15.23** | **14.6** |

There is about 3% - 5% performance improvements.

---

Benchmark Result after https://github.com/hexojs/hexo/pull/4125/commits/095d28e0a5012ddd17bc67ca8970ccbc1ff12809

| | NodeJS 8 | NodeJS 10 | NodeJS 12 | NodeJS 13 |
|:---:|:---:|:---:|:---:|:---:|
| Current Master Branch | 17.87 | 14.83 | 15.91 | 14.77 |
| This PR | **16.38** | **15.12** | **14.32** | **14.52** |

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
