### PR TITLE
perf(backtick_code): shorthand

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -9,10 +9,14 @@ const rLangCaption = /([^\s]+)\s*(.+)?/;
 const escapeSwigTag = str => str.replace(/{/g, '&#123;').replace(/}/g, '&#125;');
 
 function backtickCodeBlock(data) {
+  const dataContent = data.content;
+
+  if (!dataContent.includes('```') && !dataContent.includes('~~~')) return;
+
   const hljsCfg = this.config.highlight || {};
   const prismCfg = this.config.prismjs || {};
 
-  data.content = data.content.replace(rBacktick, ($0, start, $2, _args, _content, end) => {
+  data.content = dataContent.replace(rBacktick, ($0, start, $2, _args, _content, end) => {
     let content = _content.replace(/\n$/, '');
 
     // neither highlight or prismjs is enabled, return escaped content directly.

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -80,6 +80,14 @@ describe('Backtick code block', () => {
     hexo.config.prismjs = oldPrismCfg;
   });
 
+  it('shorthand', () => {
+    const data = {
+      content: 'Hello, world!'
+    };
+
+    should.not.exist(codeBlock(data));
+  });
+
   it('highlightjs - default', () => {
     const data = {
       content: [


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Shorthand syntax. Return directly when there is no backtick code block inside a post.

## How to test

```sh
git clone -b perf-backtick-code-filter https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
