### PR TITLE
refactor(box): remove Bluebird.asCallback

### DIFF
--- a/lib/box/file.js
+++ b/lib/box/file.js
@@ -10,24 +10,16 @@ class File {
     this.type = type;
   }
 
-  read(options, callback) {
-    if (!callback && typeof options === 'function') {
-      callback = options;
-      options = {};
-    }
-    return readFile(this.source, options).asCallback(callback);
+  read(options) {
+    return readFile(this.source, options);
   }
 
   readSync(options) {
     return readFileSync(this.source, options);
   }
 
-  stat(options, callback) {
-    if (!callback && typeof options === 'function') {
-      callback = options;
-    }
-
-    return stat(this.source).asCallback(callback);
+  stat(options) {
+    return stat(this.source);
   }
 
   statSync(options) {

--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -41,15 +41,10 @@ class Box extends EventEmitter {
     const ctx = this.context;
 
     class _File extends File {
-      render(options, callback) {
-        if (!callback && typeof options === 'function') {
-          callback = options;
-          options = {};
-        }
-
+      render(options) {
         return ctx.render.render({
           path: this.source
-        }, options).asCallback(callback);
+        }, options);
       }
 
       renderSync(options) {

--- a/test/scripts/box/file.js
+++ b/test/scripts/box/file.js
@@ -55,14 +55,6 @@ describe('File', () => {
     result.should.eql(body);
   });
 
-  it('read() - callback', callback => {
-    file.read((err, content) => {
-      should.not.exist(err);
-      content.should.eql(body);
-      callback();
-    });
-  });
-
   it('readSync()', () => {
     file.readSync().should.eql(body);
   });
@@ -75,15 +67,6 @@ describe('File', () => {
     stats[0].should.eql(stats[1]);
   });
 
-  it('stat() - callback', callback => {
-    file.stat((err, fileStats) => {
-      if (err) return callback(err);
-
-      fileStats.should.eql(statSync(file.source));
-      callback();
-    });
-  });
-
   it('statSync()', () => {
     file.statSync().should.eql(statSync(file.source));
   });
@@ -91,15 +74,6 @@ describe('File', () => {
   it('render()', async () => {
     const result = await file.render();
     result.should.eql(obj);
-  });
-
-  it('render() - callback', callback => {
-    file.render((err, data) => {
-      if (err) return callback(err);
-
-      data.should.eql(obj);
-      callback();
-    });
   });
 
   it('renderSync()', () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Remove the `callback` from `box`.

All hexo internal functions are not relied on `box`'s callback, and `box`'s callback usage is never mentioned in Hexo API documents: https://hexo.io/api/box

## How to test

```sh
git clone -b reduce-ascallback-box https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
