### PR TITLE
refactor: deprecate config.external_link as boolean

### DIFF
--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -10,15 +10,16 @@ function externalLinkFilter(data) {
   const { config } = this;
 
   if (typeof EXTERNAL_LINK_POST_CONFIG === 'undefined') {
-    if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
-      // Deprecated: config.external_link boolean option will be removed in future
-      || config.external_link === true) {
-      EXTERNAL_LINK_POST_CONFIG = Object.assign({
-        enable: true,
-        field: 'site',
-        exclude: []
-      }, config.external_link);
+    // Deprecated: config.external_link no longer support boolean
+    if (typeof config.external_link === 'boolean') {
+      throw new TypeError('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
     }
+
+    EXTERNAL_LINK_POST_CONFIG = Object.assign({
+      enable: true,
+      field: 'site',
+      exclude: []
+    }, config.external_link);
   }
 
   if (config.external_link === false || EXTERNAL_LINK_POST_CONFIG.enable === false

--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -12,7 +12,7 @@ function externalLinkFilter(data) {
   if (typeof EXTERNAL_LINK_POST_CONFIG === 'undefined') {
     // Deprecated: config.external_link no longer support boolean
     if (typeof config.external_link === 'boolean') {
-      throw new TypeError('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
+      throw new TypeError('config.external_link no longer supports Boolean value. Changelog: https://github.com/hexojs/hexo/releases/tag/5.0.0');
     }
 
     EXTERNAL_LINK_POST_CONFIG = Object.assign({

--- a/lib/plugins/filter/after_render/external_link.js
+++ b/lib/plugins/filter/after_render/external_link.js
@@ -12,7 +12,7 @@ function externalLinkFilter(data) {
   if (typeof EXTERNAL_LINK_SITE_CONFIG === 'undefined') {
     // Deprecated: config.external_link no longer support boolean
     if (typeof config.external_link === 'boolean') {
-      throw new TypeError('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
+      throw new TypeError('config.external_link no longer supports Boolean value. Changelog: https://github.com/hexojs/hexo/releases/tag/5.0.0');
     }
 
     EXTERNAL_LINK_SITE_CONFIG = Object.assign({

--- a/lib/plugins/filter/after_render/external_link.js
+++ b/lib/plugins/filter/after_render/external_link.js
@@ -10,15 +10,16 @@ function externalLinkFilter(data) {
   const { config } = this;
 
   if (typeof EXTERNAL_LINK_SITE_CONFIG === 'undefined') {
-    if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
-      // Deprecated: config.external_link boolean option will be removed in future
-      || config.external_link === true) {
-      EXTERNAL_LINK_SITE_CONFIG = Object.assign({
-        enable: true,
-        field: 'site',
-        exclude: []
-      }, config.external_link);
+    // Deprecated: config.external_link no longer support boolean
+    if (typeof config.external_link === 'boolean') {
+      throw new TypeError('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
     }
+
+    EXTERNAL_LINK_SITE_CONFIG = Object.assign({
+      enable: true,
+      field: 'site',
+      exclude: []
+    }, config.external_link);
   }
 
   if (config.external_link === false || EXTERNAL_LINK_SITE_CONFIG.enable === false

--- a/test/scripts/filters/external_link.js
+++ b/test/scripts/filters/external_link.js
@@ -95,14 +95,20 @@ describe('External link', () => {
     ].join('\n'));
   });
 
-  it('old option - false', () => {
+  it('deprecated option - false', () => {
     const content = 'foo'
       + '<a href="https://hexo.io/">Hexo</a>'
       + 'bar';
 
     hexo.config.external_link = false;
 
-    should.not.exist(externalLink(content));
+    try {
+      externalLink(content);
+    } catch (err) {
+      err.name.should.eql('TypeError');
+      err.message.should.eql('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
+    }
+
     hexo.config.external_link = {
       enable: true,
       field: 'site',
@@ -115,8 +121,12 @@ describe('External link', () => {
 
     hexo.config.external_link = true;
 
-    const result = externalLink(content);
-    result.should.eql('<a target="_blank" rel="noopener" href="https://hexo.io/">Hexo</a>');
+    try {
+      externalLink(content);
+    } catch (err) {
+      err.name.should.eql('TypeError');
+      err.message.should.eql('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
+    }
 
     hexo.config.external_link = {
       enable: true,
@@ -269,25 +279,6 @@ describe('External link - post', () => {
       '8. Ignore links whose hostname is same as config',
       '<a href="https://example.com">Example Domain</a>'
     ].join('\n'));
-  });
-
-
-  it('backward compatibility', () => {
-    const content = 'foo'
-      + '<a href="https://hexo.io/">Hexo</a>'
-      + 'bar';
-
-    const data = {content};
-    hexo.config.external_link = false;
-
-    externalLink(data);
-    data.content.should.eql(content);
-
-    hexo.config.external_link = {
-      enable: true,
-      field: 'post',
-      exclude: ''
-    };
   });
 
   it('exclude - string', () => {

--- a/test/scripts/filters/external_link.js
+++ b/test/scripts/filters/external_link.js
@@ -281,6 +281,28 @@ describe('External link - post', () => {
     ].join('\n'));
   });
 
+  it('deprecated boolean config', () => {
+    const content = 'foo'
+      + '<a href="https://hexo.io/">Hexo</a>'
+      + 'bar';
+
+    const data = { content };
+    hexo.config.external_link = false;
+
+    try {
+      externalLink(data);
+    } catch (err) {
+      err.name.should.eql('TypeError');
+      err.message.should.eql('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
+    }
+
+    hexo.config.external_link = {
+      enable: true,
+      field: 'post',
+      exclude: ''
+    };
+  });
+
   it('exclude - string', () => {
     const content = [
       '<a href="https://foo.com/">Hexo</a>',

--- a/test/scripts/filters/external_link.js
+++ b/test/scripts/filters/external_link.js
@@ -106,7 +106,7 @@ describe('External link', () => {
       externalLink(content);
     } catch (err) {
       err.name.should.eql('TypeError');
-      err.message.should.eql('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
+      err.message.should.eql('config.external_link no longer supports Boolean value. Changelog: https://github.com/hexojs/hexo/releases/tag/5.0.0');
     }
 
     hexo.config.external_link = {
@@ -125,7 +125,7 @@ describe('External link', () => {
       externalLink(content);
     } catch (err) {
       err.name.should.eql('TypeError');
-      err.message.should.eql('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
+      err.message.should.eql('config.external_link no longer supports Boolean value. Changelog: https://github.com/hexojs/hexo/releases/tag/5.0.0');
     }
 
     hexo.config.external_link = {
@@ -293,7 +293,7 @@ describe('External link - post', () => {
       externalLink(data);
     } catch (err) {
       err.name.should.eql('TypeError');
-      err.message.should.eql('config.external_link no longer supports Boolean value, changelog: https://github.com/hexojs/hexo/releases/');
+      err.message.should.eql('config.external_link no longer supports Boolean value. Changelog: https://github.com/hexojs/hexo/releases/tag/5.0.0');
     }
 
     hexo.config.external_link = {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

`config.external_link` with boolean value is deprecated since Hexo 4.0.0. It is now removed.

## How to test

```sh
git clone -b deprecate-external-link-filter-boolean https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
