### PR TITLE
fix(#3464): override permalink use the front-matter

### DIFF
--- a/lib/plugins/filter/post_permalink.js
+++ b/lib/plugins/filter/post_permalink.js
@@ -6,7 +6,13 @@ let permalink;
 
 function postPermalinkFilter(data) {
   const { config } = this;
-  const { id, _id, slug, title, date } = data;
+  const { id, _id, slug, title, date, __permalink } = data;
+
+  if (__permalink) {
+    if (!__permalink.startsWith('/')) return `/${__permalink}`;
+    return __permalink;
+  }
+
   const hash = slug && date
     ? createSha1Hash().update(slug + date.unix().toString()).digest('hex').slice(0, 12)
     : null;
@@ -57,7 +63,6 @@ function postPermalinkFilter(data) {
       meta[key] = config.permalink_defaults[key];
     }
   }
-
 
   return permalink.stringify(meta);
 }

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -121,7 +121,7 @@ module.exports = ctx => {
       }
 
       if (data.permalink) {
-        data.slug = data.permalink;
+        data.__permalink = data.permalink;
         delete data.permalink;
       }
 

--- a/test/scripts/filters/post_permalink.js
+++ b/test/scripts/filters/post_permalink.js
@@ -148,4 +148,27 @@ describe('post_permalink', () => {
 
     await Promise.all(posts.map(post => Post.removeById(post._id)));
   });
+
+  it('permalink - should override everything', async () => {
+    hexo.config.permalink = ':year/:month/:day/:title/';
+
+    const posts = await Post.insert([{
+      source: 'my-new-post.md',
+      slug: 'hexo/permalink-test',
+      __permalink: 'hexo/permalink-test',
+      title: 'Permalink Test',
+      date: moment('2014-01-02')
+    }, {
+      source: 'another-new-post.md',
+      slug: '/hexo-hexo/permalink-test-2',
+      __permalink: '/hexo-hexo/permalink-test-2',
+      title: 'Permalink Test',
+      date: moment('2014-01-02')
+    }]);
+
+    postPermalink(posts[0]).should.eql('/hexo/permalink-test');
+    postPermalink(posts[1]).should.eql('/hexo-hexo/permalink-test-2');
+
+    await Promise.all(posts.map(post => Post.removeById(post._id)));
+  });
 });

--- a/test/scripts/processors/post.js
+++ b/test/scripts/processors/post.js
@@ -979,7 +979,8 @@ describe('post', () => {
     await writeFile(file.source, body);
     await process(file);
     const post = Post.findOne({source: file.path});
-    post.slug.should.eql('foooo');
+
+    post.__permalink.should.eql('foooo');
 
     post.remove();
     unlink(file.source);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The PR closes #1158, closes #1813, closes #3464

https://github.com/hexojs/hexo/issues/3464#issuecomment-644238739

https://github.com/hexojs/hexo/blob/edef5c2a9c1217aaab02f64397e7e94d2f98e4fa/lib/plugins/processor/post.js#L123-L126

Originally, during the processing of the post, the `permalink` defined in the front-matter which is `data.permalink`, will override `data.slug` and `data.permalink` will be deleted.

And, in `post_permalink` filter, `data.slug` will be used to get `name` and `title` property:

https://github.com/hexojs/hexo/blob/edef5c2a9c1217aaab02f64397e7e94d2f98e4fa/lib/plugins/filter/post_permalink.js#L15-L16

So if I got a post: `source/_posts/i-love-hexo/hello.md`, I will get:

- title: `i-love-hexo/hello`
- name: `hello`

If I then defines `permalink` as `permalink-test/hi.md`, I will get:

- title: `permalink-test/hi`
- name: `hi`.

I don't know why it is designed like this. Maybe using the `permalink` to override the relative path under `source/_posts`. But it doesn't make any sense - why I have to override the relative path? I could just create required directories under `source/_posts` and it will be fine.

Also, the behavior of `Post` is different from `Page`, which `permalink` in the front-matter is truly able to override the `hexo.config.permalink`. And that behavior is what user really want.

So in this PR, I made a few changes toward post processor and `post_permalink` filter.

**As the behavior of the `permalink` in the front-matter has changed, thus the PR is still considered as a Breaking Change**

## How to test

```sh
git clone -b fix-issue-3464 https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
