### PR TITLE
test: replace sinon#assert

### DIFF
--- a/test/scripts/box/box.js
+++ b/test/scripts/box/box.js
@@ -4,7 +4,7 @@ const { join, sep } = require('path');
 const { appendFile, mkdir, mkdirs, rename, rmdir, stat, unlink, writeFile } = require('hexo-fs');
 const Promise = require('bluebird');
 const { hash, Pattern } = require('hexo-util');
-const { spy, match, assert: sinonAssert } = require('sinon');
+const { spy, match } = require('sinon');
 
 describe('Box', () => {
   const Hexo = require('../../../lib/hexo');
@@ -110,7 +110,7 @@ describe('Box', () => {
     await writeFile(path, 'a');
     await box.process();
 
-    sinonAssert.calledWithMatch(processor, { type: 'create', path: name });
+    processor.calledWithMatch({ type: 'create', path: name }).should.be.true;
 
     await rmdir(box.base);
   });
@@ -134,7 +134,7 @@ describe('Box', () => {
     ]);
     await box.process();
 
-    sinonAssert.calledWithMatch(processor, { type: 'update', path: name });
+    processor.calledWithMatch({ type: 'update', path: name }).should.be.true;
 
     await rmdir(box.base);
   });
@@ -157,7 +157,7 @@ describe('Box', () => {
     });
     await box.process();
 
-    sinonAssert.calledWithMatch(processor, { type: 'skip', path: name });
+    processor.calledWithMatch({ type: 'skip', path: name }).should.be.true;
 
     await rmdir(box.base);
   });
@@ -180,7 +180,7 @@ describe('Box', () => {
     });
     await box.process();
 
-    sinonAssert.calledWithMatch(processor, { type: 'skip', path: name });
+    processor.calledWithMatch({ type: 'skip', path: name }).should.be.true;
 
     await rmdir(box.base);
   });
@@ -203,7 +203,7 @@ describe('Box', () => {
     });
     await box.process();
 
-    sinonAssert.calledWithMatch(processor, { type: 'skip', path: name });
+    processor.calledWithMatch({ type: 'skip', path: name }).should.be.true;
 
     await rmdir(box.base);
   });
@@ -223,7 +223,7 @@ describe('Box', () => {
     ]);
     await box.process();
 
-    sinonAssert.calledWith(processor, match.has('type', 'delete'));
+    processor.calledWith(match.has('type', 'delete')).should.be.true;
     processor.calledOnce.should.be.true;
 
     await rmdir(box.base);
@@ -240,7 +240,7 @@ describe('Box', () => {
     await writeFile(path, 'a');
     await box.process();
 
-    sinonAssert.calledWith(processor, match.has('params', match.has('id', '123456')));
+    processor.calledWith(match.has('params', match.has('id', '123456'))).should.be.true;
     processor.calledOnce.should.be.true;
 
     await rmdir(box.base);
@@ -314,12 +314,12 @@ describe('Box', () => {
     box.isWatching().should.be.true;
     await Promise.delay(500);
 
-    sinonAssert.calledWithMatch(processor.firstCall, {
+    processor.firstCall.calledWithMatch({
       source: src,
       path: path,
       type: 'create',
       params: {}
-    });
+    }).should.be.true;
 
     box.unwatch();
     await rmdir(box.base);
@@ -343,12 +343,12 @@ describe('Box', () => {
     await appendFile(src, 'b');
     await Promise.delay(500);
 
-    sinonAssert.calledWithMatch(processor.lastCall, {
+    processor.lastCall.calledWithMatch({
       source: src,
       path: path,
       type: 'update',
       params: {}
-    });
+    }).should.be.true;
 
     box.unwatch();
     await rmdir(box.base);
@@ -372,12 +372,12 @@ describe('Box', () => {
     await unlink(src);
     await Promise.delay(500);
 
-    sinonAssert.calledWithMatch(processor.lastCall, {
+    processor.lastCall.calledWithMatch({
       source: src,
       path: path,
       type: 'delete',
       params: {}
-    });
+    }).should.be.true;
 
     box.unwatch();
     await rmdir(box.base);
@@ -632,8 +632,8 @@ describe('Box', () => {
     await writeFile(join(box.base, 'a.txt'), 'a');
     await box.process();
 
-    sinonAssert.calledWithMatch(beforeSpy, { type: 'create', path: 'a.txt' });
-    sinonAssert.calledWithMatch(afterSpy, { type: 'create', path: 'a.txt' });
+    beforeSpy.calledWithMatch({ type: 'create', path: 'a.txt' }).should.be.true;
+    afterSpy.calledWithMatch({ type: 'create', path: 'a.txt' }).should.be.true;
     beforeSpy.calledOnce.should.be.true;
     afterSpy.calledOnce.should.be.true;
 

--- a/test/scripts/console/config.js
+++ b/test/scripts/console/config.js
@@ -3,7 +3,7 @@
 const { mkdirs, readFile, rmdir, unlink, writeFile } = require('hexo-fs');
 const { join } = require('path');
 const { load } = require('js-yaml');
-const { stub, assert: sinonAssert } = require('sinon');
+const { stub } = require('sinon');
 
 describe('config', () => {
   const Hexo = require('../../../lib/hexo');
@@ -28,7 +28,7 @@ describe('config', () => {
       logStub.restore();
     }
 
-    sinonAssert.calledWith(logStub, hexo.config);
+    logStub.calledWith(hexo.config).should.be.true;
   });
 
   it('read config', async () => {
@@ -40,7 +40,7 @@ describe('config', () => {
       logStub.restore();
     }
 
-    sinonAssert.calledWith(logStub, hexo.config.title);
+    logStub.calledWith(hexo.config.title).should.be.true;
   });
 
   it('read nested config', async () => {
@@ -52,7 +52,7 @@ describe('config', () => {
       };
 
       await config({_: ['server.port']});
-      sinonAssert.calledWith(logStub, hexo.config.server.port);
+      logStub.calledWith(hexo.config.server.port).should.be.true;
     } finally {
       delete hexo.config.server;
       logStub.restore();

--- a/test/scripts/console/deploy.js
+++ b/test/scripts/console/deploy.js
@@ -2,7 +2,7 @@
 
 const { exists, mkdirs, readFile, rmdir, writeFile } = require('hexo-fs');
 const { join } = require('path');
-const { spy, stub, assert: sinonAssert } = require('sinon');
+const { spy, stub } = require('sinon');
 
 describe('deploy', () => {
   const Hexo = require('../../../lib/hexo');
@@ -32,10 +32,9 @@ describe('deploy', () => {
       logStub.restore();
     }
 
-    sinonAssert.calledWithMatch(
-      logStub,
+    logStub.calledWithMatch(
       'You should configure deployment settings in _config.yml first!'
-    );
+    ).should.be.true;
   });
 
   it('single deploy setting', async () => {
@@ -57,11 +56,11 @@ describe('deploy', () => {
     beforeListener.calledOnce.should.be.true;
     afterListener.calledOnce.should.be.true;
 
-    sinonAssert.calledWith(deployer, {
+    deployer.calledWith({
       type: 'foo',
       foo: 'foo',
       bar: 'bar'
-    });
+    }).should.be.true;
   });
 
   it('multiple deploy setting', async () => {
@@ -80,16 +79,16 @@ describe('deploy', () => {
     deployer1.calledOnce.should.be.true;
     deployer2.calledOnce.should.be.true;
 
-    sinonAssert.calledWith(deployer1, {
+    deployer1.calledWith({
       type: 'foo',
       foo: 'foo',
       test: true
-    });
-    sinonAssert.calledWith(deployer2, {
+    }).should.be.true;
+    deployer2.calledWith({
       type: 'bar',
       bar: 'bar',
       test: true
-    });
+    }).should.be.true;
   });
 
   // it('deployer not found'); missing-unit-test

--- a/test/scripts/console/list_categories.js
+++ b/test/scripts/console/list_categories.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Promise = require('bluebird');
-const { stub, assert: sinonAssert } = require('sinon');
+const { stub } = require('sinon');
 
 describe('Console list', () => {
   const Hexo = require('../../../lib/hexo');
@@ -20,9 +20,9 @@ describe('Console list', () => {
 
   it('no categories', () => {
     listCategories();
-    sinonAssert.calledWithMatch(logStub, 'Name');
-    sinonAssert.calledWithMatch(logStub, 'Posts');
-    sinonAssert.calledWithMatch(logStub, 'No categories.');
+    logStub.calledWithMatch('Name').should.be.true;
+    logStub.calledWithMatch('Posts').should.be.true;
+    logStub.calledWithMatch('No categories.').should.be.true;
   });
 
   it('categories', async () => {
@@ -41,9 +41,9 @@ describe('Console list', () => {
     ], (tags, i) => output[i].setCategories(tags));
     await hexo.locals.invalidate();
     listCategories();
-    sinonAssert.calledWithMatch(logStub, 'Name');
-    sinonAssert.calledWithMatch(logStub, 'Posts');
-    sinonAssert.calledWithMatch(logStub, 'baz');
-    sinonAssert.calledWithMatch(logStub, 'foo');
+    logStub.calledWithMatch('Name').should.be.true;
+    logStub.calledWithMatch('Posts').should.be.true;
+    logStub.calledWithMatch('baz').should.be.true;
+    logStub.calledWithMatch('foo').should.be.true;
   });
 });

--- a/test/scripts/console/list_page.js
+++ b/test/scripts/console/list_page.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { stub, assert: sinonAssert } = require('sinon');
+const { stub } = require('sinon');
 
 describe('Console list', () => {
   const Hexo = require('../../../lib/hexo');
@@ -20,10 +20,10 @@ describe('Console list', () => {
 
   it('no page', () => {
     listPages();
-    sinonAssert.calledWithMatch(logStub, 'Date');
-    sinonAssert.calledWithMatch(logStub, 'Title');
-    sinonAssert.calledWithMatch(logStub, 'Path');
-    sinonAssert.calledWithMatch(logStub, 'No pages.');
+    logStub.calledWithMatch('Date').should.be.true;
+    logStub.calledWithMatch('Title').should.be.true;
+    logStub.calledWithMatch('Path').should.be.true;
+    logStub.calledWithMatch('No pages.').should.be.true;
   });
 
   it('page', async () => {
@@ -33,10 +33,10 @@ describe('Console list', () => {
       path: 'bar'
     });
     listPages();
-    sinonAssert.calledWithMatch(logStub, 'Date');
-    sinonAssert.calledWithMatch(logStub, 'Title');
-    sinonAssert.calledWithMatch(logStub, 'Path');
-    sinonAssert.calledWithMatch(logStub, 'Hello World');
-    sinonAssert.calledWithMatch(logStub, 'foo');
+    logStub.calledWithMatch('Date').should.be.true;
+    logStub.calledWithMatch('Title').should.be.true;
+    logStub.calledWithMatch('Path').should.be.true;
+    logStub.calledWithMatch('Hello World').should.be.true;
+    logStub.calledWithMatch('foo').should.be.true;
   });
 });

--- a/test/scripts/console/list_post.js
+++ b/test/scripts/console/list_post.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { stub, assert: sinonAssert } = require('sinon');
+const { stub } = require('sinon');
 
 describe('Console list', () => {
   const Hexo = require('../../../lib/hexo');
@@ -19,12 +19,12 @@ describe('Console list', () => {
 
   it('no post', () => {
     listPosts();
-    sinonAssert.calledWithMatch(logStub, 'Date');
-    sinonAssert.calledWithMatch(logStub, 'Title');
-    sinonAssert.calledWithMatch(logStub, 'Path');
-    sinonAssert.calledWithMatch(logStub, 'Category');
-    sinonAssert.calledWithMatch(logStub, 'Tags');
-    sinonAssert.calledWithMatch(logStub, 'No posts.');
+    logStub.calledWithMatch('Date').should.be.true;
+    logStub.calledWithMatch('Title').should.be.true;
+    logStub.calledWithMatch('Path').should.be.true;
+    logStub.calledWithMatch('Category').should.be.true;
+    logStub.calledWithMatch('Tags').should.be.true;
+    logStub.calledWithMatch('No posts.').should.be.true;
   });
 
   it('post', async () => {
@@ -39,15 +39,16 @@ describe('Console list', () => {
     await hexo.locals.invalidate();
 
     listPosts();
-    sinonAssert.calledWithMatch(logStub, 'Date');
-    sinonAssert.calledWithMatch(logStub, 'Title');
-    sinonAssert.calledWithMatch(logStub, 'Path');
-    sinonAssert.calledWithMatch(logStub, 'Category');
-    sinonAssert.calledWithMatch(logStub, 'Tags');
-    for (let i = 0; i < posts.length; i++) {
-      sinonAssert.calledWithMatch(logStub, posts[i].source);
-      sinonAssert.calledWithMatch(logStub, posts[i].slug);
-      sinonAssert.calledWithMatch(logStub, posts[i].title);
-    }
+    logStub.calledWithMatch('Date').should.be.true;
+    logStub.calledWithMatch('Title').should.be.true;
+    logStub.calledWithMatch('Path').should.be.true;
+    logStub.calledWithMatch('Category').should.be.true;
+    logStub.calledWithMatch('Tags').should.be.true;
+    posts.forEach(post => {
+      logStub.calledWithMatch(post.source).should.be.true;
+      logStub.calledWithMatch(post.source).should.be.true;
+      logStub.calledWithMatch(post.slug).should.be.true;
+      logStub.calledWithMatch(post.title).should.be.true;
+    });
   });
 });

--- a/test/scripts/console/list_tags.js
+++ b/test/scripts/console/list_tags.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Promise = require('bluebird');
-const { stub, assert: sinonAssert } = require('sinon');
+const { stub } = require('sinon');
 
 describe('Console list', () => {
   const Hexo = require('../../../lib/hexo');
@@ -22,10 +22,10 @@ describe('Console list', () => {
 
   it('no tags', () => {
     listTags();
-    sinonAssert.calledWithMatch(logStub, 'Name');
-    sinonAssert.calledWithMatch(logStub, 'Posts');
-    sinonAssert.calledWithMatch(logStub, 'Path');
-    sinonAssert.calledWithMatch(logStub, 'No tags.');
+    logStub.calledWithMatch('Name').should.be.true;
+    logStub.calledWithMatch('Posts').should.be.true;
+    logStub.calledWithMatch('Path').should.be.true;
+    logStub.calledWithMatch('No tags.').should.be.true;
   });
 
   it('tags', async () => {
@@ -45,12 +45,12 @@ describe('Console list', () => {
     await hexo.locals.invalidate();
 
     listTags();
-    sinonAssert.calledWithMatch(logStub, 'Name');
-    sinonAssert.calledWithMatch(logStub, 'Posts');
-    sinonAssert.calledWithMatch(logStub, 'Path');
-    sinonAssert.calledWithMatch(logStub, 'baz');
-    sinonAssert.calledWithMatch(logStub, 'foo');
-    sinonAssert.calledWithMatch(logStub, 'tags/baz');
-    sinonAssert.calledWithMatch(logStub, 'tags/foo');
+    logStub.calledWithMatch('Name').should.be.true;
+    logStub.calledWithMatch('Posts').should.be.true;
+    logStub.calledWithMatch('Path').should.be.true;
+    logStub.calledWithMatch('baz').should.be.true;
+    logStub.calledWithMatch('foo').should.be.true;
+    logStub.calledWithMatch('tags/baz').should.be.true;
+    logStub.calledWithMatch('tags/foo').should.be.true;
   });
 });

--- a/test/scripts/console/migrate.js
+++ b/test/scripts/console/migrate.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { spy, assert: sinonAssert } = require('sinon');
+const { spy } = require('sinon');
 
 describe('migrate', () => {
   const Hexo = require('../../../lib/hexo');
@@ -14,7 +14,7 @@ describe('migrate', () => {
 
     await migrate({_: ['test'], foo: 1, bar: 2});
 
-    sinonAssert.calledWithMatch(migrator, { foo: 1, bar: 2 });
+    migrator.calledWithMatch({ foo: 1, bar: 2 }).should.be.true;
     migrator.calledOnce.should.be.true;
   });
 });

--- a/test/scripts/hexo/render.js
+++ b/test/scripts/hexo/render.js
@@ -3,7 +3,7 @@
 const { writeFile, rmdir } = require('hexo-fs');
 const { join } = require('path');
 const yaml = require('js-yaml');
-const { spy, assert: sinonAssert } = require('sinon');
+const { spy } = require('sinon');
 
 describe('Render', () => {
   const Hexo = require('../../../lib/hexo');
@@ -184,7 +184,7 @@ describe('Render', () => {
     return hexo.render.render(data).then(result => {
       onRenderEnd.calledOnce.should.be.true;
       filter.calledOnce.should.be.true;
-      sinonAssert.calledWith(filter, 'foobar');
+      filter.calledWith('foobar').should.be.true;
 
       hexo.extend.filter.unregister('after_render:txt', filter);
     });
@@ -262,7 +262,7 @@ describe('Render', () => {
     const result = hexo.render.renderSync(data);
 
     filter.calledOnce.should.be.true;
-    sinonAssert.calledWith(filter, data.text, data);
+    filter.calledWith(data.text, data).should.be.true;
     result.should.eql(data.text.trim());
 
     hexo.extend.filter.unregister('after_render:html', filter);

--- a/test/scripts/hexo/router.js
+++ b/test/scripts/hexo/router.js
@@ -5,7 +5,7 @@ const { Readable } = require('stream');
 const { join } = require('path');
 const crypto = require('crypto');
 const { createReadStream } = require('hexo-fs');
-const { spy, assert: sinonAssert } = require('sinon');
+const { spy } = require('sinon');
 const testUtil = require('../../util');
 
 describe('Router', () => {
@@ -70,7 +70,7 @@ describe('Router', () => {
 
     data.modified.should.be.true;
     listener.calledOnce.should.be.true;
-    sinonAssert.calledWith(listener, 'test');
+    listener.calledWith('test').should.be.true;
     return checkStream(data, 'foo');
   });
 
@@ -198,7 +198,7 @@ describe('Router', () => {
     router.set('test', 'foo');
     router.remove('test');
     should.not.exist(router.get('test'));
-    sinonAssert.calledWith(listener, 'test');
+    listener.calledWith('test').should.be.true;
     listener.calledOnce.should.be.true;
   });
 

--- a/test/scripts/theme/view.js
+++ b/test/scripts/theme/view.js
@@ -3,7 +3,7 @@
 const { join } = require('path');
 const { mkdirs, rmdir, writeFile } = require('hexo-fs');
 const moment = require('moment');
-const { fake, assert: sinonAssert } = require('sinon');
+const { fake } = require('sinon');
 
 describe('View', () => {
   const Hexo = require('../../../lib/hexo');
@@ -209,7 +209,7 @@ describe('View', () => {
     content.should.eql('bar');
 
     hexo.extend.filter.unregister('after_render:html', filter);
-    sinonAssert.alwaysCalledWith(filter, 'foo');
+    filter.alwaysCalledWith('foo').should.be.true;
   });
 
   it('renderSync()', () => {
@@ -281,7 +281,7 @@ describe('View', () => {
     hexo.extend.filter.register('after_render:html', filter);
     view.renderSync({test: 'foo'}).should.eql('bar');
     hexo.extend.filter.unregister('after_render:html', filter);
-    sinonAssert.alwaysCalledWith(filter, 'foo');
+    filter.alwaysCalledWith('foo').should.be.true;
   });
 
   it('_resolveLayout()', () => {

--- a/test/scripts/theme_processors/config.js
+++ b/test/scripts/theme_processors/config.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { spy, assert: sinonAssert } = require('sinon');
+const { spy } = require('sinon');
 const { join } = require('path');
 const { mkdirs, rmdir, unlink, writeFile} = require('hexo-fs');
 const Promise = require('bluebird');
@@ -83,7 +83,7 @@ describe('config', () => {
     return process(file).then(() => {
       should.fail('Return value must be rejected');
     }, () => {
-      sinonAssert.calledWith(logSpy, 'Theme config load failed.');
+      logSpy.calledWith('Theme config load failed.').should.be.true;
     }).finally(() => logSpy.restore());
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Replace `sinon#assert` with `Chai.Assertion.LanguageChain`.

## How to test

```sh
git clone -b test-replace-sinonAssert https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
