### PR TITLE
fix: remove unused type check

### DIFF
--- a/lib/plugins/helper/css.js
+++ b/lib/plugins/helper/css.js
@@ -16,13 +16,8 @@ const flatten = function(arr, result = []) {
 
 function cssHelper(...args) {
   let result = '\n';
-  let items = args;
 
-  if (!Array.isArray(args)) items = [args];
-
-  items = flatten(items);
-
-  items.forEach(item => {
+  flatten(args).forEach(item => {
     // Old syntax
     if (typeof item === 'string' || item instanceof String) {
       let path = item;

--- a/lib/plugins/helper/js.js
+++ b/lib/plugins/helper/js.js
@@ -18,13 +18,8 @@ const flatten = function(arr, result = []) {
 
 function jsHelper(...args) {
   let result = '\n';
-  let items = args;
 
-  if (!Array.isArray(args)) items = [args];
-
-  items = flatten(items);
-
-  items.forEach(item => {
+  flatten(args).forEach(item => {
     // Old syntax
     if (typeof item === 'string' || item instanceof String) {
       let path = item;


### PR DESCRIPTION
`args` must be an array