### PR TITLE
feat(post_ermalink): add `:second` attr option for post permalink

### DIFF
--- a/lib/plugins/filter/post_permalink.js
+++ b/lib/plugins/filter/post_permalink.js
@@ -20,6 +20,7 @@ function postPermalinkFilter(data) {
     day: date.format('DD'),
     hour: date.format('HH'),
     minute: date.format('mm'),
+    second: date.format('ss'),
     i_month: date.format('M'),
     i_day: date.format('D'),
     hash

--- a/test/scripts/filters/post_permalink.js
+++ b/test/scripts/filters/post_permalink.js
@@ -82,16 +82,16 @@ describe('post_permalink', () => {
     Post.removeById(post._id);
   });
 
-  it('hour and minute', async () => {
-    hexo.config.permalink = ':year/:month/:day/:hour/:minute/:post_title/';
+  it('hour minute and second', async () => {
+    hexo.config.permalink = ':year/:month/:day/:hour/:minute/:second/:post_title/';
 
     const post = await Post.insert({
       source: 'sub/2015-05-06-my-new-post.md',
       slug: '2015-05-06-my-new-post',
       title: 'My New Post',
-      date: moment('2015-05-06 12:13')
+      date: moment('2015-05-06 12:13:14')
     });
-    postPermalink(post).should.eql('2015/05/06/12/13/my-new-post/');
+    postPermalink(post).should.eql('2015/05/06/12/13/14/my-new-post/');
     Post.removeById(post._id);
   });
 

--- a/test/scripts/filters/post_permalink.js
+++ b/test/scripts/filters/post_permalink.js
@@ -96,7 +96,7 @@ describe('post_permalink', () => {
   });
 
   it('time is omitted in front-matter', async () => {
-    hexo.config.permalink = ':year/:month/:day/:hour/:minute/:post_title/';
+    hexo.config.permalink = ':year/:month/:day/:hour/:minute/:second/:post_title/';
 
     const post = await Post.insert({
       source: 'sub/2015-05-06-my-new-post.md',
@@ -104,7 +104,7 @@ describe('post_permalink', () => {
       title: 'My New Post',
       date: moment('2015-05-06')
     });
-    postPermalink(post).should.eql('2015/05/06/00/00/my-new-post/');
+    postPermalink(post).should.eql('2015/05/06/00/00/00/my-new-post/');
     Post.removeById(post._id);
   });
 


### PR DESCRIPTION
## What does it do?

Like this:
```
# _config.yml
permalink: :year/:month/:day/:hour/:minute/:second/:post_title/
```
Will generate:
```
example.com/2015/05/06/12/13/14/my-new-post/
```

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
