### PR TITLE
fix(tag-code): parse 'wrap' option

### DIFF
--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -150,7 +150,7 @@ module.exports = ctx => function codeTag(args, content) {
       mark,
       tab: hljsCfg.tab_replace,
       autoDetect: hljsCfg.auto_detect,
-      wrap: typeof wrap === 'undefined' ? wrap : hljsCfg.wrap
+      wrap: typeof wrap === 'boolean' ? wrap : hljsCfg.wrap
     };
 
     content = highlight(content, hljsOption);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
notice this issue when testing https://github.com/hexojs/hexo/pull/4390


## How to test

```sh
git clone -b tag-code-wrap https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
