### PR TITLE
fix(excerpt): stricter regex

### DIFF
--- a/lib/plugins/filter/after_post_render/excerpt.js
+++ b/lib/plugins/filter/after_post_render/excerpt.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const rExcerpt = /<!--+\s*more\s*--+>/i;
+const rExcerpt = /<!-- ?more ?-->/i;
 
 function excerptFilter(data) {
   const { content } = data;

--- a/test/scripts/filters/excerpt.js
+++ b/test/scripts/filters/excerpt.js
@@ -23,36 +23,14 @@ describe('Excerpt', () => {
   });
 
   it('with <!-- more -->', () => {
+    const _moreCases = [
+      '<!-- more -->',
+      '<!-- more-->',
+      '<!--more -->',
+      '<!--more-->'
+    ];
 
-    _moreCases().forEach(_test);
-
-    function _moreCases() {
-      const template = '<!--{{lead}}more{{tail}}-->';
-      // see: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp#Special_characters_meaning_in_regular_expressions
-      const spaces = ' \f\n\r\t\v\u00a0\u1680\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u2028\u2029\u202f\u205f\u3000\ufeff';
-      const cases = [];
-      let more, lead, tail, s, e;
-
-      for (let i = 0; i < spaces.length; ++i) {
-        lead = spaces[i];
-        for (let k = 0; k < spaces.length; ++k) {
-          tail = spaces[k];
-          s = '';
-          for (let m = 0; m < 3; ++m) {
-            e = '';
-            for (let n = 0; n < 3; ++n) {
-              more = template.replace('{{lead}}', s).replace('{{tail}}', e);
-              cases.push(more);
-              e += tail;
-            }
-
-            s += lead;
-          }
-        }
-      }
-
-      return cases;
-    }
+    _moreCases.forEach(moreCase => _test(moreCase));
 
     function _test(more) {
       const content = [


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
The current regex to detect the excerpt tag `<!-- more -->` is too lenient, it matches `<!--- more --->` and even

```
<!--
more
-->
```

This PR restricts it to two dashes only and zero or one space.


## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
