### PR TITLE
refactor(post/tag): render tag before content

### DIFF
--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -77,7 +77,7 @@ class NunjucksBlock extends NunjucksTag {
   }
 
   run(context, args, body) {
-    return this._run(context, args, trimBody(body));
+    return this._run(context, args, trimBody(body)) + '\n';
   }
 }
 
@@ -111,7 +111,7 @@ class NunjucksAsyncBlock extends NunjucksBlock {
       body = () => result || '';
 
       this._run(context, args, trimBody(body)).then(result => {
-        callback(err, result);
+        callback(err, result && `${result}\n`);
       });
     });
   }

--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -109,7 +109,7 @@ class NunjucksAsyncBlock extends NunjucksBlock {
       body = () => result || '';
 
       this._run(context, args, trimBody(body)).then(result => {
-        callback(err, result && `${result}\n`);
+        callback(err, `${result}\n`);
       });
     });
   }

--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -4,8 +4,6 @@ const stripIndent = require('strip-indent');
 const { cyan } = require('chalk');
 const nunjucks = require('nunjucks');
 const Promise = require('bluebird');
-const placeholder = '\uFFFC';
-const rPlaceholder = /(?:<|&lt;)!--\uFFFC(\d+)--(?:>|&gt;)/g;
 
 class NunjucksTag {
   constructor(name, fn) {
@@ -228,15 +226,8 @@ class Tag {
       options = {};
     }
 
-    const cache = [];
-
-    const escapeContent = str => `<!--${placeholder}${cache.push(str) - 1}-->`;
-
-    str = str.replace(/<pre><code.*>[\s\S]*?<\/code><\/pre>/gm, escapeContent);
-
     return Promise.fromCallback(cb => { this.env.renderString(str, options, cb); })
-      .catch(err => Promise.reject(formatNunjucksError(err, str)))
-      .then(result => result.replace(rPlaceholder, (_, index) => cache[index]));
+      .catch(err => Promise.reject(formatNunjucksError(err, str)));
   }
 }
 

--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const assert = require('assert');
 const moment = require('moment');
 const Promise = require('bluebird');
 const { join, extname } = require('path');
@@ -11,29 +10,6 @@ const { copyDir, exists, listDir, mkdirs, readFile, rmdir, unlink, writeFile } =
 const yfm = require('hexo-front-matter');
 
 const preservedKeys = ['title', 'slug', 'path', 'layout', 'date', 'content'];
-const rEscapeContent = /<escape(?:[^>]*)>([\s\S]*?)<\/escape>/g;
-const rPlaceholder = /(?:<|&lt;)!--hexoPostRenderEscape:(\d+)--(?:>|&gt;)/g;
-
-class PostRenderCache {
-  constructor() {
-    this.cache = [];
-  }
-
-  escapeContent(str) {
-    return str.replace(rEscapeContent, (_, content) => `<!--hexoPostRenderEscape:${this.cache.push(content) - 1}-->`);
-  }
-
-  loadContent(str) {
-    const restored = str.replace(rPlaceholder, (_, index) => {
-      assert(this.cache[index]);
-      const value = this.cache[index];
-      this.cache[index] = null;
-      return value;
-    });
-    if (restored === str) return restored;
-    return this.loadContent(restored); // self-recursive for nexted escaping
-  }
-}
 
 const prepareFrontMatter = data => {
   for (const [key, item] of Object.entries(data)) {
@@ -230,17 +206,12 @@ class Post {
     // disable Nunjucks when the renderer spcify that.
     const disableNunjucks = ext && ctx.render.renderer.get(ext) && !!ctx.render.renderer.get(ext).disableNunjucks;
 
-    const cacheObj = new PostRenderCache();
-
     return promise.then(content => {
       data.content = content;
 
       // Run "before_post_render" filters
       return ctx.execFilter('before_post_render', data, { context: ctx });
     }).then(() => {
-      // Escape content wrapped in <escape></escape>
-      data.content = cacheObj.escapeContent(data.content);
-
       if (isSwig) {
         // Render with Nunjucks if the post is a swig file
         return tag.render(data.content, data);
@@ -256,9 +227,8 @@ class Post {
         engine: data.engine,
         toString: true,
         onRenderEnd(content) {
-          // Replace cache data with real contents
-          data.content = cacheObj.loadContent(content);
-
+          data.content = content.replace(/<!--hexoPostRenderEscape:/g, '')
+            .replace(/:hexoPostRenderEscape-->/g, '');
           return data.content;
         }
       }, options);

--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -11,11 +11,8 @@ const { copyDir, exists, listDir, mkdirs, readFile, rmdir, unlink, writeFile } =
 const yfm = require('hexo-front-matter');
 
 const preservedKeys = ['title', 'slug', 'path', 'layout', 'date', 'content'];
-
-const _escapeContent = (cache, str) => {
-  const placeholder = '\uFFFC';
-  return `<!--${placeholder}${cache.push(str) - 1}-->`;
-};
+const rEscapeContent = /<escape(?:[^>]*)>([\s\S]*?)<\/escape>/g;
+const rPlaceholder = /(?:<|&lt;)!--hexoPostRenderEscape:(\d+)--(?:>|&gt;)/g;
 
 class PostRenderCache {
   constructor() {
@@ -23,12 +20,10 @@ class PostRenderCache {
   }
 
   escapeContent(str) {
-    const rEscapeContent = /<escape(?:[^>]*)>([\s\S]*?)<\/escape>/g;
-    return str.replace(rEscapeContent, (_, content) => _escapeContent(this.cache, content));
+    return str.replace(rEscapeContent, (_, content) => `<!--hexoPostRenderEscape:${this.cache.push(content) - 1}-->`);
   }
 
   loadContent(str) {
-    const rPlaceholder = /(?:<|&lt;)!--\uFFFC(\d+)--(?:>|&gt;)/g;
     const restored = str.replace(rPlaceholder, (_, index) => {
       assert(this.cache[index]);
       const value = this.cache[index];
@@ -37,19 +32,6 @@ class PostRenderCache {
     });
     if (restored === str) return restored;
     return this.loadContent(restored); // self-recursive for nexted escaping
-  }
-
-  escapeAllSwigTags(str) {
-    const rSwigVar = /\{\{[\s\S]*?\}\}/g;
-    const rSwigComment = /\{#[\s\S]*?#\}/g;
-    const rSwigBlock = /\{%[\s\S]*?%\}/g;
-    const rSwigFullBlock = /\{% *(.+?)(?: *| +.*?)%\}[\s\S]+?\{% *end\1 *%\}/g;
-
-    const escape = _str => _escapeContent(this.cache, _str);
-    return str.replace(rSwigFullBlock, escape)
-      .replace(rSwigBlock, escape)
-      .replace(rSwigComment, '')
-      .replace(rSwigVar, escape);
   }
 }
 
@@ -96,7 +78,7 @@ class Post {
     const ctx = this.context;
     const { config } = ctx;
 
-    data.slug = slugize((data.slug || data.title).toString(), {transform: config.filename_case});
+    data.slug = slugize((data.slug || data.title).toString(), { transform: config.filename_case });
     data.layout = (data.layout || config.default_layout).toLowerCase();
     data.date = data.date ? moment(data.date) : moment();
 
@@ -135,7 +117,7 @@ class Post {
     let yfmSplit;
 
     return this._getScaffold(data.layout).then(scaffold => {
-      const frontMatter = prepareFrontMatter({...data});
+      const frontMatter = prepareFrontMatter({ ...data });
       yfmSplit = yfm.split(scaffold);
 
       return tag.render(yfmSplit.data, frontMatter);
@@ -183,7 +165,7 @@ class Post {
     const ctx = this.context;
     const { config } = ctx;
     const draftDir = join(ctx.source_dir, '_drafts');
-    const slug = slugize(data.slug.toString(), {transform: config.filename_case});
+    const slug = slugize(data.slug.toString(), { transform: config.filename_case });
     data.slug = slug;
     const regex = new RegExp(`^${escapeRegExp(slug)}(?:[^\\/\\\\]+)`);
     let src = '';
@@ -254,27 +236,22 @@ class Post {
       data.content = content;
 
       // Run "before_post_render" filters
-      return ctx.execFilter('before_post_render', data, {context: ctx});
+      return ctx.execFilter('before_post_render', data, { context: ctx });
     }).then(() => {
+      // Escape content wrapped in <escape></escape>
       data.content = cacheObj.escapeContent(data.content);
 
       if (isSwig) {
-        // Render with Nunjucks if this is a swig file
+        // Render with Nunjucks if the post is a swig file
         return tag.render(data.content, data);
-      }
-
-      // Escape all Swig tags
-      if (!disableNunjucks) {
-        data.content = cacheObj.escapeAllSwigTags(data.content);
       }
 
       const options = data.markdown || {};
       if (!config.highlight.enable) options.highlight = null;
-
       ctx.log.debug('Rendering post: %s', magenta(source));
-      // Render with markdown or other renderer
-      return ctx.render.render({
-        text: data.content,
+
+      const promise = text => ctx.render.render({
+        text,
         path: source,
         engine: data.engine,
         toString: true,
@@ -282,18 +259,22 @@ class Post {
           // Replace cache data with real contents
           data.content = cacheObj.loadContent(content);
 
-          // Return content after replace the placeholders
-          if (disableNunjucks) return data.content;
-
-          // Render with Nunjucks
-          return tag.render(data.content, data);
+          return data.content;
         }
       }, options);
+
+      if (!disableNunjucks) {
+        return tag.render(data.content, data).then(promise);
+      }
+
+      // Nunjucks is disabled
+      return promise(data.content);
+
     }).then(content => {
       data.content = content;
 
       // Run "after_post_render" filters
-      return ctx.execFilter('after_post_render', data, {context: ctx});
+      return ctx.execFilter('after_post_render', data, { context: ctx });
     }).asCallback(callback);
   }
 }

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -63,7 +63,7 @@ function backtickCodeBlock(data) {
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;');
 
-    return `${start}<escape>${content}</escape>${end}`;
+    return `${start}<!--hexoPostRenderEscape:${content}:hexoPostRenderEscape-->${end}`;
   });
 }
 

--- a/test/fixtures/post_render.js
+++ b/test/fixtures/post_render.js
@@ -45,7 +45,7 @@ exports.expected = [
   '<h2 id="Another-title"><a href="#Another-title" class="headerlink" title="Another title"></a>Another title</h2>',
   '<blockquote>',
   '<p>quote content</p>\n',
-  '</blockquote>\n\n',
+  '</blockquote>\n\n\n',
   '<blockquote><p>quote content</p>\n',
   '<footer><strong>Hello World</strong></footer></blockquote>'
 ].join('');

--- a/test/fixtures/post_render.js
+++ b/test/fixtures/post_render.js
@@ -7,7 +7,7 @@ const code = [
   '  sleep()'
 ].join('\n');
 
-const content = [
+exports.content = [
   '# Title',
   '``` python',
   code,
@@ -24,7 +24,19 @@ const content = [
   '{% endquote %}'
 ].join('\n');
 
-exports.content = content;
+exports.content_for_issue_3346 = [
+  '# Title',
+  '```',
+  '{% test1 %}',
+  '{{ test2 }}',
+  '```',
+  'some content',
+  '',
+  '## Another title',
+  '{% blockquote %}',
+  'quote content',
+  '{% endblockquote %}'
+].join('\n');
 
 exports.expected = [
   '<h1 id="Title"><a href="#Title" class="headerlink" title="Title"></a>Title</h1>',
@@ -49,4 +61,14 @@ exports.expected_disable_nunjucks = [
   '<p>{% quote Hello World %}<br>',
   'quote content<br>',
   '{% endquote %}</p>'
+].join('');
+
+exports.expected_for_issue_3346 = [
+  '<h1 id="Title"><a href="#Title" class="headerlink" title="Title"></a>Title</h1>',
+  highlight('{% test1 %}\n{{ test2 }}').replace(/{/g, '&#123;').replace(/}/g, '&#125;'), // Escaped by backtick_code_block
+  '\n<p>some content</p>\n',
+  '<h2 id="Another-title"><a href="#Another-title" class="headerlink" title="Another title"></a>Another title</h2>',
+  '<blockquote>',
+  '<p>quote content</p>\n',
+  '</blockquote>'
 ].join('');

--- a/test/scripts/extend/tag.js
+++ b/test/scripts/extend/tag.js
@@ -37,7 +37,7 @@ describe('Tag', () => {
     ].join('\n');
 
     const result = await tag.render(str);
-    result.should.eql('foo bar test content');
+    result.should.eql('foo bar test content\n');
   });
 
   it('register() - async block', async () => {
@@ -52,7 +52,7 @@ describe('Tag', () => {
     ].join('\n');
 
     const result = await tag.render(str);
-    result.should.eql('foo bar test content');
+    result.should.eql('foo bar test content\n');
   });
 
   it('register() - nested test', async () => {
@@ -111,7 +111,7 @@ describe('Tag', () => {
     ].join('\n');
 
     const result = await tag.render(str);
-    result.should.eql('test content');
+    result.should.eql('test content\n');
   });
 
   it('register() - async callback', async () => {

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -67,7 +67,7 @@ describe('Backtick code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + highlight(code, {lang: 'js'}) + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code, {lang: 'js'}) + ':hexoPostRenderEscape-->');
   });
 
   it('without language name', () => {
@@ -82,7 +82,7 @@ describe('Backtick code block', () => {
     const expected = highlight(code);
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('without language name - ignore tab character', () => {
@@ -97,7 +97,7 @@ describe('Backtick code block', () => {
     const expected = highlight(code);
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('title', () => {
@@ -115,7 +115,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('url', () => {
@@ -133,7 +133,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('link text', () => {
@@ -151,7 +151,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('indent', () => {
@@ -171,7 +171,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('line number false', () => {
@@ -191,7 +191,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('line number false, don`t first_line_number always1', () => {
@@ -212,7 +212,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('line number false, don`t care first_line_number inilne', () => {
@@ -233,7 +233,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('line number true', () => {
@@ -253,7 +253,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('line number, first_line_number always1, js=', () => {
@@ -275,7 +275,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('line number, first_line_number inline, js', () => {
@@ -297,7 +297,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('line number, first_line_number inline, js=1', () => {
@@ -319,7 +319,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('line number, first_line_number inline, js=2', () => {
@@ -341,7 +341,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('tab replace', () => {
@@ -367,7 +367,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + expected + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
   });
 
   it('wrap', () => {
@@ -382,7 +382,7 @@ describe('Backtick code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<escape>' + highlight(code, { lang: 'js', wrap: false }) + '</escape>');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code, { lang: 'js', wrap: false }) + ':hexoPostRenderEscape-->');
 
     hexo.config.highlight.wrap = true;
   });

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -939,4 +939,15 @@ describe('Post', () => {
     });
   });
 
+  // test for Issue #3346
+  it('render() - swig tag inside backtick code block', () => {
+    const content = fixture.content_for_issue_3346;
+
+    return post.render(null, {
+      content,
+      engine: 'markdown'
+    }).then(data => {
+      data.content.trim().should.eql(fixture.expected_for_issue_3346);
+    });
+  });
 });

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -645,7 +645,7 @@ describe('Post', () => {
     }).then(data => {
       data.content.trim().should.eql([
         highlighted,
-        '',
+        '\n',
         highlighted
       ].join('\n'));
     });
@@ -910,7 +910,7 @@ describe('Post', () => {
       engine: 'markdown'
     }).then(data => {
       data.content.trim().should.eql([
-        '<blockquote class="pullquote"><p>content1</p>\n</blockquote>\n\n',
+        '<blockquote class="pullquote"><p>content1</p>\n</blockquote>\n\n\n',
         '<p>This is a following paragraph</p>\n',
         '<blockquote class="pullquote"><p>content2</p>\n</blockquote>'
       ].join(''));
@@ -932,7 +932,7 @@ describe('Post', () => {
       engine: 'markdown'
     }).then(data => {
       data.content.trim().should.eql([
-        '<blockquote class="pullquote center"><p>content1</p>\n</blockquote>\n\n',
+        '<blockquote class="pullquote center"><p>content1</p>\n</blockquote>\n\n\n',
         '<p>This is a following paragraph</p>\n',
         '<blockquote class="pullquote center"><p>content2</p>\n</blockquote>'
       ].join(''));
@@ -949,5 +949,42 @@ describe('Post', () => {
     }).then(data => {
       data.content.trim().should.eql(fixture.expected_for_issue_3346);
     });
+  });
+
+  // test for https://github.com/hexojs/hexo/pull/4171#issuecomment-594412367
+  it('render() - markdown content right after swig tag', async () => {
+    const content = [
+      '{% pullquote warning %}',
+      'Text',
+      '{% endpullquote %}',
+      '# Title 0',
+      '{% pullquote warning %}',
+      'Text',
+      '{% endpullquote %}',
+      '{% pullquote warning %}',
+      'Text',
+      '{% endpullquote %}',
+      '# Title 1',
+      '{% pullquote warning %}',
+      'Text',
+      '{% endpullquote %}',
+      '{% pullquote warning %}Text{% endpullquote %}',
+      '# Title 2',
+      '{% pullquote warning %}Text{% endpullquote %}',
+      '{% pullquote warning %}Text{% endpullquote %}',
+      '# Title 3',
+      '{% pullquote warning %}Text{% endpullquote %}'
+    ].join('\n');
+
+    const data = await post.render(null, {
+      content,
+      engine: 'markdown'
+    });
+
+    // We only to make sure markdown content is rendered correctly
+    data.content.trim().should.include('<h1 id="Title-0"><a href="#Title-0" class="headerlink" title="Title 0"></a>Title 0</h1>');
+    data.content.trim().should.include('<h1 id="Title-1"><a href="#Title-1" class="headerlink" title="Title 1"></a>Title 1</h1>');
+    data.content.trim().should.include('<h1 id="Title-2"><a href="#Title-2" class="headerlink" title="Title 2"></a>Title 2</h1>');
+    data.content.trim().should.include('<h1 id="Title-3"><a href="#Title-3" class="headerlink" title="Title 3"></a>Title 3</h1>');
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Continuation of https://github.com/hexojs/hexo/issues/3543#issuecomment-569865652 and https://github.com/hexojs/hexo/pull/4161

Currently post rendering process is something like this: https://github.com/hexojs/hexo/pull/4161#issuecomment-591802138. But basically, hexo will render markdown first, then the tag (using nunjucks). So hexo has to remove all swig tags before markdown rendering, and restore them after markdown rendering is finished.

In this PR, I make hexo renders tag first, then markdown, so that remove and restore swig tag are not necessary any more, resulted in 6% faster in generation speed. And the post rendering related test cases are passed as well.

I wonder why Hexo has to render tag after markdown at the beginning.

## How to test

```sh
git clone -b render-tag-before-md https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.


Issue resolved: https://github.com/hexojs/hexo/issues/2821