### PR TITLE
fix: access error code from error object directly

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -102,7 +102,7 @@ class Box extends EventEmitter {
 
       return this._checkFileStatus(prefix + path).then(file => fn(file).thenReturn(file));
     })).catch(err => {
-      if (err.cause && err.cause.code === 'ENOENT') return;
+      if (err && err.code === 'ENOENT') return;
       throw err;
     }).reduce((files, item) => files.concat(item), []);
   }
@@ -136,7 +136,7 @@ class Box extends EventEmitter {
       return this._readDir(base, file => this._processFile(file.type, file.path)).map(file => file.path).then(files => // Handle deleted files
         Promise.filter(cacheFiles, path => !files.includes(path)).map(path => this._processFile(File.TYPE_DELETE, path)));
     }).catch(err => {
-      if (err.cause && err.cause.code !== 'ENOENT') throw err;
+      if (err && err.code !== 'ENOENT') throw err;
     }).asCallback(callback);
   }
 

--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -76,7 +76,7 @@ function generateConsole(args = {}) {
       log.info('Deleted: %s', magenta(path));
     }, err => {
       // Skip ENOENT errors (file was deleted)
-      if (err.cause && err.cause.code === 'ENOENT') return;
+      if (err && err.code === 'ENOENT') return;
       throw err;
     });
   }
@@ -110,7 +110,7 @@ function generateConsole(args = {}) {
       }
     }).catch(err => {
       // Create public folder if not exists
-      if (err.cause && err.cause.code === 'ENOENT') {
+      if (err && err.code === 'ENOENT') {
         return fs.mkdirs(publicDir);
       }
 

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -158,7 +158,7 @@ module.exports = ctx => {
 
       return fs.listDir(assetDir);
     }).catch(err => {
-      if (err.cause && err.cause.code === 'ENOENT') return [];
+      if (err && err.code === 'ENOENT') return [];
       throw err;
     }).filter(item => !isExcludedFile(item, ctx.config)).map(item => {
       const id = join(assetDir, item).substring(baseDirLength).replace(/\\/g, '/');


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

https://github.com/hexojs/hexo-cli/pull/190

## How to test

```sh
git clone -b fix-hexo-fs-enoent https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
