### PR TITLE
refactor(hexo_index): remove unused parameter

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -81,10 +81,8 @@ function debounce(func, wait) {
     const args = arguments;
     clearTimeout(timeout);
     timeout = setTimeout(() => {
-      timeout = null;
       func.apply(context, args);
     }, wait);
-    if (!timeout) func.apply(context, args);
   };
 }
 

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -74,7 +74,7 @@ const createLoadThemeRoute = function(generatorResult, locals, ctx) {
   };
 };
 
-function debounce(func, wait, immediate) {
+function debounce(func, wait) {
   let timeout;
   return function() {
     const context = this;
@@ -82,9 +82,9 @@ function debounce(func, wait, immediate) {
     clearTimeout(timeout);
     timeout = setTimeout(() => {
       timeout = null;
-      if (!immediate) func.apply(context, args);
+      func.apply(context, args);
     }, wait);
-    if (immediate && !timeout) func.apply(context, args);
+    if (!timeout) func.apply(context, args);
   };
 }
 


### PR DESCRIPTION
## What does it do?
`immediate` parameter is never called. Found by [lgtm](https://lgtm.com/projects/g/hexojs/hexo/snapshot/456b4eb3a67752d00d607db6a4f24f777c66d4fd/files/lib/hexo/index.js?sort=name&dir=ASC&mode=heatmap).


## How to test

```sh
git clone -b unused-parameter https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
