### PR TITLE
refactor: drop hexo-util#HashStream

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -3,7 +3,7 @@
 const { join, sep } = require('path');
 const Promise = require('bluebird');
 const File = require('./file');
-const { Pattern, HashStream } = require('hexo-util');
+const { Pattern, createSha1Hash } = require('hexo-util');
 const { createReadStream, readdir, stat, watch } = require('hexo-fs');
 const { magenta } = require('chalk');
 const { EventEmitter } = require('events');
@@ -238,11 +238,11 @@ function escapeBackslash(path) {
 function getHash(path) {
   return new Promise((resolve, reject) => {
     const src = createReadStream(path);
-    const hasher = new HashStream();
+    const hasher = createSha1Hash();
 
     src.pipe(hasher)
       .on('finish', () => {
-        resolve(hasher.read().toString('hex'));
+        resolve(hasher.digest('hex'));
       })
       .on('error', reject);
   });

--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -7,7 +7,7 @@ const prettyHrtime = require('pretty-hrtime');
 const { cyan, magenta } = require('chalk');
 const tildify = require('tildify');
 const { PassThrough } = require('stream');
-const { CacheStream, HashStream } = require('hexo-util');
+const { CacheStream, createSha1Hash } = require('hexo-util');
 
 function generateConsole(args = {}) {
   const force = args.f || args.force;
@@ -42,12 +42,12 @@ function generateConsole(args = {}) {
     const cacheId = `public/${path}`;
     const dataStream = wrapDataStream(route.get(path), bail);
     const cacheStream = new CacheStream();
-    const hashStream = new HashStream();
+    const hashStream = createSha1Hash();
 
     // Get data => Cache data => Calculate hash
     return pipeStream(dataStream, cacheStream, hashStream).then(() => {
       const cache = Cache.findById(cacheId);
-      const hash = hashStream.read().toString('hex');
+      const hash = hashStream.digest('hex');
 
       // Skip generating if hash is unchanged
       if (!force && cache && cache.hash === hash) {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

`hexo-util#HashStream` has already deprecated and is removed in https://github.com/hexojs/hexo-util/pull/198. This PR drop the usage of it. 

## How to test

```sh
git clone -b drop-hashstream https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
