### PR TITLE
feat: bring up config.updated_option

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -55,8 +55,10 @@ module.exports = {
   // Date / Time format
   date_format: 'YYYY-MM-DD',
   time_format: 'HH:mm:ss',
-  // Use post date for updated date instead of file modification date when front-matter provides no updated date
-  use_date_for_updated: false,
+  updated_option: 'mtime',
+  // * mtime: file modification date (default)
+  // * date: use_date_for_updated
+  // * empty: no more update
   // Pagination
   per_page: 10,
   pagination_dir: 'page',

--- a/lib/models/page.js
+++ b/lib/models/page.js
@@ -17,7 +17,6 @@ module.exports = ctx => {
     },
     updated: {
       type: Moment,
-      default: moment,
       language: ctx.config.languages,
       timezone: ctx.config.timezone
     },

--- a/lib/models/post.js
+++ b/lib/models/post.js
@@ -27,7 +27,6 @@ module.exports = ctx => {
     },
     updated: {
       type: Moment,
-      default: moment,
       language: ctx.config.languages,
       timezone: ctx.config.timezone
     },

--- a/lib/plugins/processor/asset.js
+++ b/lib/plugins/processor/asset.js
@@ -48,12 +48,8 @@ module.exports = ctx => {
 
       if (data.updated) {
         if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg);
-      } else if (use_date_for_updated) {
+      } else if (use_date_for_updated || updated_option === 'date') {
         data.updated = data.date;
-      } else if (updated_option === 'date') {
-        data.updated = data.date;
-      } else if (updated_option === 'mtime') {
-        data.updated = stats.mtime;
       } else if (updated_option === 'empty') {
         delete data.updated;
       } else {

--- a/lib/plugins/processor/asset.js
+++ b/lib/plugins/processor/asset.js
@@ -12,7 +12,7 @@ module.exports = ctx => {
     const { path } = file;
     const doc = Page.findOne({source: path});
     const { config } = ctx;
-    const { timezone: timezoneCfg, use_date_for_updated } = config;
+    const { timezone: timezoneCfg, use_date_for_updated, updated_option } = config;
 
     if (file.type === 'skip' && doc) {
       return;
@@ -50,6 +50,12 @@ module.exports = ctx => {
         if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg);
       } else if (use_date_for_updated) {
         data.updated = data.date;
+      } else if (updated_option === 'date') {
+        data.updated = data.date;
+      } else if (updated_option === 'mtime') {
+        data.updated = stats.mtime;
+      } else if (updated_option === 'empty') {
+        delete data.updated;
       } else {
         data.updated = stats.mtime;
       }

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -85,12 +85,8 @@ module.exports = ctx => {
 
       if (data.updated) {
         if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg);
-      } else if (use_date_for_updated) {
+      } else if (use_date_for_updated || updated_option === 'date') {
         data.updated = data.date;
-      } else if (updated_option === 'date') {
-        data.updated = data.date;
-      } else if (updated_option === 'mtime') {
-        data.updated = stats.mtime;
       } else if (updated_option === 'empty') {
         delete data.updated;
       } else {

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -27,7 +27,7 @@ module.exports = ctx => {
     const { path } = file.params;
     const doc = Post.findOne({source: file.path});
     const { config } = ctx;
-    const { timezone: timezoneCfg, use_date_for_updated } = config;
+    const { timezone: timezoneCfg, use_date_for_updated, updated_option } = config;
     let categories, tags;
 
     if (file.type === 'skip' && doc) {
@@ -87,6 +87,12 @@ module.exports = ctx => {
         if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg);
       } else if (use_date_for_updated) {
         data.updated = data.date;
+      } else if (updated_option === 'date') {
+        data.updated = data.date;
+      } else if (updated_option === 'mtime') {
+        data.updated = stats.mtime;
+      } else if (updated_option === 'empty') {
+        delete data.updated;
       } else {
         data.updated = stats.mtime;
       }

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -43,7 +43,9 @@ describe('open_graph', () => {
       meta({property: 'og:site_name', content: hexo.config.title}),
       meta({property: 'og:locale', content: 'en_US'}),
       meta({property: 'article:published_time', content: post.date.toISOString()}),
-      meta({property: 'article:modified_time', content: post.updated.toISOString()}),
+      // page.updated will no longer exist by default
+      // See https://github.com/hexojs/hexo/pull/4278
+      // meta({property: 'article:modified_time', content: post.updated.toISOString()}),
       meta({property: 'article:author', content: hexo.config.author}),
       meta({property: 'article:tag', content: 'optimize'}),
       meta({property: 'article:tag', content: 'web'}),

--- a/test/scripts/models/page.js
+++ b/test/scripts/models/page.js
@@ -21,11 +21,11 @@ describe('Page', () => {
 
     data.title.should.eql('');
     data.date.valueOf().should.gte(now);
-    data.updated.valueOf().should.gte(now);
     data.comments.should.be.true;
     data.layout.should.eql('page');
     data._content.should.eql('');
     data.raw.should.eql('');
+    should.not.exist(data.updated);
     should.not.exist(data.content);
     should.not.exist(data.excerpt);
     should.not.exist(data.more);

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -28,13 +28,13 @@ describe('Post', () => {
     }).then(data => {
       data.title.should.eql('');
       data.date.valueOf().should.gte(now);
-      data.updated.valueOf().should.gte(now);
       data.comments.should.be.true;
       data.layout.should.eql('post');
       data._content.should.eql('');
       data.link.should.eql('');
       data.raw.should.eql('');
       data.published.should.be.true;
+      should.not.exist(data.updated);
       should.not.exist(data.content);
       should.not.exist(data.excerpt);
       should.not.exist(data.more);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Continuation of #3235, specifically #3235 (comment). https://github.com/hexojs/hexo/pull/3887#issuecomment-567723586

Quote from #3887

> User may prefer to have full control on value of post.updated and not use file modification time. Currently for my blog, I have to use a new variable lastUpdated as a workaround; since that variable is not recognized by many plugins, I have to fork many plugins.
>
> With this PR, config.optional_updated can be enabled (disabled by default), to leave post.updated to be empty if updated: is not set in the front-matter.

This PR introduced a new option `updated_option` which accept:

- `mtime`: This is the default behavior of hexo, use file's `mtime` as `data.updated` when not set in front-matter.
- `date`: Use `data.date` as `data.updated` when not set in front-matter.
- `empty`: Completely remove `data.updated` when not set in front-matter. This shouldn't be used by common users as it *will* break many themes (like NexT) and plugins (like hexo-generator-feed)

The `use_date_for_updated` introduced in hexo v4 is still retained, and still has higher priority than `updated_option` (That's mean when `use_date_for_updated` is set to true, `updated_option` will be ignored).

### Breaking changes

See #3887 for more details.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
