### PR TITLE
perf(external_link): cache config

### DIFF
--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -1,23 +1,33 @@
 'use strict';
 
 const { isExternalLink } = require('hexo-util');
+let EXTERNAL_LINK_POST_CONFIG;
+let EXTERNAL_LINK_POST_ENABLED = true;
 
 function externalLinkFilter(data) {
+  if (!EXTERNAL_LINK_POST_ENABLED) return;
+
   const { config } = this;
 
-  if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
-    || config.external_link === true) {
-    config.external_link = Object.assign({
-      enable: true,
-      field: 'site',
-      exclude: []
-    }, config.external_link);
+  if (typeof EXTERNAL_LINK_POST_CONFIG === 'undefined') {
+    if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
+      || config.external_link === true) {
+      EXTERNAL_LINK_POST_CONFIG = Object.assign({
+        enable: true,
+        field: 'site',
+        exclude: []
+      }, config.external_link);
+    }
   }
-  if (config.external_link === false || config.external_link.enable === false
-    || config.external_link.field !== 'post') return;
+
+  if (config.external_link === false || EXTERNAL_LINK_POST_CONFIG.enable === false
+    || EXTERNAL_LINK_POST_CONFIG.field !== 'post') {
+    EXTERNAL_LINK_POST_ENABLED = false;
+    return;
+  }
 
   data.content = data.content.replace(/<a([\s]+|[\s]+[^<>]+[\s]+)href=["']([^<>"']+)["'][^<>]*>/gi, (str, _, href) => {
-    if (/target=/gi.test(str) || !isExternalLink(href, config.url, config.external_link.exclude)) return str;
+    if (/target=/gi.test(str) || !isExternalLink(href, config.url, EXTERNAL_LINK_POST_CONFIG.exclude)) return str;
 
     if (/rel=/gi.test(str)) {
       str = str.replace(/rel="(.*?)"/gi, (relStr, rel) => {

--- a/lib/plugins/filter/after_render/external_link.js
+++ b/lib/plugins/filter/after_render/external_link.js
@@ -1,23 +1,33 @@
 'use strict';
 
 const { isExternalLink } = require('hexo-util');
+let EXTERNAL_LINK_SITE_CONFIG;
+let EXTERNAL_LINK_SITE_ENABLED = true;
 
 function externalLinkFilter(data) {
+  if (!EXTERNAL_LINK_SITE_ENABLED) return;
+
   const { config } = this;
 
-  if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
-    || config.external_link === true) {
-    config.external_link = Object.assign({
-      enable: true,
-      field: 'site',
-      exclude: []
-    }, config.external_link);
+  if (typeof EXTERNAL_LINK_SITE_CONFIG === 'undefined') {
+    if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
+      || config.external_link === true) {
+      EXTERNAL_LINK_SITE_CONFIG = Object.assign({
+        enable: true,
+        field: 'site',
+        exclude: []
+      }, config.external_link);
+    }
   }
-  if (config.external_link === false || config.external_link.enable === false
-    || config.external_link.field !== 'site') return;
+
+  if (config.external_link === false || EXTERNAL_LINK_SITE_CONFIG.enable === false
+    || EXTERNAL_LINK_SITE_CONFIG.field !== 'site') {
+    EXTERNAL_LINK_SITE_ENABLED = false;
+    return;
+  }
 
   data = data.replace(/<a([\s]+|[\s]+[^<>]+[\s]+)href=["']([^<>"']+)["'][^<>]*>/gi, (str, _, href) => {
-    if (/target=/gi.test(str) || !isExternalLink(href, config.url, config.external_link.exclude)) return str;
+    if (/target=/gi.test(str) || !isExternalLink(href, config.url, EXTERNAL_LINK_SITE_CONFIG.exclude)) return str;
 
     if (/rel=/gi.test(str)) {
       str = str.replace(/rel="(.*?)"/gi, (relStr, rel) => {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "cheerio": "0.22.0",
+    "decache": "^4.5.1",
     "eslint": "^6.0.1",
     "eslint-config-hexo": "^4.1.0",
     "hexo-renderer-marked": "^2.0.0",

--- a/test/scripts/filters/external_link.js
+++ b/test/scripts/filters/external_link.js
@@ -1,9 +1,16 @@
 'use strict';
 
+const decache = require('decache');
+
 describe('External link', () => {
   const Hexo = require('../../../lib/hexo');
   const hexo = new Hexo();
-  const externalLink = require('../../../lib/plugins/filter/after_render/external_link').bind(hexo);
+  let externalLink;
+
+  beforeEach(() => {
+    decache('../../../lib/plugins/filter/after_render/external_link');
+    externalLink = require('../../../lib/plugins/filter/after_render/external_link').bind(hexo);
+  });
 
   hexo.config = {
     url: 'https://example.com',
@@ -166,7 +173,13 @@ describe('External link', () => {
 describe('External link - post', () => {
   const Hexo = require('../../../lib/hexo');
   const hexo = new Hexo();
-  const externalLink = require('../../../lib/plugins/filter/after_post_render/external_link').bind(hexo);
+
+  let externalLink;
+
+  beforeEach(() => {
+    decache('../../../lib/plugins/filter/after_post_render/external_link');
+    externalLink = require('../../../lib/plugins/filter/after_post_render/external_link').bind(hexo);
+  });
 
   hexo.config = {
     url: 'https://example.com',


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

This PR add cache for 2 values:

- `EXTERNAL_LINK_(POST|SITE)_ENABLED`

Since hexo will only run filter for `post` or `site`, it is important to return earlier for another one.

- `EXTERNAL_LINK_(POST|SITE)_CONFIG`

Currently, hexo handles `hexo.config.external_link` inside the filter. With config being cached there will be no need to run `Object.assign()` again and again.

## How to test

```sh
git clone -b optimize-external-filter https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
