### PR TITLE
fix(post): avoid swig in code being double escaped

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -10,6 +10,9 @@ const { slugize, escapeRegExp } = require('hexo-util');
 const { copyDir, exists, listDir, mkdirs, readFile, rmdir, unlink, writeFile } = require('hexo-fs');
 const yfm = require('hexo-front-matter');
 
+const replaceSwigTag = str => str.replace(/{/g, '\uFFFCleft\uFFFC').replace(/}/g, '\uFFFCright\uFFFC');
+const restoreReplacesSwigTag = str => str.replace(/\uFFFCleft\uFFFC/g, '&#123;').replace(/\uFFFCright\uFFFC/g, '&#125;');
+
 const preservedKeys = ['title', 'slug', 'path', 'layout', 'date', 'content'];
 
 const rPlaceholder = /(?:<|&lt;)!--\uFFFC(\d+)--(?:>|&gt;)/g;
@@ -18,7 +21,7 @@ const rSwigComment = /\{#[\s\S]*?#\}/g;
 const rSwigBlock = /\{%[\s\S]*?%\}/g;
 const rSwigFullBlock = /\{% *(.+?)(?: *| +.*?)%\}[\s\S]+?\{% *end\1 *%\}/g;
 const rSwigRawFullBlock = /{% *raw *%\}[\s\S]+?\{% *endraw *%\}/g;
-const rSwigTagInsideInlineCode = /`.*{.*}.*`/g;
+const rSwigTagInsideInlineCode = /`.*?{.*?}.*?`/g;
 
 const _escapeContent = (cache, str) => {
   const placeholder = '\uFFFC';
@@ -48,9 +51,7 @@ class PostRenderCache {
   escapeAllSwigTags(str) {
     const escape = _str => _escapeContent(this.cache, _str);
     return str.replace(rSwigRawFullBlock, escape) // Escape {% raw %} first
-      .replace(rSwigTagInsideInlineCode, str => {
-        return str.replace(/{/g, '&#123;').replace(/}/g, '&#125;');
-      })
+      .replace(rSwigTagInsideInlineCode, replaceSwigTag) // Avoid double escaped by marked renderer
       .replace(rSwigFullBlock, escape)
       .replace(rSwigBlock, escape)
       .replace(rSwigComment, '')
@@ -256,7 +257,6 @@ class Post {
 
     return promise.then(content => {
       data.content = content;
-
       // Run "before_post_render" filters
       return ctx.execFilter('before_post_render', data, { context: ctx });
     }).then(() => {
@@ -277,7 +277,7 @@ class Post {
         toString: true,
         onRenderEnd(content) {
           // Replace cache data with real contents
-          data.content = cacheObj.loadContent(content);
+          data.content = cacheObj.loadContent(restoreReplacesSwigTag(content));
 
           // Return content after replace the placeholders
           if (disableNunjucks) return data.content;
@@ -287,6 +287,7 @@ class Post {
         }
       }, options);
     }).then(content => {
+      // restore { and } inside inline code
       data.content = content;
 
       // Run "after_post_render" filters


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Continuing #4352

https://github.com/hexojs/hexo/pull/4352/files#r441953318

Marked.js will escape code by default. If the swig inside ` ``  ` has been escaped, it will be escaped again by marked.js.

This PR avoid it.

cc @stevenjoezhang

## How to test

```sh
git clone -b avoid-swig-double-escape https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
