### PR TITLE
feat(youtube_tag): support playlist

### DIFF
--- a/lib/plugins/tag/youtube.js
+++ b/lib/plugins/tag/youtube.js
@@ -6,11 +6,17 @@ const { htmlTag } = require('hexo-util');
 * Youtube tag
 *
 * Syntax:
-*   {% youtube video_id %}
+*   {% youtube video_id, type %}
 */
 
-function youtubeTag(id) {
-  const src = 'https://www.youtube.com/embed/' + id;
+function youtubeTag([id, type = 'video']) {
+  let src;
+
+  if (type === 'video') {
+    src = 'https://www.youtube.com/embed/' + id;
+  } else if (type === 'playlist') {
+    src = 'https://www.youtube.com/embed/videoseries?list=' + id;
+  }
 
   const iframeTag = htmlTag('iframe', {
     src,

--- a/test/scripts/tags/youtube.js
+++ b/test/scripts/tags/youtube.js
@@ -14,4 +14,14 @@ describe('youtube', () => {
     $('iframe').attr('allowfullscreen').should.eql('');
     $('iframe').attr('loading').should.eql('lazy');
   });
+
+  it('type', () => {
+    const $video = cheerio.load(youtube(['foo', 'video']));
+    $video('.video-container').html().should.be.ok;
+    $video('iframe').attr('src').should.eql('https://www.youtube.com/embed/foo');
+
+    const $playlist = cheerio.load(youtube(['foo', 'playlist']));
+    $playlist('.video-container').html().should.be.ok;
+    $playlist('iframe').attr('src').should.eql('https://www.youtube.com/embed/videoseries?list=foo');
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

#3267 Add playlist support for `youtube` tag.

Related documents: https://support.google.com/youtube/answer/171780?hl=en

Usage:

```
// By default youtube tag will output video
{% youtube [id] %}

// Manually set type
{% youtube [id] 'video' %}
{% youtube [id] 'playlist' %}
```

## How to test

```sh
git clone -btag-youtube-playlist https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
