### PR TITLE
Fix not to pass callback to hexo-fs

### DIFF
--- a/lib/box/file.js
+++ b/lib/box/file.js
@@ -11,6 +11,10 @@ class File {
   }
 
   read(options, callback) {
+    if (!callback && typeof options === 'function') {
+      callback = options;
+      options = {};
+    }
     return readFile(this.source, options).asCallback(callback);
   }
 

--- a/lib/plugins/console/deploy.js
+++ b/lib/plugins/console/deploy.js
@@ -1,8 +1,7 @@
 'use strict';
 
-const fs = require('hexo-fs');
+const { exists } = require('hexo-fs');
 const { underline, magenta } = require('chalk');
-const Promise = require('bluebird');
 
 function deployConsole(args) {
   let config = this.config.deploy;
@@ -20,20 +19,21 @@ function deployConsole(args) {
     return;
   }
 
-  return new Promise((resolve, reject) => {
-    const generateArgs = {...args};
-    generateArgs.d = false;
-    generateArgs.deploy = false;
+  const generateArgs = {...args};
+  generateArgs.d = false;
+  generateArgs.deploy = false;
 
-    if (args.g || args.generate) {
-      this.call('generate', args).then(resolve, reject);
-    } else {
-      fs.exists(this.public_dir, exist => {
-        if (exist) return resolve();
-        this.call('generate', args).then(resolve, reject);
-      });
-    }
-  }).then(() => {
+  let promise;
+
+  if (args.g || args.generate) {
+    promise = this.call('generate', args);
+  } else {
+    promise = exists(this.public_dir).then(exist => {
+      if (!exist) return this.call('generate', args);
+    });
+  }
+
+  return promise.then(() => {
     this.emit('deployBefore');
 
     if (!Array.isArray(config)) config = [config];

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "chalk": "^4.0.0",
     "hexo-cli": "^3.0.0",
     "hexo-front-matter": "^1.0.0",
-    "hexo-fs": "3.0.1",
+    "hexo-fs": "^3.1.0",
     "hexo-i18n": "^1.0.0",
     "hexo-log": "^1.0.0",
     "hexo-renderer-nunjucks": "^2.0.0",

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -19,7 +19,7 @@ describe('Post', () => {
   before(() => {
     clock = useFakeTimers(now);
 
-    return mkdirs(hexo.base_dir, () => hexo.init()).then(() => // Load marked renderer for testing
+    return mkdirs(hexo.base_dir).then(() => hexo.init()).then(() => // Load marked renderer for testing
       hexo.loadPlugin(require.resolve('hexo-renderer-marked'))).then(() => hexo.scaffold.set('post', [
       '---',
       'title: {{ title }}',


### PR DESCRIPTION
## What does it do?
The PR of #4336 is a provisional measure.
hexo-fs@3.1.0 needs to be modified to not pass the callback directly to hexo-fs.


## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
