### PR TITLE
feat(tag): show source of the error & beautify

### DIFF
--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { stripIndent } = require('hexo-util');
-const { cyan } = require('chalk');
+const { cyan, magenta, red } = require('chalk');
 const { Environment } = require('nunjucks');
 const Promise = require('bluebird');
 const placeholder = '\uFFFC';
@@ -129,7 +129,7 @@ const LINES_OF_CONTEXT = 5;
 
 const getContext = (lines, errLine, location, type) => {
   const message = [
-    location + ' ' + type,
+    location + ' ' + red(type),
     cyan('    =====               Context Dump               ====='),
     cyan('    === (line number probably different from source) ===')
   ];
@@ -158,14 +158,14 @@ const getContext = (lines, errLine, location, type) => {
  * @param  {string}   str string input for Nunjucks
  * @return {Error}    New error object with embedded context
  */
-const formatNunjucksError = (err, input) => {
+const formatNunjucksError = (err, input, source = '') => {
   const match = err.message.match(/Line (\d+), Column \d+/);
   if (!match) return err;
   const errLine = parseInt(match[1], 10);
   if (isNaN(errLine)) return err;
 
   // trim useless info from Nunjucks Error
-  const splited = err.message.replace('(unknown path)', '').split('\n');
+  const splited = err.message.replace('(unknown path)', source ? magenta(source) : '').split('\n');
 
   const e = new Error();
   e.name = 'Nunjucks Error';
@@ -222,11 +222,14 @@ class Tag {
     if (env.hasExtension(name)) env.removeExtension(name);
   }
 
-  render(str, options, callback) {
+  render(str, options = {}, callback) {
     if (!callback && typeof options === 'function') {
       callback = options;
       options = {};
     }
+
+    // Get path of post from source
+    const source = options.source || '';
 
     const cache = [];
 
@@ -235,7 +238,7 @@ class Tag {
     str = str.replace(/<pre><code.*?>[\s\S]*?<\/code><\/pre>/gm, escapeContent);
 
     return Promise.fromCallback(cb => { this.env.renderString(str, options, cb); })
-      .catch(err => Promise.reject(formatNunjucksError(err, str)))
+      .catch(err => Promise.reject(formatNunjucksError(err, str, source)))
       .then(result => result.replace(rPlaceholder, (_, index) => cache[index]))
       .asCallback(callback);
   }

--- a/test/scripts/extend/tag_errors.js
+++ b/test/scripts/extend/tag_errors.js
@@ -102,4 +102,26 @@ describe('Tag Errors', () => {
       assertNunjucksError(err, 2, 'expected variable end');
     }
   });
+
+  it('source file path', async () => {
+    const source = '_posts/hello-world.md';
+    const tag = new Tag();
+
+    tag.register('test',
+      (args, content) => {},
+      { ends: true });
+
+    const body = [
+      '{% test %}',
+      '  {{docker ps -aq | map docker inspect -f "{{.Name}} {{.Mounts}}"}}',
+      '{% endtest %}'
+    ].join('\n');
+
+    try {
+      // Add { source } as option
+      await tag.render(body, { source });
+    } catch (err) {
+      err.message.should.contains(source);
+    }
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

#3859 #4109 #1771

- Show the source file that contains error
  `source` is available as a property of `options` that passed to `tag.render`.
- Beautify the Error
  - The source of error will be colored in magenta while the error type will be in red.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

![image](https://user-images.githubusercontent.com/40715044/87559875-69a21480-c6ed-11ea-8798-841e71bbf9df.png)

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
