### PR TITLE
Fix mismatching between TOC helper and `hexo-util.htmlTag`

### DIFF
--- a/lib/plugins/helper/toc.js
+++ b/lib/plugins/helper/toc.js
@@ -25,7 +25,7 @@ function tocHelper(str, options = {}) {
   for (let i = 0, len = data.length; i < len; i++) {
     const el = data[i];
     const { level, id, text } = el;
-    const href = id ? `#${id}` : id;
+    const href = id ? `#${id}` : null;
 
     lastNumber[level - 1]++;
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fix the issue #4181.

Unit test of Hexo fails for two items of TOC helper function.
This is caused by mismatching between TOC helper and `hexo-util.htmlTag`.
(I guess it only by test case and source codes.)

## How to test

```sh
git clone -b bugfix/test_failed_for_toc_helper https://github.com/seaoak/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
