### PR TITLE
perf(external_link): update regexp

### DIFF
--- a/lib/plugins/filter/after_post_render/external_link.js
+++ b/lib/plugins/filter/after_post_render/external_link.js
@@ -2,7 +2,7 @@
 
 const { isExternalLink } = require('hexo-util');
 let EXTERNAL_LINK_POST_ENABLED = true;
-const rATag = /<a(?:\s+?|\s+?[^<>]+\s+?)?href=["']([^<>"']+)["'][^<>]*>/gi;
+const rATag = /<a(?:\s+?|\s+?[^<>]+\s+?)?href=["']((?:\/\/|http(?:s)?:)[^<>"']+)["'][^<>]*>/gi;
 const rTargetAttr = /target=/i;
 const rRelAttr = /rel=/i;
 const rRelStrAttr = /rel=["']([^<>"']*)["']/i;

--- a/lib/plugins/filter/after_render/external_link.js
+++ b/lib/plugins/filter/after_render/external_link.js
@@ -3,7 +3,7 @@
 const { isExternalLink } = require('hexo-util');
 
 let EXTERNAL_LINK_SITE_ENABLED = true;
-const rATag = /<a(?:\s+?|\s+?[^<>]+\s+?)?href=["']([^<>"']+)["'][^<>]*>/gi;
+const rATag = /<a(?:\s+?|\s+?[^<>]+\s+?)?href=["']((?:\/\/|http(?:s)?:)[^<>"']+)["'][^<>]*>/gi;
 const rTargetAttr = /target=/i;
 const rRelAttr = /rel=/i;
 const rRelStrAttr = /rel=["']([^<>"']*)["']/i;


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

`isExternalLink()` has a shorthand optimization for absolute link:

https://github.com/hexojs/hexo-util/blob/fe64888f28acaa77f26eab04e7d358c6e6029967/lib/is_external_link.js#L19

Then I think why can't we exclude relative link directly in the `rATag` to avoid extra `isExternalLink()` and `RegExp#test`? So here is the PR.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
