### PR TITLE
Replace `Stream.readable.pipe()` with `data` event API in `getHash()`

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -240,11 +240,13 @@ function getHash(path) {
     const src = createReadStream(path);
     const hasher = createSha1Hash();
 
-    src.pipe(hasher)
-      .on('finish', () => {
-        resolve(hasher.digest('hex'));
-      })
-      .on('error', reject);
+    src.on('data', chunk => {
+      hasher.update(chunk);
+    });
+    src.on('end', () => {
+      resolve(hasher.digest('hex'));
+    });
+    src.on('error', reject);
   });
 }
 


### PR DESCRIPTION
## What does it do?

Fix one of errors of the issue #3818. (https://github.com/hexojs/hexo/issues/3818#issuecomment-622249260)

With Node.js v10.x, `npm test` fails some times.
One of them is `process() - skip (mtime changed but hash matched):` as follows:

```
  1) Hexo
       Box
         Box
           process() - skip (mtime changed but hash matched):
     AssertError: expected spy to be called with match
[_File] {
  params: {  },
  path: "a.txt",
  source: "J:\00_Seaoak\hexo\simplify_codeblock_escape\hexo\test\scripts\box\box_tmp\test\a.txt",
  type: "update"
} { path: "a.txt", type: "skip" }
      at Object.fail (J:\00_Seaoak\hexo\simplify_codeblock_escape\hexo\node_modules\sinon\lib\sinon\assert.js:107:21)
      at failAssertion (J:\00_Seaoak\hexo\simplify_codeblock_escape\hexo\node_modules\sinon\lib\sinon\assert.js:66:16)
      at Object.assert.(anonymous function) [as calledWithMatch] (J:\00_Seaoak\hexo\simplify_codeblock_escape\hexo\node_modules\sinon\lib\sinon\assert.js:92:13)
      at Context.it (J:\00_Seaoak\hexo\simplify_codeblock_escape\hexo\test\scripts\box\box.js:160:17)
```

This patch fixes this error.

I found that a combination `Stream.readable.pipe()` and `Crypt.createHash()` causes this error.
By replacing `Stream.readable.pipe()` with `data` event API, this error is resolved.

*But I can not explain why this replacing does resolve this error.*


## How to test

```sh
nvm use 10.20.1
git clone -b workaround/fs.readable.pipe_not_work_well https://github.com/seaoak/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
