### PR TITLE
fix: remove useless conditions

### DIFF
--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -40,7 +40,7 @@ function generateConsole(args = {}) {
   function writeFile(path, force) {
     const dest = join(publicDir, path);
     const cacheId = `public/${path}`;
-    const dataStream = wrapDataStream(route.get(path), {bail});
+    const dataStream = wrapDataStream(route.get(path), { bail });
     const cacheStream = new CacheStream();
     const hashStream = new HashStream();
 
@@ -81,9 +81,7 @@ function generateConsole(args = {}) {
     });
   }
 
-  function wrapDataStream(dataStream, options) {
-    const bail = options && options.bail;
-
+  function wrapDataStream(dataStream, { bail }) {
     // Pass original stream with all data and errors
     if (bail === true) {
       return dataStream;

--- a/lib/plugins/helper/feed_tag.js
+++ b/lib/plugins/helper/feed_tag.js
@@ -24,7 +24,7 @@ function feedTagHelper(path, options = {}) {
     return `<link rel="alternate" href="${this.url_for(path)}" title="${title}" ${typeAttr}>`;
   }
 
-  if (!path && config.feed) {
+  if (config.feed) {
     const { feed } = config;
     if (feed.type && feed.path) {
       if (typeof feed.type === 'string') {

--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -16,17 +16,18 @@ function tagcloudHelper(tags, options) {
   const orderby = options.orderby || 'name';
   const order = options.order || 1;
   const unit = options.unit || 'px';
-  let color = options.color;
+  const color = options.color;
   const { transform } = options;
   const separator = options.separator || ' ';
   const result = [];
   let startColor, endColor;
 
   if (color) {
+    if (!options.start_color) throw new TypeError('start_color is required!');
+    if (!options.end_color) throw new TypeError('end_color is required!');
+
     startColor = new Color(options.start_color);
     endColor = new Color(options.end_color);
-
-    if (!startColor || !endColor) color = false;
   }
 
   // Sort the tags

--- a/test/scripts/helpers/tagcloud.js
+++ b/test/scripts/helpers/tagcloud.js
@@ -243,6 +243,18 @@ describe('tagcloud', () => {
     ].join(' '));
   });
 
+  it('color - missing start_color', () => {
+    try {
+      tagcloud({
+        color: true,
+        end_color: 'pink'
+      });
+      should.fail();
+    } catch (err) {
+      err.message.should.eql('start_color is required!');
+    }
+  });
+
   it('separator', () => {
     const result = tagcloud({
       separator: ', '


### PR DESCRIPTION
## What does it do?
Issues found by lgtm.com (https://lgtm.com/projects/g/hexojs/hexo/)

- generate.js
  - second parameter of `wrapDataStream()` is always called with an object, so there's no need for null-checking. (both `{ undefined }` and `{ null: null }` are truthy)
- feed_tag.js
  * no need for second additional null-checking on `path` variable.
- tagcloud.js
  * `if (!startColor || !endColor) color = false;` is unreachable since `new Color(null)` will throw error.
  * throw more descriptive error (error message now says which required option is missing)

## How to test

```sh
git clone -b check-condition https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
