### PR TITLE
fix(helpers): call url_for from hexo-util

### DIFF
--- a/lib/plugins/helper/css.js
+++ b/lib/plugins/helper/css.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { htmlTag } = require('hexo-util');
+const { htmlTag, url_for } = require('hexo-util');
 
 const flatten = function(arr, result = []) {
   for (const i in arr) {
@@ -24,10 +24,10 @@ function cssHelper(...args) {
       if (!path.endsWith('.css')) {
         path += '.css';
       }
-      result += `<link rel="stylesheet" href="${this.url_for(path)}">\n`;
+      result += `<link rel="stylesheet" href="${url_for.call(this, path)}">\n`;
     } else {
       // New syntax
-      item.href = this.url_for(item.href);
+      item.href = url_for.call(this, item.href);
       if (!item.href.endsWith('.css')) item.href += '.css';
       result += htmlTag('link', { rel: 'stylesheet', ...item }) + '\n';
     }

--- a/lib/plugins/helper/favicon_tag.js
+++ b/lib/plugins/helper/favicon_tag.js
@@ -1,7 +1,9 @@
 'use strict';
 
+const { url_for } = require('hexo-util');
+
 function faviconTagHelper(path) {
-  return `<link rel="shortcut icon" href="${this.url_for(path)}">`;
+  return `<link rel="shortcut icon" href="${url_for.call(this, path)}">`;
 }
 
 module.exports = faviconTagHelper;

--- a/lib/plugins/helper/feed_tag.js
+++ b/lib/plugins/helper/feed_tag.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { url_for } = require('hexo-util');
+
 const feedFn = (str = '') => {
   if (str) return str.replace(/2$/, '');
   return str;
@@ -21,19 +23,19 @@ function feedTagHelper(path, options = {}) {
 
     const typeAttr = type ? `type="application/${type}+xml"` : '';
 
-    return `<link rel="alternate" href="${this.url_for(path)}" title="${title}" ${typeAttr}>`;
+    return `<link rel="alternate" href="${url_for.call(this, path)}" title="${title}" ${typeAttr}>`;
   }
 
   if (config.feed) {
     const { feed } = config;
     if (feed.type && feed.path) {
       if (typeof feed.type === 'string') {
-        return `<link rel="alternate" href="${this.url_for(feed.path)}" title="${title}" type="application/${feedFn(feed.type)}+xml">`;
+        return `<link rel="alternate" href="${url_for.call(this, feed.path)}" title="${title}" type="application/${feedFn(feed.type)}+xml">`;
       }
 
       let result = '';
       for (const i in feed.type) {
-        result += `<link rel="alternate" href="${this.url_for(feed.path[i])}" title="${title}" type="application/${feedFn(feed.type[i])}+xml">`;
+        result += `<link rel="alternate" href="${url_for.call(this, feed.path[i])}" title="${title}" type="application/${feedFn(feed.type[i])}+xml">`;
       }
       return result;
     }

--- a/lib/plugins/helper/image_tag.js
+++ b/lib/plugins/helper/image_tag.js
@@ -1,10 +1,10 @@
 'use strict';
 
-const { htmlTag } = require('hexo-util');
+const { htmlTag, url_for } = require('hexo-util');
 
 function imageTagHelper(path, options = {}) {
   const attrs = Object.assign({
-    src: this.url_for(path)
+    src: url_for.call(this, path)
   }, options);
 
   if (attrs.class && Array.isArray(attrs.class)) {

--- a/lib/plugins/helper/js.js
+++ b/lib/plugins/helper/js.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { htmlTag } = require('hexo-util');
+const { htmlTag, url_for } = require('hexo-util');
 
 /* flatten() to be replaced by Array.flat()
 after Node 10 has reached EOL */
@@ -26,10 +26,10 @@ function jsHelper(...args) {
       if (!path.endsWith('.js')) {
         path += '.js';
       }
-      result += `<script src="${this.url_for(path)}"></script>\n`;
+      result += `<script src="${url_for.call(this, path)}"></script>\n`;
     } else {
       // New syntax
-      item.src = this.url_for(item.src);
+      item.src = url_for.call(this, item.src);
       if (!item.src.endsWith('.js')) item.src += '.js';
       result += htmlTag('script', { ...item }, '') + '\n';
     }

--- a/lib/plugins/helper/link_to.js
+++ b/lib/plugins/helper/link_to.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { htmlTag } = require('hexo-util');
+const { htmlTag, url_for } = require('hexo-util');
 
 function linkToHelper(path, text, options = {}) {
   if (typeof options === 'boolean') options = {external: options};
@@ -8,7 +8,7 @@ function linkToHelper(path, text, options = {}) {
   if (!text) text = path.replace(/^https?:\/\/|\/$/g, '');
 
   const attrs = Object.assign({
-    href: this.url_for(path),
+    href: url_for.call(this, path),
     title: text
   }, options);
 

--- a/lib/plugins/helper/list_archives.js
+++ b/lib/plugins/helper/list_archives.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { toMomentLocale } = require('./date');
+const { url_for } = require('hexo-util');
 
 function listArchivesHelper(options = {}) {
   const { config } = this;
@@ -61,7 +62,7 @@ function listArchivesHelper(options = {}) {
       url += `${item.month}/`;
     }
 
-    return this.url_for(url);
+    return url_for.call(this, url);
   };
 
   if (style === 'list') {

--- a/lib/plugins/helper/list_categories.js
+++ b/lib/plugins/helper/list_categories.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { url_for } = require('hexo-util');
+
 function listCategoriesHelper(categories, options) {
   if (!options && (!categories || !Object.prototype.hasOwnProperty.call(categories, 'length'))) {
     options = categories;
@@ -57,7 +59,7 @@ function listCategoriesHelper(categories, options) {
 
       result += `<li class="${className}-list-item${additionalClassName}">`;
 
-      result += `<a class="${className}-list-link${isCurrent ? ' current' : ''}" href="${this.url_for(cat.path)}${suffix}">`;
+      result += `<a class="${className}-list-link${isCurrent ? ' current' : ''}" href="${url_for.call(this, cat.path)}${suffix}">`;
       result += transform ? transform(cat.name) : cat.name;
       result += '</a>';
 
@@ -81,7 +83,7 @@ function listCategoriesHelper(categories, options) {
     prepareQuery(parent).forEach((cat, i) => {
       if (i || level) result += separator;
 
-      result += `<a class="${className}-link" href="${this.url_for(cat.path)}${suffix}">`;
+      result += `<a class="${className}-link" href="${url_for.call(this, cat.path)}${suffix}">`;
       result += transform ? transform(cat.name) : cat.name;
 
       if (showCount) {

--- a/lib/plugins/helper/list_posts.js
+++ b/lib/plugins/helper/list_posts.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { url_for } = require('hexo-util');
+
 function listPostsHelper(posts, options) {
   if (!options && (!posts || !Object.prototype.hasOwnProperty.call(posts, 'length'))) {
     options = posts;
@@ -30,7 +32,7 @@ function listPostsHelper(posts, options) {
 
       result += `<li class="${className}-list-item">`;
 
-      result += `<a class="${className}-list-link" href="${this.url_for(post.path)}">`;
+      result += `<a class="${className}-list-link" href="${url_for.call(this, post.path)}">`;
       result += transform ? transform(title) : title;
       result += '</a>';
 
@@ -44,7 +46,7 @@ function listPostsHelper(posts, options) {
 
       const title = post.title || post.slug;
 
-      result += `<a class="${className}-link" href="${this.url_for(post.path)}">`;
+      result += `<a class="${className}-link" href="${url_for.call(this, post.path)}">`;
       result += transform ? transform(title) : title;
       result += '</a>';
     });

--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { url_for } = require('hexo-util');
+
 function listTagsHelper(tags, options) {
   if (!options && (!tags || !Object.prototype.hasOwnProperty.call(tags, 'length'))) {
     options = tags;
@@ -50,7 +52,7 @@ function listTagsHelper(tags, options) {
     tags.forEach(tag => {
       result += `<li class="${liClass}">`;
 
-      result += `<a class="${aClass}" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
+      result += `<a class="${aClass}" href="${url_for.call(this, tag.path)}${suffix}" rel="tag">`;
       result += transform ? transform(tag.name) : tag.name;
       result += '</a>';
 
@@ -66,7 +68,7 @@ function listTagsHelper(tags, options) {
     tags.forEach((tag, i) => {
       if (i) result += separator;
 
-      result += `<a class="${aClass}" href="${this.url_for(tag.path)}${suffix}" rel="tag">`;
+      result += `<a class="${aClass}" href="${url_for.call(this, tag.path)}${suffix}" rel="tag">`;
       result += transform ? transform(tag.name) : tag.name;
 
       if (showCount) {

--- a/lib/plugins/helper/paginator.js
+++ b/lib/plugins/helper/paginator.js
@@ -1,11 +1,11 @@
 'use strict';
 
-const { htmlTag } = require('hexo-util');
+const { htmlTag, url_for } = require('hexo-util');
 
 const createLink = (options, ctx) => {
   const { base, format } = options;
 
-  return i => ctx.url_for(i === 1 ? base : base + format.replace('%d', i));
+  return i => url_for.call(ctx, i === 1 ? base : base + format.replace('%d', i));
 };
 
 const createPageTag = (options, ctx) => {

--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Color } = require('hexo-util');
+const { Color, url_for } = require('hexo-util');
 
 function tagcloudHelper(tags, options) {
   if (!options && (!tags || !Object.prototype.hasOwnProperty.call(tags, 'length'))) {
@@ -67,7 +67,7 @@ function tagcloudHelper(tags, options) {
     }
 
     result.push(
-      `<a href="${this.url_for(tag.path)}" style="${style}"${attr}>${transform ? transform(tag.name) : tag.name}</a>`
+      `<a href="${url_for.call(this, tag.path)}" style="${style}"${attr}>${transform ? transform(tag.name) : tag.name}</a>`
     );
   });
 

--- a/test/scripts/helpers/css.js
+++ b/test/scripts/helpers/css.js
@@ -10,8 +10,6 @@ describe('css', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const css = require('../../../lib/plugins/helper/css').bind(ctx);
 
   function assertResult(result, expected) {

--- a/test/scripts/helpers/favicon_tag.js
+++ b/test/scripts/helpers/favicon_tag.js
@@ -8,8 +8,6 @@ describe('favicon_tag', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const favicon = require('../../../lib/plugins/helper/favicon_tag').bind(ctx);
 
   it('path', () => {

--- a/test/scripts/helpers/feed_tag.js
+++ b/test/scripts/helpers/feed_tag.js
@@ -12,8 +12,6 @@ describe('feed_tag', () => {
 
   beforeEach(() => { ctx.config.feed = {}; });
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const feed = require('../../../lib/plugins/helper/feed_tag').bind(ctx);
 
   it('path - atom', () => {

--- a/test/scripts/helpers/image_tag.js
+++ b/test/scripts/helpers/image_tag.js
@@ -8,8 +8,6 @@ describe('image_tag', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const img = require('../../../lib/plugins/helper/image_tag').bind(ctx);
 
   it('path', () => {

--- a/test/scripts/helpers/js.js
+++ b/test/scripts/helpers/js.js
@@ -10,8 +10,6 @@ describe('js', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const js = require('../../../lib/plugins/helper/js').bind(ctx);
 
   function assertResult(result, expected) {

--- a/test/scripts/helpers/link_to.js
+++ b/test/scripts/helpers/link_to.js
@@ -8,8 +8,6 @@ describe('link_to', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const linkTo = require('../../../lib/plugins/helper/link_to').bind(ctx);
 
   it('path', () => {

--- a/test/scripts/helpers/list_archives.js
+++ b/test/scripts/helpers/list_archives.js
@@ -10,8 +10,6 @@ describe('list_archives', () => {
     page: {}
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const listArchives = require('../../../lib/plugins/helper/list_archives').bind(ctx);
 
   function resetLocals() {

--- a/test/scripts/helpers/list_categories.js
+++ b/test/scripts/helpers/list_categories.js
@@ -10,8 +10,6 @@ describe('list_categories', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const listCategories = require('../../../lib/plugins/helper/list_categories').bind(ctx);
 
   before(async () => {

--- a/test/scripts/helpers/list_posts.js
+++ b/test/scripts/helpers/list_posts.js
@@ -9,8 +9,6 @@ describe('list_posts', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const listPosts = require('../../../lib/plugins/helper/list_posts').bind(ctx);
 
   hexo.config.permalink = ':title/';

--- a/test/scripts/helpers/list_tags.js
+++ b/test/scripts/helpers/list_tags.js
@@ -10,8 +10,6 @@ describe('list_tags', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const listTags = require('../../../lib/plugins/helper/list_tags').bind(ctx);
 
   before(async () => {

--- a/test/scripts/helpers/mail_to.js
+++ b/test/scripts/helpers/mail_to.js
@@ -10,8 +10,6 @@ describe('mail_to', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const mailto = require('../../../lib/plugins/helper/mail_to').bind(ctx);
 
   it('path', () => {

--- a/test/scripts/helpers/paginator.js
+++ b/test/scripts/helpers/paginator.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const { url_for } = require('hexo-util');
+
 describe('paginator', () => {
   const Hexo = require('../../../lib/hexo');
   const hexo = new Hexo(__dirname);
@@ -13,12 +15,10 @@ describe('paginator', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const paginator = require('../../../lib/plugins/helper/paginator').bind(ctx);
 
   function link(i) {
-    return ctx.url_for(i === 1 ? '' : 'page/' + i + '/');
+    return url_for.call(ctx, i === 1 ? '' : 'page/' + i + '/');
   }
 
   function checkResult(result, data) {

--- a/test/scripts/helpers/tagcloud.js
+++ b/test/scripts/helpers/tagcloud.js
@@ -12,8 +12,6 @@ describe('tagcloud', () => {
     config: hexo.config
   };
 
-  ctx.url_for = require('../../../lib/plugins/helper/url_for').bind(ctx);
-
   const tagcloud = require('../../../lib/plugins/helper/tagcloud').bind(ctx);
 
   before(async () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
``` js
const css = hexo.extend.helper.get('css').bind(hexo)
const css = hexo.extend.helper.get('css')
```

doesn't work for me, somehow [`url_for()`](https://github.com/hexojs/hexo/blob/14890743dd00e1a1e7c4bd9c7ef632f609d35a4c/lib/plugins/helper/css.js#L27) is not available in the `hexo` context. I tried v4.0.0, v4.1.1, v4.2.1 & v5 in Node 12.18


## How to test

```sh
git clone -b url_for https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
