### PR TITLE
perf(mocha): run tests in parallel

### DIFF
--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -25,6 +25,30 @@ jobs:
       - name: Install Dependencies
         run: npm install
       - name: Test
+        run: npm run test
+        env:
+          CI: true
+  coverage:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node-version: ['12.x']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Cache NPM dependencies
+        uses: actions/cache@v1
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-npm-cache
+          restore-keys: ${{ runner.os }}-npm-cache
+      - name: Install Dependencies
+        run: npm install
+      - name: Coverage
         run: npm run test-cov
         env:
           CI: true
@@ -32,14 +56,3 @@ jobs:
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
-          flag-name: run-${{ runner.os }}-${{ matrix.node-version }}
-          parallel: true
-  coverall-finish:
-    needs: tester
-    runs-on: ubuntu-latest
-    steps:
-    - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.github_token }}
-        parallel-finished: true

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,5 @@ tmp/
 yarn.lock
 package-lock.json
 .nyc_output/
+coverage/
 .tmp*

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -5,3 +5,4 @@ full-trace: true
 exit: true
 require: 
   - "chai/register-should"
+parallel: true

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "eslint": "eslint .",
     "test": "mocha test/index.js",
-    "test-cov": "nyc --reporter=lcovonly npm run test",
+    "test-cov": "nyc --reporter=lcovonly npm run test -- --no-parallel",
     "lint-staged": "lint-staged"
   },
   "directories": {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
A [new feature](https://mochajs.org/#parallel-tests) of mocha@8. Consistently 3s faster in my single-core VM.
nyc (for now, v15.1.0) [doesn't](https://github.com/istanbuljs/nyc/issues/1328) support mocha's parallel mode yet, so parallel mode is disabled in test coverage job.

## How to test

```sh
git clone -b parallel-mocha https://github.com/hexojs/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
