### PR TITLE
Revert "perf: avoid running plugins in 'clean' command"

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -222,16 +222,6 @@ class Hexo extends EventEmitter {
   }
 
   init() {
-    // Load only the relevant plugins in hexo clean
-    if (this.env.cmd === 'clean') {
-      this.env.init = true;
-      return Promise.all([
-        this.extend.console.register('clean', 'Remove generated files and cache.', require('../plugins/console/clean')),
-        require('../plugins/filter')(this),
-        require('./load_plugins')(this)
-      ]);
-    }
-
     this.log.debug('Hexo version: %s', magenta(this.version));
     this.log.debug('Working directory: %s', magenta(tildify(this.base_dir)));
 


### PR DESCRIPTION
This reverts commit 33dcc90b7914d9b96fb666e9cb7322868f00acae (#4386).

load_plugins.js was initially retained so that `after_clean` filter
still can run, however it loads every plugins including irrelevant
ones; this can cause `undefined` error when running `hexo clean` especially in hexo.extend.helper.get()
because default helpers are not loaded.

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?



## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
