### PR TITLE
docs: deprecate config.external_link (boolean) & config.use_date_for_updated

### DIFF
--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -11,6 +11,7 @@ function externalLinkFilter(data) {
 
   if (typeof EXTERNAL_LINK_POST_CONFIG === 'undefined') {
     if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
+      // Deprecated: config.external_link boolean option will be removed in future
       || config.external_link === true) {
       EXTERNAL_LINK_POST_CONFIG = Object.assign({
         enable: true,

--- a/lib/plugins/filter/after_render/external_link.js
+++ b/lib/plugins/filter/after_render/external_link.js
@@ -11,6 +11,7 @@ function externalLinkFilter(data) {
 
   if (typeof EXTERNAL_LINK_SITE_CONFIG === 'undefined') {
     if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
+      // Deprecated: config.external_link boolean option will be removed in future
       || config.external_link === true) {
       EXTERNAL_LINK_SITE_CONFIG = Object.assign({
         enable: true,

--- a/lib/plugins/processor/asset.js
+++ b/lib/plugins/processor/asset.js
@@ -12,7 +12,9 @@ module.exports = ctx => {
     const { path } = file;
     const doc = Page.findOne({source: path});
     const { config } = ctx;
-    const { timezone: timezoneCfg, use_date_for_updated, updated_option } = config;
+    const { timezone: timezoneCfg } = config;
+    // Deprecated: use_date_for_updated will be removed in future
+    const updated_option = config.use_date_for_updated === true ? 'date' : config.updated_option;
 
     if (file.type === 'skip' && doc) {
       return;
@@ -48,7 +50,7 @@ module.exports = ctx => {
 
       if (data.updated) {
         if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg);
-      } else if (use_date_for_updated || updated_option === 'date') {
+      } else if (updated_option === 'date') {
         data.updated = data.date;
       } else if (updated_option === 'empty') {
         delete data.updated;

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -27,7 +27,9 @@ module.exports = ctx => {
     const { path } = file.params;
     const doc = Post.findOne({source: file.path});
     const { config } = ctx;
-    const { timezone: timezoneCfg, use_date_for_updated, updated_option } = config;
+    const { timezone: timezoneCfg } = config;
+    // Deprecated: use_date_for_updated will be removed in future
+    const updated_option = config.use_date_for_updated === true ? 'date' : config.updated_option;
     let categories, tags;
 
     if (file.type === 'skip' && doc) {
@@ -85,7 +87,7 @@ module.exports = ctx => {
 
       if (data.updated) {
         if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg);
-      } else if (use_date_for_updated || updated_option === 'date') {
+      } else if (updated_option === 'date') {
         data.updated = data.date;
       } else if (updated_option === 'empty') {
         delete data.updated;


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Deprecate old options, to be dropped in the next major release (Hexo 6), **not a breaking change** for Hexo 5. Retain backward compatibility only for one major version.

Initially I planned to drop `config.external_link: true` so that new option is used,

``` yml
external_link:
  enable: true
```

but I noticed the [release note](https://github.com/hexojs/hexo/releases/tag/4.0.0) didn't mention about deprecation, so the old option is retained for now.


## How to test

```sh
git clone -b drop-old-external_link https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
