### PR TITLE
refactor(toc): avoid using htmlTag

### DIFF
--- a/lib/plugins/helper/toc.js
+++ b/lib/plugins/helper/toc.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { htmlTag, tocObj } = require('hexo-util');
+const { tocObj, escapeHTML, encodeURL } = require('hexo-util');
 
 function tocHelper(str, options = {}) {
   options = Object.assign({
@@ -14,10 +14,11 @@ function tocHelper(str, options = {}) {
 
   if (!data.length) return '';
 
-  const className = options.class;
+  const className = escapeHTML(options.class);
   const listNumber = options.list_number;
 
-  let result = htmlTag('ol', { class: className });
+  let result = `<ol class="${className}">`;
+
   const lastNumber = [0, 0, 0, 0, 0, 0];
   let firstLevel = 0;
   let lastLevel = 0;
@@ -25,7 +26,7 @@ function tocHelper(str, options = {}) {
   for (let i = 0, len = data.length; i < len; i++) {
     const el = data[i];
     const { level, id, text } = el;
-    const href = id ? `#${id}` : id;
+    const href = id ? `#${encodeURL(id)}` : null;
 
     lastNumber[level - 1]++;
 
@@ -39,7 +40,7 @@ function tocHelper(str, options = {}) {
       }
 
       if (level > lastLevel) {
-        result += htmlTag('ol', { class: `${className}-child` });
+        result += `<ol class="${className}-child">`;
       } else {
         result += '</li>';
       }
@@ -47,11 +48,16 @@ function tocHelper(str, options = {}) {
       firstLevel = level;
     }
 
-    result += htmlTag('li', { class: `${className}-item ${className}-level-${level}` });
-    result += htmlTag('a', { class: `${className}-link`, href });
+    result += `<li class="${className}-item ${className}-level-${level}">`;
+    if (href) {
+      result += `<a class="${className}-link" href="${href}">`;
+    } else {
+      result += `<a class="${className}-link">`;
+    }
+
 
     if (listNumber) {
-      result += htmlTag('span', { class: `${className}-number` });
+      result += `<span class="${className}-number">`;
 
       for (let i = firstLevel - 1; i < level; i++) {
         result += `${lastNumber[i]}.`;
@@ -60,7 +66,7 @@ function tocHelper(str, options = {}) {
       result += '</span> ';
     }
 
-    result += htmlTag('span', { class: `${className}-text` }, text) + '</a>';
+    result += `<span class="${className}-text">${text}</span></a>`;
 
     lastLevel = level;
   }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fix #4181, an alternative to #4182. 

By avoid using over complicated `htmlTag()` to gain better performance and fit the current test cases.

## How to test

```sh
git clone -b refactor/og-remove-htmltag https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
