### PR TITLE
fix: return callback if called

### DIFF
--- a/lib/box/file.js
+++ b/lib/box/file.js
@@ -21,7 +21,6 @@ class File {
   stat(options, callback) {
     if (!callback && typeof options === 'function') {
       callback = options;
-      options = {};
     }
 
     return stat(this.source).asCallback(callback);

--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -236,7 +236,8 @@ class Tag {
 
     return Promise.fromCallback(cb => { this.env.renderString(str, options, cb); })
       .catch(err => Promise.reject(formatNunjucksError(err, str)))
-      .then(result => result.replace(rPlaceholder, (_, index) => cache[index]));
+      .then(result => result.replace(rPlaceholder, (_, index) => cache[index]))
+      .asCallback(callback);
   }
 }
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
fix remaining alerts of [lgtm](https://lgtm.com/projects/g/hexojs/hexo/?mode=list).

- `file.js` - since `options` is not used in the function, there's no need to handle it.
- `tag.js` - return a callback if `render()` is called with a callback.

## How to test

```sh
git clone -b callback-handling https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
