### PR TITLE
perf(open_graph): replace striptags with regexp

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -2,7 +2,8 @@
 
 const { parse, resolve } = require('url');
 const { isMoment, isDate } = require('moment');
-const { encodeURL, prettyUrls, htmlTag, stripHTML, escapeHTML, Cache } = require('hexo-util');
+const { encodeURL, prettyUrls, htmlTag, escapeHTML, Cache } = require('hexo-util');
+const stripHTML = str => str.replace(/<[^>]+?>/ig, '');
 
 const localeMap = {
   'en': 'en_US',


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

hexo-util's `stripHTML()` is using `striptags`, which is designed to be able to handle any invalid html made by XSS attacker.

However, the stripHTML here only needs to handle `page.content`, which is definitely valid HTML as it is generated by renderer (marked, Nunjucks, etc.), a simple regexp will do the job well then.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

The performance of generation improved by 7% according to the benchmark.

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
