### PR TITLE
refactor(external_link): migrate config during load_config

### DIFF
--- a/lib/hexo/load_config.js
+++ b/lib/hexo/load_config.js
@@ -8,6 +8,7 @@ const { exists, readdir } = require('hexo-fs');
 const { magenta } = require('chalk');
 const { deepMerge } = require('hexo-util');
 const validateConfig = require('./validate_config');
+const { external_link: externalLinkDefaultCfg } = require('./default_config');
 
 module.exports = async ctx => {
   if (!ctx.env.init) return;
@@ -30,9 +31,18 @@ module.exports = async ctx => {
   validateConfig(ctx);
 
   ctx.config_path = configPath;
-
+  // Trim multiple trailing '/'
   config.root = config.root.replace(/\/*$/, '/');
+  // Remove any trailing '/'
   config.url = config.url.replace(/\/+$/, '');
+
+  // Deprecated: config.external_link boolean option will be removed in future
+  if (typeof config.external_link === 'boolean') {
+    config.external_link = {
+      ...externalLinkDefaultCfg,
+      enable: config.external_link
+    };
+  }
 
   ctx.public_dir = resolve(baseDir, config.public_dir) + sep;
   ctx.source_dir = resolve(baseDir, config.source_dir) + sep;

--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -1,34 +1,20 @@
 'use strict';
 
 const { isExternalLink } = require('hexo-util');
-let EXTERNAL_LINK_POST_CONFIG;
 let EXTERNAL_LINK_POST_ENABLED = true;
 
 function externalLinkFilter(data) {
   if (!EXTERNAL_LINK_POST_ENABLED) return;
 
-  const { config } = this;
+  const { external_link, url } = this.config;
 
-  if (typeof EXTERNAL_LINK_POST_CONFIG === 'undefined') {
-    if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
-      // Deprecated: config.external_link boolean option will be removed in future
-      || config.external_link === true) {
-      EXTERNAL_LINK_POST_CONFIG = Object.assign({
-        enable: true,
-        field: 'site',
-        exclude: []
-      }, config.external_link);
-    }
-  }
-
-  if (config.external_link === false || EXTERNAL_LINK_POST_CONFIG.enable === false
-    || EXTERNAL_LINK_POST_CONFIG.field !== 'post') {
+  if (!external_link.enable || external_link.field !== 'post') {
     EXTERNAL_LINK_POST_ENABLED = false;
     return;
   }
 
   data.content = data.content.replace(/<a\s+(?:[^<>]+\s)?href=["']([^<>"']+)["'][^<>]*>/gi, (str, href) => {
-    if (/target=/gi.test(str) || !isExternalLink(href, config.url, EXTERNAL_LINK_POST_CONFIG.exclude)) return str;
+    if (/target=/gi.test(str) || !isExternalLink(href, url, external_link.exclude)) return str;
 
     if (/rel=/gi.test(str)) {
       str = str.replace(/rel="(.*?)"/gi, (relStr, rel) => {

--- a/lib/plugins/filter/after_render/external_link.js
+++ b/lib/plugins/filter/after_render/external_link.js
@@ -1,34 +1,21 @@
 'use strict';
 
 const { isExternalLink } = require('hexo-util');
-let EXTERNAL_LINK_SITE_CONFIG;
+
 let EXTERNAL_LINK_SITE_ENABLED = true;
 
 function externalLinkFilter(data) {
   if (!EXTERNAL_LINK_SITE_ENABLED) return;
 
-  const { config } = this;
+  const { external_link, url } = this.config;
 
-  if (typeof EXTERNAL_LINK_SITE_CONFIG === 'undefined') {
-    if (typeof config.external_link === 'undefined' || typeof config.external_link === 'object'
-      // Deprecated: config.external_link boolean option will be removed in future
-      || config.external_link === true) {
-      EXTERNAL_LINK_SITE_CONFIG = Object.assign({
-        enable: true,
-        field: 'site',
-        exclude: []
-      }, config.external_link);
-    }
-  }
-
-  if (config.external_link === false || EXTERNAL_LINK_SITE_CONFIG.enable === false
-    || EXTERNAL_LINK_SITE_CONFIG.field !== 'site') {
+  if (!external_link.enable || external_link.field !== 'site') {
     EXTERNAL_LINK_SITE_ENABLED = false;
     return;
   }
 
-  data = data.replace(/<a\s+(?:[^<>]+\s)?href=["']([^<>"']+)["'][^<>]*>/gi, (str, href) => {
-    if (/target=/i.test(str) || !isExternalLink(href, config.url, EXTERNAL_LINK_SITE_CONFIG.exclude)) return str;
+  return data.replace(/<a\s+(?:[^<>]+\s)?href=["']([^<>"']+)["'][^<>]*>/gi, (str, href) => {
+    if (/target=/i.test(str) || !isExternalLink(href, url, external_link.exclude)) return str;
 
     if (/rel=/i.test(str)) {
       str = str.replace(/rel="(.*?)"/gi, (relStr, rel) => {
@@ -39,8 +26,6 @@ function externalLinkFilter(data) {
 
     return str.replace('href=', 'target="_blank" rel="noopener" href=');
   });
-
-  return data;
 }
 
 module.exports = externalLinkFilter;

--- a/test/scripts/filters/external_link.js
+++ b/test/scripts/filters/external_link.js
@@ -95,36 +95,6 @@ describe('External link', () => {
     ].join('\n'));
   });
 
-  it('old option - false', () => {
-    const content = 'foo'
-      + '<a href="https://hexo.io/">Hexo</a>'
-      + 'bar';
-
-    hexo.config.external_link = false;
-
-    should.not.exist(externalLink(content));
-    hexo.config.external_link = {
-      enable: true,
-      field: 'site',
-      exclude: ''
-    };
-  });
-
-  it('old option - true', () => {
-    const content = '<a href="https://hexo.io/">Hexo</a>';
-
-    hexo.config.external_link = true;
-
-    const result = externalLink(content);
-    result.should.eql('<a target="_blank" rel="noopener" href="https://hexo.io/">Hexo</a>');
-
-    hexo.config.external_link = {
-      enable: true,
-      field: 'site',
-      exclude: ''
-    };
-  });
-
   it('exclude - string', () => {
     const content = [
       '<a href="https://foo.com/">Hexo</a>',

--- a/test/scripts/hexo/load_config.js
+++ b/test/scripts/hexo/load_config.js
@@ -106,6 +106,51 @@ describe('Load config', () => {
     }
   });
 
+  // Deprecated: config.external_link boolean option will be removed in future
+  it('migrate external_link config from boolean to object - true', async () => {
+    const content = 'external_link: true';
+
+    try {
+      await writeFile(hexo.config_path, content);
+      await loadConfig(hexo);
+      hexo.config.external_link.should.eql({
+        enable: true,
+        field: 'site',
+        exclude: ''
+      });
+    } finally {
+      await unlink(hexo.config_path);
+    }
+  });
+
+  it('migrate external_link config from boolean to object - false', async () => {
+    const content = 'external_link: false';
+
+    try {
+      await writeFile(hexo.config_path, content);
+      await loadConfig(hexo);
+      hexo.config.external_link.should.eql({
+        enable: false,
+        field: 'site',
+        exclude: ''
+      });
+    } finally {
+      await unlink(hexo.config_path);
+    }
+  });
+
+  it('migrate external_link config from boolean to object - undefined', async () => {
+    try {
+      // Test undefined
+      await writeFile(hexo.config_path, '');
+
+      await loadConfig(hexo);
+      hexo.config.external_link.should.eql(defaultConfig.external_link);
+    } finally {
+      await unlink(hexo.config_path);
+    }
+  });
+
   it('custom public_dir', async () => {
     try {
       await writeFile(hexo.config_path, 'public_dir: foo');


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Instead of migrating old boolean format config into object format every time the filter is executed, run the config migration during `load_config`.

## How to test

```sh
git clone -b config-external-link-process https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
