### PR TITLE
refactor: copy object with spread operator

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -125,7 +125,7 @@ class Hexo {
       tag: new Tag()
     };
 
-    this.config = Object.assign({}, defaultConfig);
+    this.config = { ...defaultConfig };
 
     this.log = logger(this.env);
 

--- a/lib/plugins/console/deploy.js
+++ b/lib/plugins/console/deploy.js
@@ -50,7 +50,7 @@ function deployConsole(args) {
 
     this.log.info('Deploying: %s', magenta(type));
 
-    return Reflect.apply(deployers[type], this, [Object.assign({}, item, args)]).then(() => {
+    return Reflect.apply(deployers[type], this, [{ ...item, ...args }]).then(() => {
       this.log.info('Deploy done: %s', magenta(type));
     });
   }).then(() => {

--- a/lib/plugins/filter/new_post_path.js
+++ b/lib/plugins/filter/new_post_path.js
@@ -76,9 +76,10 @@ function newPostPathFilter(data = {}, replace) {
           if (!reservedKeys[key]) filenameData[key] = data[key];
         }
 
-        target = join(postDir, permalink.stringify(
-          Object.assign({}, permalinkDefaults, filenameData)
-        ));
+        target = join(postDir, permalink.stringify({
+          ...permalinkDefaults,
+          ...filenameData
+        }));
       }
     }
   } else {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

According to [the post](https://thecodebarbarian.com/object-assign-vs-object-spread.html), `Object.assign` is as fast as spread operator when shallow merging object (`Object.assign` is even slightly faster). However, when use `Object.assign` for copy object (passing `{}` as the first parameter), spread operator is consistently faster.

## How to test

```sh
git clone -b spread-operator https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
