### PR TITLE
refactor: remove site config from theme config

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -368,7 +368,7 @@ class Hexo {
         this.path = path;
         this.url = full_url_for.call(ctx, path);
         this.config = config;
-        this.theme = deepMerge(config, theme.config);
+        this.theme = theme.config;
         this._ = _;
         this.layout = 'layout';
         this.env = env;


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

```yaml
# _config.yml under hexo directory
a:
  foo: 'bar'
c: 'vaz'
```

```yaml
# _config.yml under theme directory
a:
  foo: 'abc'
b:
  baz: 'vrf'
```

**Before this PR**

In theme template:

- `theme.b.baz` --- `vrf`
- `config.a.foo` --- `bar`
- `theme.a.foo` --- `abc`

- `config.c` --- `vaz`
- `theme.c` --- `vaz`

**After this PR**

In theme template:

- `theme.b.baz` --- `vrf`
- `config.a.foo` --- `bar`
- `theme.a.foo` --- `abc`

- `config.c` --- `vaz`
- `theme.c` --- Throw `undefined` error

---

Since current behavior (merge site config into theme config) is not documented, I am assuming there is no theme developer is relying this behavior.

## How to test

```sh
git clone -b remove-site-config-from-theme-config https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
