### PR TITLE
fix(logging): log database only in relevant commands

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -142,7 +142,9 @@ class Hexo extends EventEmitter {
     // root for saving the db. Otherwise default to `base`.
     const dbPath = args.output || base;
 
-    this.log.d(`Writing database to ${dbPath}/db.json`);
+    if (/^(init|new|g|publish|s|deploy|render|migrate)/.test(this.env.cmd)) {
+      this.log.d(`Writing database to ${dbPath}/db.json`);
+    }
 
     this.database = new Database({
       version: dbVersion,


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
`Writing database to ${dbPath}/db.json` debug log is only relevant in the following [commands](https://hexo.io/docs/commands):
- init
- new
- generate
- publish
- server
- deploy
- render
- migrate


## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
