### PR TITLE
Bugfix/parsing code error in backticks

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -2,14 +2,15 @@
 
 const { highlight } = require('hexo-util');
 
-const rBacktick = /^((?:[^\S\r\n]*>){0,3}[^\S\r\n]*)(`{3,}|~{3,}) *(.*) *\n([\s\S]+?)\s*\2(\n+|$)/gm;
+const rBacktick = /^((?:[^\S\r\n]*>){0,3}[^\S\r\n]*)(`{3,}|~{3,})[^\S\r\n]*((?:.*?[^`\s])?)[^\S\r\n]*\n((?:[\s\S]*?\n)?)(?:(?:[^\S\r\n]*>){0,3}[^\S\r\n]*)\2(\n+|$)/gm;
 const rAllOptions = /([^\s]+)\s+(.+?)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/;
 const rLangCaption = /([^\s]+)\s*(.+)?/;
 
 function backtickCodeBlock(data) {
   const config = this.config.highlight || {};
   if (!config.enable) return;
-  data.content = data.content.replace(rBacktick, ($0, start, $2, _args, content, end) => {
+  data.content = data.content.replace(rBacktick, ($0, start, $2, _args, _content, end) => {
+    let content = _content.replace(/\n$/, '');
     const args = _args.split('=').shift();
 
     const options = {
@@ -52,10 +53,10 @@ function backtickCodeBlock(data) {
 
     // PR #3765
     if (start.includes('>')) {
+      // headding of last line is already removed by the top RegExp "rBacktick"
       const depth = start.split('>').length - 1;
       const regexp = new RegExp(`^([^\\S\\r\\n]*>){0,${depth}}([^\\S\\r\\n]|$)`, 'mg');
-      const paddingOnEnd = ' '; // complement uncaptured whitespaces at last line
-      content = (content + paddingOnEnd).replace(regexp, '').replace(/\n$/, '');
+      content = content.replace(regexp, '');
     }
 
     content = highlight(content, options)

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -386,4 +386,38 @@ describe('Backtick code block', () => {
 
     hexo.config.highlight.wrap = true;
   });
+
+  // test for Issue #4220
+  it('skip a Swig template', () => {
+    const data = {
+      content: [
+        '```foo```',
+        '',
+        '```',
+        code,
+        '```'
+      ].join('\n')
+    };
+
+    codeBlock(data);
+    data.content.should.eql('```foo```\n\n<escape>' + highlight(code, {}) + '</escape>');
+  });
+
+  // test for Issue #4190
+  it('ignore triple backticks at the line which is started by extra characters', () => {
+    const data = {
+      content: [
+        '```',
+        code,
+        'foo```',
+        '',
+        'bar```',
+        'baz',
+        '```'
+      ].join('\n')
+    };
+
+    codeBlock(data);
+    data.content.should.eql('<escape>' + highlight(code + '\nfoo```\n\nbar```\nbaz', {}) + '</escape>');
+  });
 });


### PR DESCRIPTION
## What does it do?

Fix the issue #4190 and #4220.

Current `backtick_code_block` filter does not consider a Swig template
which form is a pair of triple backticks in single line.

This patch makes the filter to ignore such lines.

And also the filter mistook triple-backtick as the end of targets
even if there are some extra characters at the head of line.

This patch fixes it too.

## How to test

```sh
git clone -b bugfix/parsing_code_error_in_backticks https://github.com/seaoak/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
