### PR TITLE
feat(tagcloud): new option class & level

### DIFF
--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -18,6 +18,7 @@ function tagcloudHelper(tags, options) {
   const unit = options.unit || 'px';
   const color = options.color;
   const className = options.class;
+  const level = options.level || 10;
   const { transform } = options;
   const separator = options.separator || ' ';
   const result = [];
@@ -58,7 +59,7 @@ function tagcloudHelper(tags, options) {
     const ratio = length ? sizes.indexOf(tag.length) / length : 0;
     const size = min + ((max - min) * ratio);
     let style = `font-size: ${parseFloat(size.toFixed(2))}${unit};`;
-    const attr = className ? ` class="${className}-${Math.round(ratio * 10)}"` : '';
+    const attr = className ? ` class="${className}-${Math.round(ratio * level)}"` : '';
 
     if (color) {
       const midColor = startColor.mix(endColor, ratio);

--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -66,7 +66,7 @@ function tagcloudHelper(tags, options) {
     }
 
     result.push(
-      `<a href="${this.url_for(tag.path)}" style="${style}"${name}>${transform ? transform(tag.name) : tag.name}</a>`
+      `<a href="${this.url_for(tag.path)}" style="${style}"${attr}>${transform ? transform(tag.name) : tag.name}</a>`
     );
   });
 

--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -58,7 +58,7 @@ function tagcloudHelper(tags, options) {
     const ratio = length ? sizes.indexOf(tag.length) / length : 0;
     const size = min + ((max - min) * ratio);
     let style = `font-size: ${parseFloat(size.toFixed(2))}${unit};`;
-    const name = className ? ` class="${className}-${Math.round(ratio * 10)}"` : '';
+    const attr = className ? ` class="${className}-${Math.round(ratio * 10)}"` : '';
 
     if (color) {
       const midColor = startColor.mix(endColor, ratio);

--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -17,6 +17,7 @@ function tagcloudHelper(tags, options) {
   const order = options.order || 1;
   const unit = options.unit || 'px';
   const color = options.color;
+  const className = options.class;
   const { transform } = options;
   const separator = options.separator || ' ';
   const result = [];
@@ -57,6 +58,7 @@ function tagcloudHelper(tags, options) {
     const ratio = length ? sizes.indexOf(tag.length) / length : 0;
     const size = min + ((max - min) * ratio);
     let style = `font-size: ${parseFloat(size.toFixed(2))}${unit};`;
+    const name = className ? ` class="${className}-${Math.round(ratio * 10)}"` : '';
 
     if (color) {
       const midColor = startColor.mix(endColor, ratio);
@@ -64,7 +66,7 @@ function tagcloudHelper(tags, options) {
     }
 
     result.push(
-      `<a href="${this.url_for(tag.path)}" style="${style}">${transform ? transform(tag.name) : tag.name}</a>`
+      `<a href="${this.url_for(tag.path)}" style="${style}"${name}>${transform ? transform(tag.name) : tag.name}</a>`
     );
   });
 

--- a/test/scripts/helpers/tagcloud.js
+++ b/test/scripts/helpers/tagcloud.js
@@ -267,4 +267,17 @@ describe('tagcloud', () => {
       '<a href="/tags/def/" style="font-size: 10px;">def</a>'
     ].join(', '));
   });
+
+  it('class name', () => {
+    const result = tagcloud({
+      class: 'tag-cloud'
+    });
+
+    result.should.eql([
+      '<a href="/tags/abc/" style="font-size: 13.33px;" class="tag-cloud-3">abc</a>',
+      '<a href="/tags/bcd/" style="font-size: 20px;" class="tag-cloud-10">bcd</a>',
+      '<a href="/tags/cde/" style="font-size: 16.67px;" class="tag-cloud-7">cde</a>',
+      '<a href="/tags/def/" style="font-size: 10px;" class="tag-cloud-0">def</a>'
+    ].join(' '));
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The color of the tag in the tag-cloud is defined by the inline style, e.g.
```html
<a href="/tags/bcd/" style="font-size: 20px; color: #4682b4">bcd</a>
```
However, for themes that support the dark mode, it's necessary to display different tag colors for different background colors. Class name will be a better choice.
See also https://github.com/next-theme/hexo-theme-next/commit/cbcd3f04abfbc15c82f1cf430eca15591015fadc

Usage:
```njk
{{ tagcloud({ class: 'tag-cloud' }) }}
```
```styl
for $tag-cloud in (0 .. 10) {
  $tag-cloud-color = mix($tag-cloud-end, $tag-cloud-start, $tag-cloud * 10);
  .tag-cloud-{$tag-cloud} {
    color: $tag-cloud-color;
  }
}

@media (prefers-color-scheme: dark) {
  for $tag-cloud in (0 .. 10) {
    $tag-cloud-color = mix($tag-cloud-end-dark, $tag-cloud-start-dark, $tag-cloud * 10);
    .tag-cloud-{$tag-cloud} {
      color: $tag-cloud-color;
    }
  }
}
```

## How to test

```sh
git clone -b tagcloud https://github.com/hexojs/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
