### PR TITLE
Escape indented code block before render

### DIFF
--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -2,10 +2,10 @@
 
 const { escapeHTML, stripIndent } = require('hexo-util');
 
-const rIndentedCodeBlock = /(^|(?:^|\n)(?:(?: {0,3}>){1,3}[^\S\r\n])?[^\S\r\n]*\n)((?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*?)(\n|$))+)/g;
+const rIndentedCodeBlock = /(^|(?:^|\n)(?:(?: {0,3}>){1,3}[^\S\r\n])?[^\S\r\n]*)((?:(?:^|\n)((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*))+)(?=\n|$)/g;
 
 function indentedCodeBlock(data) {
-  data.content = data.content.replace(rIndentedCodeBlock, ($0, before, content, start, $4, $5, end) => {
+  data.content = data.content.replace(rIndentedCodeBlock, ($0, before, content, start, $4, $5) => {
 
     // PR #3765
     if (start.includes('>')) {
@@ -25,7 +25,7 @@ function indentedCodeBlock(data) {
 
     const markedContent = '<!--hexoPostRenderEscape:' + wrappedContent + ':hexoPostRenderEscape-->';
 
-    return `${before}${start}${markedContent}${end}`;
+    return `${before}${start}${markedContent}\n`;
   });
 }
 

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -3,7 +3,7 @@
 const stripIndent = require('strip-indent');
 const { highlight } = require('hexo-util');
 
-const rIndentedCodeBlock = /^(?:((?:[^\S\r\n]{0,3}>){0,3}[^\S\r\n]*?)( {4}|\t)([^\n]*?)(\n|$))+/gm;
+const rIndentedCodeBlock = /^(?:((?: {0,3}>){0,3}[^\S\r\n])( {4}|\t)([^\n]*?)(\n|$))+/gm;
 
 function indentedCodeBlock(data) {
   const config = this.config.highlight || {};

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -18,13 +18,14 @@ function indentedCodeBlock(data) {
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;');
 
-    const wrappedContent = `<pre><code>${escapedContent}</code></pre>`;
+    // hack to guard blank lines from incorrect rendering
+    const guardedContent = escapedContent.replace(/^/mg, start).replace(start, '');
 
-    const guardedContent = '<!--hexoPostRenderEscape:'
-        + wrappedContent.replace(/^/mg, start) // hack to guard blank lines from incorrect rendering
-        + ':hexoPostRenderEscape-->';
+    const wrappedContent = `<pre><code>${guardedContent}</code></pre>`;
 
-    return `${before}${start}${guardedContent}${end}`;
+    const markedContent = '<!--hexoPostRenderEscape:' + wrappedContent + ':hexoPostRenderEscape-->';
+
+    return `${before}${start}${markedContent}${end}`;
   });
 }
 

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -7,7 +7,10 @@ const rIndentedCodeBlock = /(^|(?:^|\n)(?:(?: {0,3}>){1,3}[^\S\r\n])?[^\S\r\n]*)
 function indentedCodeBlock(data) {
   data.content = data.content.replace(rIndentedCodeBlock, ($0, before, content, start, $4, $5) => {
 
-    before = before.replace(/[^\S\r\n]+$/, ' ');
+    content = content.replace(/^\n/, x => {
+      before = before + '\n';
+      return '';
+    });
 
     // PR #3765
     if (start.includes('>')) {

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -3,7 +3,7 @@
 const stripIndent = require('strip-indent');
 const { highlight } = require('hexo-util');
 
-const rIndentedCodeBlock = /^(?:((?:[^\S\r\n]*>){0,3}[^\S\r\n]*?)( {4})([^\n]*)(\n|$))+/gm;
+const rIndentedCodeBlock = /^(?:((?:[^\S\r\n]{0,3}>){0,3}[^\S\r\n]*?)( {4}|\t)([^\n]*?)(\n|$))+/gm;
 
 function indentedCodeBlock(data) {
   const config = this.config.highlight || {};

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -1,0 +1,40 @@
+'use strict';
+
+const stripIndent = require('strip-indent');
+const { highlight } = require('hexo-util');
+
+const rIndentedCodeBlock = /^(?:((?:[^\S\r\n]*>){0,3}[^\S\r\n]*?)( {3})([^\n]*)(\n|$))+/gm;
+
+function indentedCodeBlock(data) {
+  const config = this.config.highlight || {};
+  if (!config.enable) return;
+  data.content = data.content.replace(rIndentedCodeBlock, (content, start, $2, $3, end) => {
+    const options = {
+      hljs: config.hljs,
+      autoDetect: config.auto_detect,
+      gutter: config.line_number,
+      tab: config.tab_replace,
+      wrap: config.wrap
+    };
+
+    if (options.gutter) {
+      config.first_line_number = config.first_line_number || 'always1';
+    }
+
+    // PR #3765
+    if (start.includes('>')) {
+      const depth = start.split('>').length - 1;
+      const regexp = new RegExp(`^([^\\S\\r\\n]*>){0,${depth}}([^\\S\\r\\n]|$)`, 'mg');
+      const paddingOnEnd = ' '; // complement uncaptured whitespaces at last line
+      content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
+    }
+
+    content = highlight(stripIndent(content), options)
+      .replace(/{/g, '&#123;')
+      .replace(/}/g, '&#125;');
+
+    return `${start}<!--hexoPostRenderEscape:${content}:hexoPostRenderEscape-->${end}`;
+  });
+}
+
+module.exports = indentedCodeBlock;

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -30,7 +30,7 @@ function indentedCodeBlock(data) {
 
     const markedContent = '<!--hexoPostRenderEscape:' + wrappedContent + ':hexoPostRenderEscape-->';
 
-    return `${before}${start}${markedContent}\n`;
+    return `${before}${start}${markedContent}`;
   });
 }
 

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -3,8 +3,6 @@
 const { escapeHTML, stripIndent } = require('hexo-util');
 
 const rIndentedCodeBlock = /(^|(?:^|\n)(?:(?: {0,3}>){1,3}[^\S\r\n])?[^\S\r\n]*\n)((?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*?)(\n|$))+)/g;
-const guardStartTag = '<!--hexoPostRenderEscape:';
-const guardEndTag = ':hexoPostRenderEscape-->';
 
 function indentedCodeBlock(data) {
   data.content = data.content.replace(rIndentedCodeBlock, ($0, before, content, start, $4, $5, end) => {
@@ -23,9 +21,9 @@ function indentedCodeBlock(data) {
 
     const wrappedContent = `<pre><code>${escapedContent}</code></pre>`;
 
-    const guardedContent = guardStartTag
-        + wrappedContent.replace(/^\n/mg, `${guardEndTag}${guardStartTag}\n`) // guard blank lines
-        + guardEndTag;
+    const guardedContent = '<!--hexoPostRenderEscape:'
+        + wrappedContent.replace(/^/mg, start) // hack to guard blank lines from incorrect rendering
+        + ':hexoPostRenderEscape-->';
 
     return `${before}${start}${guardedContent}${end}`;
   });

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -2,10 +2,10 @@
 
 const { escapeHTML, stripIndent } = require('hexo-util');
 
-const rIndentedCodeBlock = /^(?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*?)(\n|$))+/gm;
+const rIndentedCodeBlock = /(^|(?:^|\n)(?:(?: {0,3}>){1,3}[^\S\r\n])?[^\S\r\n]*\n)((?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*?)(\n|$))+)/g;
 
 function indentedCodeBlock(data) {
-  data.content = data.content.replace(rIndentedCodeBlock, (content, start, $2, $3, end) => {
+  data.content = data.content.replace(rIndentedCodeBlock, ($0, before, content, start, $4, $5, end) => {
 
     // PR #3765
     if (start.includes('>')) {
@@ -21,7 +21,7 @@ function indentedCodeBlock(data) {
 
     const wrappedContent = `<pre><code>${escapedContent}</code></pre>`;
 
-    return `${start}<!--hexoPostRenderEscape:${wrappedContent}:hexoPostRenderEscape-->${end}`;
+    return `${before}${start}<!--hexoPostRenderEscape:${wrappedContent}:hexoPostRenderEscape-->${end}`;
   });
 }
 

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -24,7 +24,7 @@ function indentedCodeBlock(data) {
     // PR #3765
     if (start.includes('>')) {
       const depth = start.split('>').length - 1;
-      const regexp = new RegExp(`^([^\\S\\r\\n]*>){0,${depth}}([^\\S\\r\\n]|$)`, 'mg');
+      const regexp = new RegExp(`^( {0,3}>){0,${depth}}([^\\S\\r\\n]|$)`, 'mg');
       const paddingOnEnd = ' '; // complement uncaptured whitespaces at last line
       content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
     }

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -11,8 +11,7 @@ function indentedCodeBlock(data) {
     if (start.includes('>')) {
       const depth = start.split('>').length - 1;
       const regexp = new RegExp(`^( {0,3}>){0,${depth}}([^\\S\\r\\n]|$)`, 'mg');
-      const paddingOnEnd = ' '; // complement uncaptured whitespaces at last line
-      content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
+      content = content.replace(regexp, '');
     }
 
     const escapedContent = escapeHTML(stripIndent(content))

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -1,20 +1,12 @@
 'use strict';
 
 const stripIndent = require('strip-indent');
-const { highlight } = require('hexo-util');
+const { escapeHTML } = require('hexo-util');
 
 const rIndentedCodeBlock = /^(?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*?)(\n|$))+/gm;
 
 function indentedCodeBlock(data) {
-  const config = this.config.highlight || {};
   data.content = data.content.replace(rIndentedCodeBlock, (content, start, $2, $3, end) => {
-    const options = {
-      hljs: config.hljs,
-      autoDetect: config.auto_detect,
-      gutter: config.line_number,
-      tab: config.tab_replace,
-      wrap: config.wrap
-    };
 
     // PR #3765
     if (start.includes('>')) {
@@ -24,17 +16,11 @@ function indentedCodeBlock(data) {
       content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
     }
 
-    content = stripIndent(content);
-
-    if (config.enable) {
-      content = highlight(content, options);
-    } else {
-      content = `<pre><code>${content}</code></pre>`;
-    }
-
-    content = content
+    content = escapeHTML(stripIndent(content))
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;');
+
+    content = `<pre><code>${content}</code></pre>`;
 
     return `${start}<!--hexoPostRenderEscape:${content}:hexoPostRenderEscape-->${end}`;
   });

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -3,7 +3,7 @@
 const stripIndent = require('strip-indent');
 const { highlight } = require('hexo-util');
 
-const rIndentedCodeBlock = /^(?:((?: {0,3}>){0,3}[^\S\r\n])( {4}|\t)([^\n]*?)(\n|$))+/gm;
+const rIndentedCodeBlock = /^(?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*?)(\n|$))+/gm;
 
 function indentedCodeBlock(data) {
   const config = this.config.highlight || {};

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -17,10 +17,6 @@ function indentedCodeBlock(data) {
       wrap: config.wrap
     };
 
-    if (options.gutter) {
-      config.first_line_number = config.first_line_number || 'always1';
-    }
-
     // PR #3765
     if (start.includes('>')) {
       const depth = start.split('>').length - 1;

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -7,7 +7,6 @@ const rIndentedCodeBlock = /^(?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*
 
 function indentedCodeBlock(data) {
   const config = this.config.highlight || {};
-  if (!config.enable) return;
   data.content = data.content.replace(rIndentedCodeBlock, (content, start, $2, $3, end) => {
     const options = {
       hljs: config.hljs,
@@ -25,7 +24,15 @@ function indentedCodeBlock(data) {
       content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
     }
 
-    content = highlight(stripIndent(content), options)
+    content = stripIndent(content);
+
+    if (config.enable) {
+      content = highlight(content, options);
+    } else {
+      content = `<pre><code>${content}</code></pre>`;
+    }
+
+    content = content
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;');
 

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const stripIndent = require('strip-indent');
-const { escapeHTML } = require('hexo-util');
+const { escapeHTML, stripIndent } = require('hexo-util');
 
 const rIndentedCodeBlock = /^(?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*?)(\n|$))+/gm;
 

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -7,6 +7,8 @@ const rIndentedCodeBlock = /(^|(?:^|\n)(?:(?: {0,3}>){1,3}[^\S\r\n])?[^\S\r\n]*)
 function indentedCodeBlock(data) {
   data.content = data.content.replace(rIndentedCodeBlock, ($0, before, content, start, $4, $5) => {
 
+    before = before.replace(/[^\S\r\n]+$/, ' ');
+
     // PR #3765
     if (start.includes('>')) {
       const depth = start.split('>').length - 1;

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -15,13 +15,13 @@ function indentedCodeBlock(data) {
       content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
     }
 
-    content = escapeHTML(stripIndent(content))
+    const escapedContent = escapeHTML(stripIndent(content))
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;');
 
-    content = `<pre><code>${content}</code></pre>`;
+    const wrappedContent = `<pre><code>${escapedContent}</code></pre>`;
 
-    return `${start}<!--hexoPostRenderEscape:${content}:hexoPostRenderEscape-->${end}`;
+    return `${start}<!--hexoPostRenderEscape:${wrappedContent}:hexoPostRenderEscape-->${end}`;
   });
 }
 

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -3,6 +3,8 @@
 const { escapeHTML, stripIndent } = require('hexo-util');
 
 const rIndentedCodeBlock = /(^|(?:^|\n)(?:(?: {0,3}>){1,3}[^\S\r\n])?[^\S\r\n]*\n)((?:((?:(?: {0,3}>){1,3}[^\S\r\n])?)( {4}|\t)([^\n]*?)(\n|$))+)/g;
+const guardStartTag = '<!--hexoPostRenderEscape:';
+const guardEndTag = ':hexoPostRenderEscape-->';
 
 function indentedCodeBlock(data) {
   data.content = data.content.replace(rIndentedCodeBlock, ($0, before, content, start, $4, $5, end) => {
@@ -21,7 +23,11 @@ function indentedCodeBlock(data) {
 
     const wrappedContent = `<pre><code>${escapedContent}</code></pre>`;
 
-    return `${before}${start}<!--hexoPostRenderEscape:${wrappedContent}:hexoPostRenderEscape-->${end}`;
+    const guardedContent = guardStartTag
+        + wrappedContent.replace(/^\n/mg, `${guardEndTag}${guardStartTag}\n`) // guard blank lines
+        + guardEndTag;
+
+    return `${before}${start}${guardedContent}${end}`;
   });
 }
 

--- a/lib/plugins/filter/before_post_render/indented_code_block.js
+++ b/lib/plugins/filter/before_post_render/indented_code_block.js
@@ -3,7 +3,7 @@
 const stripIndent = require('strip-indent');
 const { highlight } = require('hexo-util');
 
-const rIndentedCodeBlock = /^(?:((?:[^\S\r\n]*>){0,3}[^\S\r\n]*?)( {3})([^\n]*)(\n|$))+/gm;
+const rIndentedCodeBlock = /^(?:((?:[^\S\r\n]*>){0,3}[^\S\r\n]*?)( {4})([^\n]*)(\n|$))+/gm;
 
 function indentedCodeBlock(data) {
   const config = this.config.highlight || {};

--- a/lib/plugins/filter/before_post_render/index.js
+++ b/lib/plugins/filter/before_post_render/index.js
@@ -4,5 +4,6 @@ module.exports = ctx => {
   const { filter } = ctx.extend;
 
   filter.register('before_post_render', require('./backtick_code_block'));
+  filter.register('before_post_render', require('./indented_code_block'));
   filter.register('before_post_render', require('./titlecase'));
 };

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const util = require('hexo-util');
-const defaultConfig = require('../../../lib/hexo/default_config');
 
 describe('Indented code block', () => {
   const Hexo = require('../../../lib/hexo');
@@ -15,50 +14,14 @@ describe('Indented code block', () => {
   ];
   const code = code_raw.join('\n');
 
-  function highlight(code, options) {
-    return util.highlight(code, options || {})
+  function wrap(code) {
+    const content = util.escapeHTML(code)
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;');
-  }
-
-  function wrap(code) {
-    return '<pre><code>' + code
-      .replace(/{/g, '&#123;')
-      .replace(/}/g, '&#125;')
-      + '</code></pre>';
+    return '<pre><code>' + content + '</code></pre>';
   }
 
   beforeEach(() => {
-    // Reset config
-    hexo.config.highlight = Object.assign({}, defaultConfig.highlight);
-  });
-
-  it('disabled', () => {
-    const content = [
-      ...code_raw
-    ].map(x => `    ${x}`).join('\n');
-
-    const data = {content};
-
-    hexo.config.highlight.enable = false;
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
-  });
-
-  it('with no config (disabled)', () => {
-    const content = [
-      ...code_raw
-    ].map(x => `    ${x}`).join('\n');
-
-    const data = {content};
-
-    const oldConfig = hexo.config.highlight;
-    delete hexo.config.highlight;
-
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
-
-    hexo.config.highlight = oldConfig;
   });
 
   it('default', () => {
@@ -69,33 +32,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code, {}) + ':hexoPostRenderEscape-->');
-  });
-
-  it('without language name', () => {
-    const data = {
-      content: [
-        ...code_raw
-      ].map(x => `    ${x}`).join('\n')
-    };
-
-    const expected = highlight(code);
-
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
-  });
-
-  it('without language name - ignore tab character', () => {
-    const data = {
-      content: [
-        ...code_raw
-      ].map(x => `    ${x}`).join('\n')
-    };
-
-    const expected = highlight(code);
-
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
   });
 
   it('indent', () => {
@@ -107,86 +44,11 @@ describe('Indented code block', () => {
       ].map(x => `    ${x}`).join('\n')
     };
 
-    const expected = highlight(code, {
-    });
-
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
   });
 
-  it('line number false', () => {
-    hexo.config.highlight.line_number = false;
-
-    const data = {
-      content: [
-        ...code_raw
-      ].map(x => `    ${x}`).join('\n')
-    };
-
-    const expected = highlight(code, {
-      gutter: false
-    });
-
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
-  });
-
-  it('line number false, don`t first_line_number always1', () => {
-    hexo.config.highlight.line_number = false;
-    hexo.config.highlight.first_line_number = 'always1';
-
-    const data = {
-      content: [
-        ...code_raw
-      ].map(x => `    ${x}`).join('\n')
-    };
-
-    const expected = highlight(code, {
-      gutter: false
-    });
-
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
-  });
-
-  it('line number false, don`t care first_line_number inilne', () => {
-    hexo.config.highlight.line_number = false;
-    hexo.config.highlight.first_line_number = 'inilne';
-
-    const data = {
-      content: [
-        ...code_raw
-      ].map(x => `    ${x}`).join('\n')
-    };
-
-    const expected = highlight(code, {
-      gutter: false
-    });
-
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
-  });
-
-  it('line number true', () => {
-    hexo.config.highlight.line_number = true;
-
-    const data = {
-      content: [
-        ...code_raw
-      ].map(x => `    ${x}`).join('\n')
-    };
-
-    const expected = highlight(code, {
-      gutter: true
-    });
-
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
-  });
-
-  it('tab replace', () => {
-    hexo.config.highlight.tab_replace = '  ';
-
+  it('include tab', () => {
     const code_raw = [
       'if (tired && night){',
       '\tsleep();',
@@ -200,26 +62,7 @@ describe('Indented code block', () => {
       ].map(x => `    ${x}`).join('\n')
     };
 
-    const expected = highlight(code, {
-      tab: '  '
-    });
-
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
-  });
-
-  it('wrap', () => {
-    hexo.config.highlight.wrap = false;
-
-    const data = {
-      content: [
-        ...code_raw
-      ].map(x => `    ${x}`).join('\n')
-    };
-
-    codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code, {wrap: false }) + ':hexoPostRenderEscape-->');
-
-    hexo.config.highlight.wrap = true;
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
   });
 });

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -22,6 +22,15 @@ describe('Indented code block', () => {
     return '<pre><code>' + content + '</code></pre>';
   }
 
+  function wrap_with_quote(code) {
+    const content = util.escapeHTML(util.stripIndent(code))
+      .replace(/{/g, '&#123;')
+      .replace(/}/g, '&#125;')
+      .replace(/^/mg, '> ')
+      .replace(/^> /, '');
+    return '<pre><code>' + content + '</code></pre>';
+  }
+
   beforeEach(() => {
   });
 
@@ -208,7 +217,7 @@ describe('Indented code block', () => {
     };
 
     const expected = [
-      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->'
+      '> <!--hexoPostRenderEscape:' + wrap_with_quote(code) + ':hexoPostRenderEscape-->'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -229,7 +238,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap_with_quote(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -277,7 +286,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap_with_quote(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -348,7 +357,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap_with_quote(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -22,7 +22,7 @@ describe('Indented code block', () => {
     return '<pre><code>' + content + '</code></pre>';
   }
 
-  function wrap_with_hack(code) {
+  function wrapWithHack(code) {
     const content = util.escapeHTML(util.stripIndent(code))
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;')
@@ -217,7 +217,7 @@ describe('Indented code block', () => {
     };
 
     const expected = [
-      '> <!--hexoPostRenderEscape:' + wrap_with_hack(code) + ':hexoPostRenderEscape-->'
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -238,7 +238,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap_with_hack(code) + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -286,7 +286,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap_with_hack(code) + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -357,7 +357,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap_with_hack(code) + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -29,7 +29,7 @@ describe('Indented code block', () => {
   it('disabled', () => {
     const content = [
       ...code_raw
-    ].map(x => `   ${x}`).join('\n');
+    ].map(x => `    ${x}`).join('\n');
 
     const data = {content};
 
@@ -41,7 +41,7 @@ describe('Indented code block', () => {
   it('with no config (disabled)', () => {
     const content = [
       ...code_raw
-    ].map(x => `   ${x}`).join('\n');
+    ].map(x => `    ${x}`).join('\n');
 
     const data = {content};
 
@@ -58,7 +58,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     codeBlock(data);
@@ -69,7 +69,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     const expected = highlight(code);
@@ -82,7 +82,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     const expected = highlight(code);
@@ -97,7 +97,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...indentCode
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     const expected = highlight(code, {
@@ -113,7 +113,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     const expected = highlight(code, {
@@ -131,7 +131,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     const expected = highlight(code, {
@@ -149,7 +149,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     const expected = highlight(code, {
@@ -166,7 +166,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     const expected = highlight(code, {
@@ -190,7 +190,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     const expected = highlight(code, {
@@ -207,7 +207,7 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `   ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n')
     };
 
     codeBlock(data);

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -140,7 +140,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n');

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -37,6 +37,42 @@ describe('Indented code block', () => {
     data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
+  it('indent in paragraph (not target)', () => {
+    const code_raw = [
+      'test test test',
+      '    hello world',
+      'test test',
+      '    hello',
+      '    world',
+      'test test test'
+    ];
+    const code = code_raw.join('\n') + '\n';
+
+    const data = {
+      content: code
+    };
+
+    codeBlock(data);
+    data.content.should.eql(code);
+  });
+
+  it('nested list items (not target)', () => {
+    const code_raw = [
+      '- aaa',
+      '  - bbb',
+      '    - ccc',
+      '      - ddd'
+    ];
+    const code = code_raw.join('\n') + '\n';
+
+    const data = {
+      content: code
+    };
+
+    codeBlock(data);
+    data.content.should.eql(code);
+  });
+
   it('single tab indent', () => {
     const data = {
       content: [

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -21,6 +21,13 @@ describe('Indented code block', () => {
       .replace(/}/g, '&#125;');
   }
 
+  function wrap(code) {
+    return '<pre><code>' + code
+      .replace(/{/g, '&#123;')
+      .replace(/}/g, '&#125;')
+      + '</code></pre>';
+  }
+
   beforeEach(() => {
     // Reset config
     hexo.config.highlight = Object.assign({}, defaultConfig.highlight);
@@ -35,7 +42,7 @@ describe('Indented code block', () => {
 
     hexo.config.highlight.enable = false;
     codeBlock(data);
-    data.content.should.eql(content);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
   });
 
   it('with no config (disabled)', () => {
@@ -49,7 +56,7 @@ describe('Indented code block', () => {
     delete hexo.config.highlight;
 
     codeBlock(data);
-    data.content.should.eql(content);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
 
     hexo.config.highlight = oldConfig;
   });

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -14,7 +14,7 @@ describe('Indented code block', () => {
   ];
   const code = code_raw.join('\n') + '\n';
   const code_cooked = code_raw.map(x => `    ${x}`);
-  const code_trimmed = code.trim();
+  const code_trimmed = code.replace(/\n$/, '');
 
   function wrap(code) {
     const content = util.escapeHTML(util.stripIndent(code))
@@ -138,7 +138,7 @@ describe('Indented code block', () => {
   it('include blank line (latter half only is target', () => {
     const code_raw = [
       'aaa',
-      '    if (tired && night){',
+      '    if (tired && night){', // lack of preceding blank line
       '    ',
       '      sleep();',
       '    }'
@@ -184,7 +184,7 @@ describe('Indented code block', () => {
   it('include quote mark as content (not target)', () => {
     const code_raw = [
       'aaa',
-      '    > if (tired && night){',
+      '    > if (tired && night){', // lack of preceding blank line
       '    >   sleep();',
       '    > ',
       '    > }'
@@ -216,7 +216,7 @@ describe('Indented code block', () => {
     data.content.should.eql(expected);
   });
 
-  it('included by blockquote (target)', () => {
+  it('included by blockquote (intermediate target)', () => {
     const data = {
       content: [
         'aaa',
@@ -239,12 +239,62 @@ describe('Indented code block', () => {
     data.content.should.eql(expected);
   });
 
-  it('included by blockquote (target, vague notation)', () => {
+  it('included by blockquote (not target)', () => {
+    const data = {
+      content: [
+        'aaa',
+        ...code_cooked, // lack of preceding blank line
+        '',
+        'bbb'
+      ].map(x => `> ${x}`).join('\n') + '\n'
+    };
+
+    const expected = data.content;
+
+    codeBlock(data);
+    data.content.should.eql(expected);
+  });
+
+  it('included by blockquote (intermediate target, last line is a blank line)', () => {
+    const code_raw = [
+      'if (tired && night){',
+      '  sleep();',
+      '}',
+      '' // last line is a blank line
+    ];
+    const code = code_raw.join('\n') + '\n';
+    const code_cooked = code_raw.map(x => `    ${x}`);
+    const code_trimmed = code.replace(/\n$/, '');
+
+
+    const data = {
+      content: [
+        'aaa',
+        '',
+        ...code_cooked,
+        '',
+        'bbb'
+      ].map(x => `> ${x}`).join('\n') + '\n'
+    };
+
+    const expected = [
+      '> aaa',
+      '> ',
+      '> <!--hexoPostRenderEscape:' + wrap(code_trimmed).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
+      '> ',
+      '> bbb'
+    ].join('\n') + '\n';
+
+    codeBlock(data);
+    data.content.should.eql(expected);
+  });
+
+  it('included by blockquote (vague notation, intermediate target)', () => {
     const data = {
       content: [
         '> aaa',
         '> ',
-        ...code_cooked,
+        ...code_cooked, // lack of quote mark
         '> ',
         '> bbb'
       ].join('\n') + '\n'
@@ -254,6 +304,55 @@ describe('Indented code block', () => {
       '> aaa',
       '> ',
       '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->',
+      '> ',
+      '> bbb'
+    ].join('\n') + '\n';
+
+    codeBlock(data);
+    data.content.should.eql(expected);
+  });
+
+  it('included by blockquote (vague notation, not target)', () => {
+    const data = {
+      content: [
+        '> aaa',
+        ...code_cooked, // lack of preceding blank line, lack of quote mark
+        '> ',
+        '> bbb'
+      ].join('\n') + '\n'
+    };
+
+    const expected = data.content;
+
+    codeBlock(data);
+    data.content.should.eql(expected);
+  });
+
+  it('included by blockquote (intermediate blank line, intermediate target)', () => {
+    const code_raw = [
+      'if (tired && night){',
+      '  sleep();',
+      '', // intermediate blank line
+      '}'
+    ];
+    const code = code_raw.join('\n') + '\n';
+    const code_cooked = code_raw.map(x => `    ${x}`);
+    const code_trimmed = code.replace(/\n$/, '');
+
+    const data = {
+      content: [
+        'aaa',
+        '',
+        ...code_cooked,
+        '',
+        'bbb'
+      ].map(x => `> ${x}`).join('\n') + '\n'
+    };
+
+    const expected = [
+      '> aaa',
+      '> ',
+      '> <!--hexoPostRenderEscape:' + wrap(code_trimmed).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -17,7 +17,7 @@ describe('Indented code block', () => {
   const code_trimmed = code.trim();
 
   function wrap(code) {
-    const content = util.escapeHTML(code)
+    const content = util.escapeHTML(util.stripIndent(code))
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;');
     return '<pre><code>' + content + '</code></pre>';
@@ -135,10 +135,38 @@ describe('Indented code block', () => {
     data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
+  it('include blank line (latter half only is target', () => {
+    const code_raw = [
+      'aaa',
+      '    if (tired && night){',
+      '    ',
+      '      sleep();',
+      '    }'
+    ];
+    const code = code_raw.slice(3).join('\n') + '\n';
+
+    const data = {
+      content: [
+        ...code_raw
+      ].join('\n') + '\n'
+    };
+
+    const expected = [
+      'aaa',
+      '    if (tired && night){',
+      '    ',
+      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->'
+    ].join('\n') + '\n';
+
+    codeBlock(data);
+    data.content.should.eql(expected);
+  });
+
   it('include quote mark as content', () => {
     const code_raw = [
       '> if (tired && night){',
       '>   sleep();',
+      '> ',
       '> }'
     ];
     const code = code_raw.join('\n') + '\n';
@@ -151,6 +179,26 @@ describe('Indented code block', () => {
 
     codeBlock(data);
     data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
+  });
+
+  it('include quote mark as content (not target)', () => {
+    const code_raw = [
+      'aaa',
+      '    > if (tired && night){',
+      '    >   sleep();',
+      '    > ',
+      '    > }'
+    ];
+    const code = code_raw.join('\n') + '\n';
+
+    const data = {
+      content: [
+        ...code_raw
+      ].join('\n') + '\n'
+    };
+
+    codeBlock(data);
+    data.content.should.eql(code);
   });
 
   it('included by blockquote (target, only itself)', () => {

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -126,7 +126,7 @@ describe('Indented code block', () => {
     data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
   });
 
-  it('include blank line', () => {
+  it('include indented blank line', () => {
     const code_raw = [
       'if (tired && night){',
       '',
@@ -144,6 +144,30 @@ describe('Indented code block', () => {
 
     codeBlock(data);
     data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
+  });
+
+  it('include non-indented blank line', () => {
+    const code_raw = [
+      'if (tired && night){',
+      '  sleep();',
+      '',
+      '}'
+    ];
+    const code_cooked = code_raw.map(x => `    ${x}`).map(x => x.replace(/^ {4}$/, ''));
+
+    const data = {
+      content: [
+        ...code_cooked
+      ].join('\n') + '\n'
+    };
+
+    const expected = [
+      '<!--hexoPostRenderEscape:' + wrap(code_cooked.slice(0, 2).join('\n') + '\n') + ':hexoPostRenderEscape-->\n',
+      '<!--hexoPostRenderEscape:' + wrap('\n' + code_cooked.slice(3, 4).join('\n') + '\n') + ':hexoPostRenderEscape-->\n'
+    ].join('\n') + '\n';
+
+    codeBlock(data);
+    data.content.should.eql(expected);
   });
 
   it('include blank line (latter half only is target', () => {

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -45,7 +45,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('indent in paragraph (not target)', () => {
@@ -92,7 +92,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('extra indent', () => {
@@ -105,7 +105,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('include tab', () => {
@@ -123,7 +123,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('include indented blank line', () => {
@@ -143,7 +143,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('include non-indented blank line', () => {
@@ -162,9 +162,9 @@ describe('Indented code block', () => {
     };
 
     const expected = [
-      '<!--hexoPostRenderEscape:' + wrap(code_cooked.slice(0, 2).join('\n') + '\n') + ':hexoPostRenderEscape-->\n',
+      '<!--hexoPostRenderEscape:' + wrap(code_cooked.slice(0, 2).join('\n') + '\n') + ':hexoPostRenderEscape-->',
       '',
-      '<!--hexoPostRenderEscape:' + wrap(code_cooked.slice(3, 4).join('\n') + '\n') + ':hexoPostRenderEscape-->\n'
+      '<!--hexoPostRenderEscape:' + wrap(code_cooked.slice(3, 4).join('\n') + '\n') + ':hexoPostRenderEscape-->'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -191,7 +191,7 @@ describe('Indented code block', () => {
       'aaa',
       '    if (tired && night){',
       '    ',
-      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n'
+      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -214,7 +214,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('include quote mark as content (not target)', () => {
@@ -245,7 +245,7 @@ describe('Indented code block', () => {
     };
 
     const expected = [
-      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->\n'
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -266,7 +266,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->\n',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -314,7 +314,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->\n',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -337,7 +337,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n',
+      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -385,7 +385,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->\n',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -14,7 +14,6 @@ describe('Indented code block', () => {
   ];
   const code = code_raw.join('\n') + '\n';
   const code_cooked = code_raw.map(x => `    ${x}`);
-  const code_trimmed = code.replace(/\n$/, '');
 
   function wrap(code) {
     const content = util.escapeHTML(util.stripIndent(code))
@@ -209,7 +208,7 @@ describe('Indented code block', () => {
     };
 
     const expected = [
-      '> <!--hexoPostRenderEscape:' + wrap(code_trimmed).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->'
+      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -230,7 +229,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap(code_trimmed).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -264,8 +263,6 @@ describe('Indented code block', () => {
     ];
     const code = code_raw.join('\n') + '\n';
     const code_cooked = code_raw.map(x => `    ${x}`);
-    const code_trimmed = code.replace(/\n$/, '');
-
 
     const data = {
       content: [
@@ -280,7 +277,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap(code_trimmed).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -337,7 +334,6 @@ describe('Indented code block', () => {
     ];
     const code = code_raw.join('\n') + '\n';
     const code_cooked = code_raw.map(x => `    ${x}`);
-    const code_trimmed = code.replace(/\n$/, '');
 
     const data = {
       content: [
@@ -352,7 +348,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap(code_trimmed).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -77,6 +77,26 @@ describe('Indented code block', () => {
     data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
   });
 
+  it('include blank line', () => {
+    const code_raw = [
+      'if (tired && night){',
+      '',
+      '  sleep();',
+      '',
+      '}'
+    ];
+    const code = code_raw.join('\n');
+
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `    ${x}`).join('\n')
+    };
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+  });
+
   it('include quote mark as content', () => {
     const code_raw = [
       '> if (tired && night){',

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -18,7 +18,8 @@ describe('Indented code block', () => {
   function wrap(code) {
     const content = util.escapeHTML(util.stripIndent(code))
       .replace(/{/g, '&#123;')
-      .replace(/}/g, '&#125;');
+      .replace(/}/g, '&#125;')
+      .replace(/\n$/, '');
     return '<pre><code>' + content + '</code></pre>';
   }
 
@@ -27,7 +28,9 @@ describe('Indented code block', () => {
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;')
       .replace(/^/mg, '> ')
-      .replace(/^> /, '');
+      .replace(/^> /, '')
+      .replace(/> $/, '')
+      .replace(/\n$/, '');
     return '<pre><code>' + content + '</code></pre>';
   }
 
@@ -42,7 +45,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
   });
 
   it('indent in paragraph (not target)', () => {
@@ -89,7 +92,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
   });
 
   it('extra indent', () => {
@@ -102,7 +105,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
   });
 
   it('include tab', () => {
@@ -120,7 +123,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
   });
 
   it('include blank line', () => {
@@ -140,7 +143,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
   });
 
   it('include blank line (latter half only is target', () => {
@@ -151,7 +154,7 @@ describe('Indented code block', () => {
       '      sleep();',
       '    }'
     ];
-    const code = code_raw.slice(3).join('\n') + '\n';
+    const code = code_raw.slice(2).join('\n') + '\n';
 
     const data = {
       content: [
@@ -162,8 +165,7 @@ describe('Indented code block', () => {
     const expected = [
       'aaa',
       '    if (tired && night){',
-      '    ',
-      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->'
+      ' <!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -186,7 +188,7 @@ describe('Indented code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n\n');
   });
 
   it('include quote mark as content (not target)', () => {
@@ -217,7 +219,7 @@ describe('Indented code block', () => {
     };
 
     const expected = [
-      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->'
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->\n'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -237,8 +239,7 @@ describe('Indented code block', () => {
 
     const expected = [
       '> aaa',
-      '> ',
-      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
+      '> > <!--hexoPostRenderEscape:' + wrapWithHack('\n' + code) + ':hexoPostRenderEscape-->\n',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -285,8 +286,7 @@ describe('Indented code block', () => {
 
     const expected = [
       '> aaa',
-      '> ',
-      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
+      '> > <!--hexoPostRenderEscape:' + wrapWithHack('\n' + code) + ':hexoPostRenderEscape-->\n',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -308,8 +308,7 @@ describe('Indented code block', () => {
 
     const expected = [
       '> aaa',
-      '> ',
-      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap('\n' + code) + ':hexoPostRenderEscape-->\n',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -356,8 +355,7 @@ describe('Indented code block', () => {
 
     const expected = [
       '> aaa',
-      '> ',
-      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->',
+      '> > <!--hexoPostRenderEscape:' + wrapWithHack('\n' + code) + ':hexoPostRenderEscape-->\n',
       '> ',
       '> bbb'
     ].join('\n') + '\n';

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -1,0 +1,218 @@
+'use strict';
+
+const util = require('hexo-util');
+const defaultConfig = require('../../../lib/hexo/default_config');
+
+describe('Indented code block', () => {
+  const Hexo = require('../../../lib/hexo');
+  const hexo = new Hexo();
+  const codeBlock = require('../../../lib/plugins/filter/before_post_render/indented_code_block').bind(hexo);
+
+  const code_raw = [
+    'if (tired && night){',
+    '  sleep();',
+    '}'
+  ];
+  const code = code_raw.join('\n');
+
+  function highlight(code, options) {
+    return util.highlight(code, options || {})
+      .replace(/{/g, '&#123;')
+      .replace(/}/g, '&#125;');
+  }
+
+  beforeEach(() => {
+    // Reset config
+    hexo.config.highlight = Object.assign({}, defaultConfig.highlight);
+  });
+
+  it('disabled', () => {
+    const content = [
+      ...code_raw
+    ].map(x => `   ${x}`).join('\n');
+
+    const data = {content};
+
+    hexo.config.highlight.enable = false;
+    codeBlock(data);
+    data.content.should.eql(content);
+  });
+
+  it('with no config (disabled)', () => {
+    const content = [
+      ...code_raw
+    ].map(x => `   ${x}`).join('\n');
+
+    const data = {content};
+
+    const oldConfig = hexo.config.highlight;
+    delete hexo.config.highlight;
+
+    codeBlock(data);
+    data.content.should.eql(content);
+
+    hexo.config.highlight = oldConfig;
+  });
+
+  it('default', () => {
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code, {}) + ':hexoPostRenderEscape-->');
+  });
+
+  it('without language name', () => {
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    const expected = highlight(code);
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+  });
+
+  it('without language name - ignore tab character', () => {
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    const expected = highlight(code);
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+  });
+
+  it('indent', () => {
+    const indentCode = code_raw.map(line => '  ' + line);
+
+    const data = {
+      content: [
+        ...indentCode
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    const expected = highlight(code, {
+    });
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+  });
+
+  it('line number false', () => {
+    hexo.config.highlight.line_number = false;
+
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    const expected = highlight(code, {
+      gutter: false
+    });
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+  });
+
+  it('line number false, don`t first_line_number always1', () => {
+    hexo.config.highlight.line_number = false;
+    hexo.config.highlight.first_line_number = 'always1';
+
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    const expected = highlight(code, {
+      gutter: false
+    });
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+  });
+
+  it('line number false, don`t care first_line_number inilne', () => {
+    hexo.config.highlight.line_number = false;
+    hexo.config.highlight.first_line_number = 'inilne';
+
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    const expected = highlight(code, {
+      gutter: false
+    });
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+  });
+
+  it('line number true', () => {
+    hexo.config.highlight.line_number = true;
+
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    const expected = highlight(code, {
+      gutter: true
+    });
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+  });
+
+  it('tab replace', () => {
+    hexo.config.highlight.tab_replace = '  ';
+
+    const code_raw = [
+      'if (tired && night){',
+      '\tsleep();',
+      '}'
+    ];
+    const code = code_raw.join('\n');
+
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    const expected = highlight(code, {
+      tab: '  '
+    });
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+  });
+
+  it('wrap', () => {
+    hexo.config.highlight.wrap = false;
+
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `   ${x}`).join('\n')
+    };
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code, {wrap: false }) + ':hexoPostRenderEscape-->');
+
+    hexo.config.highlight.wrap = true;
+  });
+});

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -12,7 +12,9 @@ describe('Indented code block', () => {
     '  sleep();',
     '}'
   ];
-  const code = code_raw.join('\n');
+  const code = code_raw.join('\n') + '\n';
+  const code_cooked = code_raw.map(x => `    ${x}`);
+  const code_trimmed = code.trim();
 
   function wrap(code) {
     const content = util.escapeHTML(code)
@@ -28,22 +30,22 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `    ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n') + '\n'
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('single tab indent', () => {
     const data = {
       content: [
         ...code_raw
-      ].map(x => `\t${x}`).join('\n')
+      ].map(x => `\t${x}`).join('\n') + '\n'
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('extra indent', () => {
@@ -52,11 +54,11 @@ describe('Indented code block', () => {
     const data = {
       content: [
         ...indentCode
-      ].map(x => `    ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n') + '\n'
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('include tab', () => {
@@ -65,16 +67,16 @@ describe('Indented code block', () => {
       '\tsleep();',
       '}'
     ];
-    const code = code_raw.join('\n');
+    const code = code_raw.join('\n') + '\n';
 
     const data = {
       content: [
         ...code_raw
-      ].map(x => `    ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n') + '\n'
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('include blank line', () => {
@@ -85,16 +87,16 @@ describe('Indented code block', () => {
       '',
       '}'
     ];
-    const code = code_raw.join('\n');
+    const code = code_raw.join('\n') + '\n';
 
     const data = {
       content: [
         ...code_raw
-      ].map(x => `    ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n') + '\n'
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
   it('include quote mark as content', () => {
@@ -103,30 +105,34 @@ describe('Indented code block', () => {
       '>   sleep();',
       '> }'
     ];
-    const code = code_raw.join('\n');
+    const code = code_raw.join('\n') + '\n';
 
     const data = {
       content: [
         ...code_raw
-      ].map(x => `    ${x}`).join('\n')
+      ].map(x => `    ${x}`).join('\n') + '\n'
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n');
   });
 
-  it('included by blockquote', () => {
-    const code_raw = [
-      'if (tired && night){',
-      '  sleep();',
-      '}'
-    ];
-    const code = code_raw.join('\n');
+  it('included by blockquote (target, only itself)', () => {
+    const data = {
+      content: [
+        ...code_cooked
+      ].map(x => `> ${x}`).join('\n') + '\n'
+    };
 
-    const code_cooked = [
-      ...code_raw
-    ].map(x => `    ${x}`);
+    const expected = [
+      '> <!--hexoPostRenderEscape:' + wrap(code_trimmed).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->'
+    ].join('\n') + '\n';
 
+    codeBlock(data);
+    data.content.should.eql(expected);
+  });
+
+  it('included by blockquote (target)', () => {
     const data = {
       content: [
         'aaa',
@@ -134,16 +140,39 @@ describe('Indented code block', () => {
         ...code_cooked,
         '',
         'bbb'
-      ].map(x => `> ${x}`).join('\n')
+      ].map(x => `> ${x}`).join('\n') + '\n'
     };
 
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap(code).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap(code_trimmed).replace(/^/mg, '> ') + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
-    ].join('\n');
+    ].join('\n') + '\n';
+
+    codeBlock(data);
+    data.content.should.eql(expected);
+  });
+
+  it('included by blockquote (target, vague notation)', () => {
+    const data = {
+      content: [
+        '> aaa',
+        '> ',
+        ...code_cooked,
+        '> ',
+        '> bbb'
+      ].join('\n') + '\n'
+    };
+
+    const expected = [
+      '> aaa',
+      '> ',
+      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->',
+      '> ',
+      '> bbb'
+    ].join('\n') + '\n';
 
     codeBlock(data);
     data.content.should.eql(expected);

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -163,7 +163,8 @@ describe('Indented code block', () => {
 
     const expected = [
       '<!--hexoPostRenderEscape:' + wrap(code_cooked.slice(0, 2).join('\n') + '\n') + ':hexoPostRenderEscape-->\n',
-      '<!--hexoPostRenderEscape:' + wrap('\n' + code_cooked.slice(3, 4).join('\n') + '\n') + ':hexoPostRenderEscape-->\n'
+      '',
+      '<!--hexoPostRenderEscape:' + wrap(code_cooked.slice(3, 4).join('\n') + '\n') + ':hexoPostRenderEscape-->\n'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -178,7 +179,7 @@ describe('Indented code block', () => {
       '      sleep();',
       '    }'
     ];
-    const code = code_raw.slice(2).join('\n') + '\n';
+    const code = code_raw.slice(3).join('\n') + '\n';
 
     const data = {
       content: [
@@ -189,7 +190,8 @@ describe('Indented code block', () => {
     const expected = [
       'aaa',
       '    if (tired && night){',
-      ' <!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n'
+      '    ',
+      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -263,7 +265,8 @@ describe('Indented code block', () => {
 
     const expected = [
       '> aaa',
-      '> > <!--hexoPostRenderEscape:' + wrapWithHack('\n' + code) + ':hexoPostRenderEscape-->\n',
+      '> ',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->\n',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -310,7 +313,8 @@ describe('Indented code block', () => {
 
     const expected = [
       '> aaa',
-      '> > <!--hexoPostRenderEscape:' + wrapWithHack('\n' + code) + ':hexoPostRenderEscape-->\n',
+      '> ',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->\n',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -332,7 +336,8 @@ describe('Indented code block', () => {
 
     const expected = [
       '> aaa',
-      '> <!--hexoPostRenderEscape:' + wrap('\n' + code) + ':hexoPostRenderEscape-->\n',
+      '> ',
+      '<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->\n',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -379,7 +384,8 @@ describe('Indented code block', () => {
 
     const expected = [
       '> aaa',
-      '> > <!--hexoPostRenderEscape:' + wrapWithHack('\n' + code) + ':hexoPostRenderEscape-->\n',
+      '> ',
+      '> <!--hexoPostRenderEscape:' + wrapWithHack(code) + ':hexoPostRenderEscape-->\n',
       '> ',
       '> bbb'
     ].join('\n') + '\n';

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -35,7 +35,18 @@ describe('Indented code block', () => {
     data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
   });
 
-  it('indent', () => {
+  it('single tab indent', () => {
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `\t${x}`).join('\n')
+    };
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+  });
+
+  it('extra indent', () => {
     const indentCode = code_raw.map(line => '  ' + line);
 
     const data = {
@@ -64,5 +75,57 @@ describe('Indented code block', () => {
 
     codeBlock(data);
     data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+  });
+
+  it('include quote mark as content', () => {
+    const code_raw = [
+      '> if (tired && night){',
+      '>   sleep();',
+      '> }'
+    ];
+    const code = code_raw.join('\n');
+
+    const data = {
+      content: [
+        ...code_raw
+      ].map(x => `    ${x}`).join('\n')
+    };
+
+    codeBlock(data);
+    data.content.should.eql('<!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->');
+  });
+
+  it('included by blockquote', () => {
+    const code_raw = [
+      'if (tired && night){',
+      '  sleep();',
+      '}'
+    ];
+    const code = code_raw.join('\n');
+
+    const code_cooked = [
+      ...code_raw
+    ].map(x => `    ${x}`);
+
+    const data = {
+      content: [
+        'aaa',
+        '',
+        ...code_cooked,
+        '',
+        'bbb'
+      ].map(x => `> ${x}`).join('\n')
+    };
+
+    const expected = [
+      '> aaa',
+      '> ',
+      '> <!--hexoPostRenderEscape:' + wrap(code) + ':hexoPostRenderEscape-->',
+      '> ',
+      '> bbb'
+    ].join('\n');
+
+    codeBlock(data);
+    data.content.should.eql(expected);
   });
 });

--- a/test/scripts/filters/indented_code_block.js
+++ b/test/scripts/filters/indented_code_block.js
@@ -22,7 +22,7 @@ describe('Indented code block', () => {
     return '<pre><code>' + content + '</code></pre>';
   }
 
-  function wrap_with_quote(code) {
+  function wrap_with_hack(code) {
     const content = util.escapeHTML(util.stripIndent(code))
       .replace(/{/g, '&#123;')
       .replace(/}/g, '&#125;')
@@ -217,7 +217,7 @@ describe('Indented code block', () => {
     };
 
     const expected = [
-      '> <!--hexoPostRenderEscape:' + wrap_with_quote(code) + ':hexoPostRenderEscape-->'
+      '> <!--hexoPostRenderEscape:' + wrap_with_hack(code) + ':hexoPostRenderEscape-->'
     ].join('\n') + '\n';
 
     codeBlock(data);
@@ -238,7 +238,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap_with_quote(code) + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap_with_hack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -286,7 +286,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap_with_quote(code) + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap_with_hack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';
@@ -357,7 +357,7 @@ describe('Indented code block', () => {
     const expected = [
       '> aaa',
       '> ',
-      '> <!--hexoPostRenderEscape:' + wrap_with_quote(code) + ':hexoPostRenderEscape-->',
+      '> <!--hexoPostRenderEscape:' + wrap_with_hack(code) + ':hexoPostRenderEscape-->',
       '> ',
       '> bbb'
     ].join('\n') + '\n';

--- a/test/scripts/filters/index.js
+++ b/test/scripts/filters/index.js
@@ -5,6 +5,7 @@ describe('Filters', () => {
   require('./excerpt');
   require('./external_link');
   require('./i18n_locals');
+  require('./indented_code_block');
   require('./meta_generator');
   require('./new_post_path');
   require('./post_permalink');


### PR DESCRIPTION
## What does it do?

Supplement of the PR #4171, for the issue #4087.

Since the PR #4171 changes rendering order,
Nunjucks tags in indented code blocks become targets of rendering by Nunjucks.
This is undesirable.

This situation can be observed in the issue #4087.

This patch escapes Nunjucks tags in indented code blocks before rendering by Nunjucks.


## How to test

```sh
git clone -b feature/escape_indented_code_block_before_render https://github.com/seaoak/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
