### PR TITLE
feat: disable deep merging theme configs by default

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -62,6 +62,7 @@ module.exports = {
   pagination_dir: 'page',
   // Extensions
   theme: 'landscape',
+  deepmerge_theme_configs: false,
   server: {
     cache: false
   },

--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -353,11 +353,13 @@ class Hexo extends EventEmitter {
 
   _generateLocals() {
     const { config, env, theme, theme_dir } = this;
-    const ctx = { config: { url: this.config.url } };
+    const { deepmerge_theme_configs, url, theme_config } = config;
+    const ctx = { config: { url } };
     const localsObj = this.locals.toObject();
 
-    if (config.theme_config) {
-      theme.config = deepMerge(theme.config, config.theme_config);
+    if (theme_config) {
+      if (!deepmerge_theme_configs) theme.config = { ...theme.config, ...theme_config };
+      else theme.config = deepMerge(theme.config, theme_config);
     }
 
     class Locals {

--- a/test/scripts/hexo/hexo.js
+++ b/test/scripts/hexo/hexo.js
@@ -18,6 +18,7 @@ describe('Hexo', () => {
   const Page = hexo.model('Page');
   const Data = hexo.model('Data');
   const route = hexo.route;
+  const defaultConfig = require('../../../lib/hexo/default_config');
 
   function checkStream(stream, expected) {
     return testUtil.stream.read(stream).then(data => {
@@ -36,6 +37,7 @@ describe('Hexo', () => {
     hexo.extend.generator.store = {};
     // Remove all routes
     route.routes = {};
+    hexo.config = { ...defaultConfig };
   });
 
   after(() => fs.rmdir(hexo.base_dir));
@@ -76,9 +78,21 @@ describe('Hexo', () => {
     hexo.config_path.should.eql(pathFn.join(base_dir, '_multiconfig.yml'));
   });
 
+  it('theme_config - disable deep clone by default', () => {
+    const hexo = new Hexo(__dirname);
+    hexo.theme.config = { a: { b: 1, c: 2 } };
+    hexo.config.theme_config = { a: { b: 3 } };
+    const Locals = hexo._generateLocals();
+    const { theme } = new Locals();
+
+    theme.a.should.not.have.own.property('c');
+    theme.a.b.should.eql(3);
+  });
+
   // Issue #3964
   it('theme_config - deep clone', () => {
     const hexo = new Hexo(__dirname);
+    hexo.config.deepmerge_theme_configs = true;
     hexo.theme.config = { a: { b: 1, c: 2 } };
     hexo.config.theme_config = { a: { b: 3 } };
     const Locals = hexo._generateLocals();


### PR DESCRIPTION
## What does it do?
Continuation of https://github.com/hexojs/hexo/pull/3967. Requested by https://github.com/hexojs/hexo/pull/3967#issuecomment-590421136 @Teekivi
deep merging theme.config and config.theme_config is considered less common use case.

cc https://github.com/hexojs/hexo/issues/3964 @cmpute

Introduce a new option:

``` yml
deepmerge_theme_configs: false
```


## How to test

```sh
git clone -b optional-merge-theme https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
