### PR TITLE
fix(post): use non-greedy regular expressions

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -43,7 +43,7 @@ class PostRenderCache {
     const rSwigVar = /\{\{[\s\S]*?\}\}/g;
     const rSwigComment = /\{#[\s\S]*?#\}/g;
     const rSwigBlock = /\{%[\s\S]*?%\}/g;
-    const rSwigFullBlock = /\{% *(.+?)(?: *| +.*)%\}[\s\S]+?\{% *end\1 *%\}/g;
+    const rSwigFullBlock = /\{% *(.+?)(?: *| +.*?)%\}[\s\S]+?\{% *end\1 *%\}/g;
 
     const escape = _str => _escapeContent(this.cache, _str);
     return str.replace(rSwigFullBlock, escape)

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -888,4 +888,48 @@ describe('Post', () => {
     });
   });
 
+  // test for PR #4161
+  it('render() - adjacent tags', () => {
+    const content = [
+      '{% pullquote %}content1{% endpullquote %}',
+      '',
+      'This is a following paragraph',
+      '',
+      '{% pullquote %}content2{% endpullquote %}'
+    ].join('\n');
+
+    return post.render(null, {
+      content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql([
+        '<blockquote class="pullquote"><p>content1</p>\n</blockquote>\n',
+        '<p>This is a following paragraph</p>\n',
+        '<blockquote class="pullquote"><p>content2</p>\n</blockquote>\n'
+      ].join(''));
+    });
+  });
+
+  // test for PR #4161
+  it('render() - adjacent tags with args', () => {
+    const content = [
+      '{% pullquote center %}content1{% endpullquote %}',
+      '',
+      'This is a following paragraph',
+      '',
+      '{% pullquote center %}content2{% endpullquote %}'
+    ].join('\n');
+
+    return post.render(null, {
+      content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql([
+        '<blockquote class="pullquote center"><p>content1</p>\n</blockquote>\n',
+        '<p>This is a following paragraph</p>\n',
+        '<blockquote class="pullquote center"><p>content2</p>\n</blockquote>\n'
+      ].join(''));
+    });
+  });
+
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Currently, the regular expression `rSwigFullBlock` used in the `escapeAllSwigTags` method in `lib/hexo/post.js` may incorrectly match the Swig / Nunjucks block. For example, the user writes the following in a markdown document

```md
{% note danger %}note text, note text, note text{% endnote %}

## Title

{% note danger %}note text, note text, note text{% endnote %}
```

Then, this regular expression will match all three lines, starting from `{% note danger %}` in the first line to the ending `{% endnote %}` in the third line, which means that `## Title` in the second line is only processed by Nunjucks but not by the Markdown renderer, so it appears as `## Title` instead of `<h2>Title</h2>` in the output HTML.

<img width="928" alt="截屏2020-02-27上午10 46 09" src="https://user-images.githubusercontent.com/16272760/75407639-7ac0d380-594e-11ea-92de-475142791820.png">


By using non-greedy regular expression, the first and third line will be matched separately to get the correct results.

I'm not an expert in regular expressions, so I can't guarantee whether this change will cause other bugs. Suggestions are welcome, thank you!

Related issues:
https://github.com/iissnan/hexo-theme-next/issues/1674
https://github.com/iissnan/hexo-theme-next/issues/1678
https://github.com/iissnan/theme-next-docs/issues/163

## How to test

```sh
git clone -b stevenjoezhang-patch-1 https://github.com/stevenjoezhang/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
