### PR TITLE
feat(youtube_tag): add cookie option

### DIFF
--- a/lib/plugins/tag/youtube.js
+++ b/lib/plugins/tag/youtube.js
@@ -6,17 +6,18 @@ const { htmlTag } = require('hexo-util');
 * Youtube tag
 *
 * Syntax:
-*   {% youtube video_id, type %}
+*   {% youtube video_id, type, cookie %}
 */
 
-function youtubeTag([id, type = 'video']) {
-  let src;
-
-  if (type === 'video') {
-    src = 'https://www.youtube.com/embed/' + id;
-  } else if (type === 'playlist') {
-    src = 'https://www.youtube.com/embed/videoseries?list=' + id;
+function youtubeTag([id, type = 'video', cookie = true]) {
+  if (typeof type === 'boolean') {
+    cookie = type;
+    type = 'video';
   }
+
+  const ytLink = cookie ? 'https://www.youtube.com' : 'https://www.youtube-nocookie.com';
+  const embed = type === 'video' ? '/embed/' : '/embed/videoseries?list=';
+  const src = ytLink + embed + id;
 
   const iframeTag = htmlTag('iframe', {
     src,

--- a/lib/plugins/tag/youtube.js
+++ b/lib/plugins/tag/youtube.js
@@ -17,10 +17,9 @@ function youtubeTag([id, type = 'video', cookie = true]) {
 
   const ytLink = cookie ? 'https://www.youtube.com' : 'https://www.youtube-nocookie.com';
   const embed = type === 'video' ? '/embed/' : '/embed/videoseries?list=';
-  const src = ytLink + embed + id;
 
   const iframeTag = htmlTag('iframe', {
-    src,
+    src: ytLink + embed + id,
     frameborder: '0',
     loading: 'lazy',
     allowfullscreen: true

--- a/test/scripts/tags/youtube.js
+++ b/test/scripts/tags/youtube.js
@@ -24,4 +24,15 @@ describe('youtube', () => {
     $playlist('.video-container').html().should.be.ok;
     $playlist('iframe').attr('src').should.eql('https://www.youtube.com/embed/videoseries?list=foo');
   });
+
+  it('cookie', () => {
+    const $video1 = cheerio.load(youtube(['foo', 'video', false]));
+    $video1('.video-container').html().should.be.ok;
+    $video1('iframe').attr('src').should.eql('https://www.youtube-nocookie.com/embed/foo');
+
+    // cookie as second parameter
+    const $video2 = cheerio.load(youtube(['foo', false]));
+    $video2('.video-container').html().should.be.ok;
+    $video2('iframe').attr('src').should.eql('https://www.youtube-nocookie.com/embed/foo');
+  });
 });


### PR DESCRIPTION
## What does it do?
youtube-nocookie.com is privacy-enhanced mode, meaning google/youtube's cookie is not used. If a visitor is logged into google/youtube, the embedded video would not be linked to the visitor's account.

https://support.google.com/youtube/answer/171780?hl=en

To use:
`{% youtube foobar, false %}`
`{% youtube foobar, 'video', false %}`


## How to test

```sh
git clone -b youtube-nocookie https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
