### PR TITLE
fix(server-cache): must match exact alias

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -317,8 +317,9 @@ class Hexo extends EventEmitter {
     const { cache } = Object.assign({
       cache: false
     }, this.config.server);
+    const { alias } = this.extend.console;
 
-    if (this.env.cmd.startsWith('s') && cache) {
+    if (alias[this.env.cmd] === 'server' && cache) {
       // enable cache when run hexo server
       useCache = true;
     }


### PR DESCRIPTION
## What does it do?
Improve compatibility with 3rd-party console plugins that start with an 's'.

By default, `server` command has the following alias (using [`abbrev`](https://www.npmjs.com/package/abbrev)):
- 's'
- 'se'
- 'ser'
- ...
- 'server'

However, if there is a 3rd-party console that also starts with an 's', like 'save', 'server' will no longer have 's' alias; instead, its alias will start with 'se'. Another example is 'selenium', 'server' alias will start with 'ser'.

These examples illustrate `cmd.startsWith('s')` might match other commands than the intended 'server'.

## How to test

```sh
git clone -b abbrev-compat https://github.com/hexojs/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
