### PR TITLE
github(issue_template): add special notice

### DIFF
--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -9,9 +9,13 @@ assignees: ''
 
 <!-- NOTE:
 
+针对简体中文用户的提示：在提交 issue 时请不要删除下面的模板，按照步骤提供相关信息将有助于我们调查你的问题。请尽量使用英语描述你的问题，这可以让更多的人帮助到你。
+
 If you find that markdown files are not rendered as expected, please go to https://marked.js.org/demo/ to see if it can be reproduced there. If it can be reproduced, please file a bug to https://github.com/markedjs/marked.
 
 If you want help on your bug, please also send us the git repository (GitHub, GitLab, Bitbucket etc...) where your hexo code is stored. It would greatly help. If you prefer not to have your hexo code out in public, please upload to a private GitHub repository and grant read-only access to hexojs/core
+
+Please take extra precaution not to attach any secret environment variables (likes password or GitHub Personal Access Token).
 
 -->
 

--- a/.github/ISSUE_TEMPLATE/question-help.md
+++ b/.github/ISSUE_TEMPLATE/question-help.md
@@ -9,9 +9,13 @@ assignees: ''
 
 <!-- NOTE:
 
+针对简体中文用户的提示：在提交 issue 时请不要删除下面的模板，按照步骤提供相关信息将有助于我们调查你的问题。请尽量使用英语描述你的问题，这可以让更多的人帮助到你。
+
 If you find that markdown files are not rendered as expected, please go to https://marked.js.org/demo/ to see if it can be reproduced there. If it can be reproduced, please file a bug to https://github.com/markedjs/marked.
 
 If you want help on your bug, please also send us the git repository (GitHub, GitLab, Bitbucket etc...) where your hexo code is stored. It would greatly help. If you prefer not to have your hexo code out in public, please upload to a private GitHub repository and grant read-only access to hexojs/core
+
+Please take extra precaution not to attach any secret environment variables (likes password or GitHub Personal Access Token).
 
 -->
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The continuation for #3905

- Add special notice for zh-CN users

> As you can see, all of issues marked as [`non-english`](https://github.com/hexojs/hexo/issues?q=is%3Aissue+is%3Aopen+label%3Anon-english) are in zh-CN, and moer than half of the issues marked as [`not following issue templates`](https://github.com/hexojs/hexo/issues?q=is%3Aissue+is%3Aopen+label%3A%22not+following+issue+template%22) are in zh-CN as well. We MUST add such a notice for Chinese users.

- tips for security (not to contain Personal Access Token in issues).

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
