### PR TITLE
perf: avoid running irrelevant plugins in 'clean' command

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -212,6 +212,16 @@ class Hexo extends EventEmitter {
   }
 
   init() {
+    // Load only the relevant plugins in hexo clean
+    if (this.env.cmd === 'clean') {
+      this.env.init = true;
+      return Promise.all([
+        this.extend.console.register('clean', 'Remove generated files and cache.', require('../plugins/console/clean')),
+        require('../plugins/filter')(this),
+        require('./load_plugins')(this)
+      ]);
+    }
+
     this.log.debug('Hexo version: %s', magenta(this.version));
     this.log.debug('Working directory: %s', magenta(tildify(this.base_dir)));
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Loading config and plugins are not needed in `hexo clean`. Noticed from #4381.
Only filter plugins are executed, i.e. to execute `after_clean` filter,


## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
