### PR TITLE
fix(#4317): non-greedy regexp for tag escape

### DIFF
--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -232,7 +232,10 @@ class Tag {
 
     const escapeContent = str => `<!--${placeholder}${cache.push(str) - 1}-->`;
 
-    str = str.replace(/<pre><code.*>[\s\S]*?<\/code><\/pre>/gm, escapeContent);
+    // FIXME: The behavoir of hexo-renderer-marked has been changed.
+    // There will be no "class" for <code> tag
+    // See: https://github.com/hexojs/hexo-renderer-marked/pull/134
+    str = str.replace(/<pre><code.*?>[\s\S]*?<\/code><\/pre>/gm, escapeContent);
 
     return Promise.fromCallback(cb => { this.env.renderString(str, options, cb); })
       .catch(err => Promise.reject(formatNunjucksError(err, str)))

--- a/test/fixtures/post_render.js
+++ b/test/fixtures/post_render.js
@@ -72,3 +72,21 @@ exports.expected_for_issue_3346 = [
   '<p>quote content</p>\n',
   '</blockquote>'
 ].join('');
+
+exports.content_for_issue_4317 = [
+  '```sh',
+  'echo "Hi"',
+  '',
+  '```',
+  '{% gist gist_id %}',
+  '',
+  '```sh',
+  'echo "Hi"',
+  '```',
+  '',
+  '{% gist gist_id_2 %}',
+  '',
+  '```sh',
+  'echo "Hi"',
+  '```'
+].join('\n');

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -1046,5 +1046,8 @@ describe('Post', () => {
     data.content.trim().should.contains(`<pre><code class="sh">${escapeHTML('echo "Hi"')}</code></pre>`);
     data.content.trim().should.contains('<script src="//gist.github.com/gist_id.js"></script>');
     data.content.trim().should.contains('<script src="//gist.github.com/gist_id_2.js"></script>');
+
+    // Re-anable highlight for other tests
+    hexo.config.highlight.enable = true;
   });
 });

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -4,7 +4,7 @@ const { join } = require('path');
 const moment = require('moment');
 const Promise = require('bluebird');
 const { readFile, mkdirs, unlink, rmdir, writeFile, exists, stat, listDir } = require('hexo-fs');
-const { highlight } = require('hexo-util');
+const { highlight, escapeHTML } = require('hexo-util');
 const { spy, useFakeTimers } = require('sinon');
 const frontMatter = require('hexo-front-matter');
 const fixture = require('../../fixtures/post_render');
@@ -1028,5 +1028,23 @@ describe('Post', () => {
     });
 
     data.content.trim().should.eql('<p><code>&amp;#123;&amp;#123; 1 + 1 &amp;#125;&amp;#125;</code> 2</p>');
+  });
+
+  // https://github.com/hexojs/hexo/issues/4317
+  it('render() - issue #4317', async () => {
+    const content = fixture.content_for_issue_4317;
+    hexo.config.highlight.enable = false;
+
+    const data = await post.render(null, {
+      content,
+      engine: 'markdown'
+    });
+
+    // FIXME: The behavoir of hexo-renderer-marked has been changed.
+    // class="sh" won't show up in next release of hexo-renderer-marked.
+    // See: https://github.com/hexojs/hexo-renderer-marked/pull/134
+    data.content.trim().should.contains(`<pre><code class="sh">${escapeHTML('echo "Hi"')}</code></pre>`);
+    data.content.trim().should.contains('<script src="//gist.github.com/gist_id.js"></script>');
+    data.content.trim().should.contains('<script src="//gist.github.com/gist_id_2.js"></script>');
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Similar to #4161, use non-greedy regexp. See #4161 for more details.

This PR closes #4317.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
