### PR TITLE
refactor(meta_generator): no longer ignore empty <head>

### DIFF
--- a/lib/plugins/filter/after_render/meta_generator.js
+++ b/lib/plugins/filter/after_render/meta_generator.js
@@ -14,7 +14,7 @@ function hexoMetaGeneratorInject(data) {
 
   META_GENERATOR_TAG = META_GENERATOR_TAG || `<meta name="generator" content="Hexo ${this.version}">`;
 
-  return data.replace(/<head>(?!<\/head>).+?<\/head>/s, str => str.replace('</head>', `${META_GENERATOR_TAG}</head>`));
+  return data.replace('</head>', `${META_GENERATOR_TAG}</head>`);
 }
 
 module.exports = hexoMetaGeneratorInject;

--- a/test/scripts/filters/meta_generator.js
+++ b/test/scripts/filters/meta_generator.js
@@ -37,32 +37,6 @@ describe('Meta Generator', () => {
     should.not.exist(metaGenerator('<head><link><meta content="foo" name="generator"></head>'));
   });
 
-  it('ignore empty head tag', () => {
-    const content = '<head></head><head><link></head><head></head>';
-    hexo.config.meta_generator = true;
-    const result = metaGenerator(content);
-
-    const $ = cheerio.load(result);
-    $('meta[name="generator"]').should.have.lengthOf(1);
-
-    const expected = '<head></head><head><link><meta name="generator" content="Hexo '
-      + hexo.version + '"></head><head></head>';
-    result.should.eql(expected);
-  });
-
-  it('apply to first non-empty head tag only', () => {
-    const content = '<head></head><head><link></head><head><link></head>';
-    hexo.config.meta_generator = true;
-    const result = metaGenerator(content);
-
-    const $ = cheerio.load(result);
-    $('meta[name="generator"]').should.have.lengthOf(1);
-
-    const expected = '<head></head><head><link><meta name="generator" content="Hexo '
-      + hexo.version + '"></head><head><link></head>';
-    result.should.eql(expected);
-  });
-
   // Test for Issue #3777
   it('multi-line head', () => {
     const content = '<head>\n<link>\n</head>';


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Ignoring empty `<head>` tag is firstly introduced in https://github.com/hexojs/hexo/pull/3315, in which `cheerio@1` will automatically append `<html><head><body>`. After #3677, cheerio has been dropped from `dependencies`. And cheerio in `devDependencies` has been pinned at `0.22.0` as well. So I just assume there will be no empty `<head>` tag any more.

The PR removes empty `<head>` detection which results in less generation time.

## How to test

```sh
git clone -b meta-generator-empty https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
