### PR TITLE
fix(console_generate): remove useless boolean-to-object conversion

### DIFF
--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -40,7 +40,7 @@ function generateConsole(args = {}) {
   function writeFile(path, force) {
     const dest = join(publicDir, path);
     const cacheId = `public/${path}`;
-    const dataStream = wrapDataStream(route.get(path), { bail });
+    const dataStream = wrapDataStream(route.get(path), bail);
     const cacheStream = new CacheStream();
     const hashStream = new HashStream();
 
@@ -81,9 +81,9 @@ function generateConsole(args = {}) {
     });
   }
 
-  function wrapDataStream(dataStream, { bail }) {
+  function wrapDataStream(dataStream, bail) {
     // Pass original stream with all data and errors
-    if (bail === true) {
+    if (bail) {
       return dataStream;
     }
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Continuation of https://github.com/hexojs/hexo/pull/4147
`bail` variable is of boolean type, passing `{ bail }` (boolean to object) as a parameter is unnecessary.


## How to test

```sh
git clone -b object-boolean https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
