### PR TITLE
fix(#4460): refactor post escape

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -12,6 +12,7 @@ const { parse: yfmParse, split: yfmSplit, stringify: yfmStringify } = require('h
 const preservedKeys = ['title', 'slug', 'path', 'layout', 'date', 'content'];
 
 const rPlaceholder = /(?:<|&lt;)!--\uFFFC(\d+)--(?:>|&gt;)/g;
+const rHexoPostRenderEscape = /<!--hexoPostRenderEscape:([\s\S]+?):hexoPostRenderEscape-->/g;
 const rSwigVarAndComment = /{[{#][\s\S]+?[}#]}/g;
 const rSwigFullBlock = /{% *(\S+?)(?: *| +.+?)%}[\s\S]+?{% *end\1 *%}/g;
 const rSwigBlock = /{%[\s\S]+?%}/g;
@@ -24,10 +25,6 @@ class PostRenderCache {
   }
 
   loadContent(str) {
-    if (str.includes('hexoPostRenderEscape')) {
-      str = str.replace(/<!--hexoPostRenderEscape:/g, '').replace(/:hexoPostRenderEscape-->/g, '');
-    }
-
     const restored = str.replace(rPlaceholder, (_, index) => {
       assert(this.cache[index]);
       const value = this.cache[index];
@@ -36,6 +33,10 @@ class PostRenderCache {
     });
     if (restored === str) return restored;
     return this.loadContent(restored); // self-recursive for nexted escaping
+  }
+
+  escapeContent(str) {
+    return str.replace(rHexoPostRenderEscape, (_, content) => _escapeContent(this.cache, content));
   }
 
   escapeAllSwigTags(str) {
@@ -247,6 +248,7 @@ class Post {
       // Run "before_post_render" filters
       return ctx.execFilter('before_post_render', data, { context: ctx });
     }).then(() => {
+      data.content = cacheObj.escapeContent(data.content);
       // Escape all Nunjucks/Swig tags
       if (!disableNunjucks) {
         data.content = cacheObj.escapeAllSwigTags(data.content);

--- a/test/fixtures/post_render.js
+++ b/test/fixtures/post_render.js
@@ -90,3 +90,11 @@ exports.content_for_issue_4317 = [
   'echo "Hi"',
   '```'
 ].join('\n');
+
+exports.content_for_issue_4460 = [
+  '```html',
+  '<body>',
+  '<!-- here goes the rest of the page -->',
+  '</body>',
+  '```'
+].join('\n');

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -1169,4 +1169,21 @@ describe('Post', () => {
     data.content.should.not.contains('&amp;#123');
     data.content.should.not.contains('&amp;#125');
   });
+
+  it('render() - issue #4460', async () => {
+    hexo.config.prismjs.enable = true;
+    hexo.config.highlight.enable = false;
+
+    const content = fixture.content_for_issue_4460;
+
+    const data = await post.render(null, {
+      content,
+      engine: 'markdown'
+    });
+
+    data.content.should.not.include('hexoPostRenderEscape');
+
+    hexo.config.prismjs.enable = false;
+    hexo.config.highlight.enable = true;
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Basically the PR is reverting https://github.com/hexojs/hexo/pull/4254.

Given a code block like this:

````markdown
```html
<body>
  <!-- here goes the rest of the page -->
</body>
```
````

`backtick_code_block` will use `prismjs` to convert the code block into html:

```
<!--hexoPostRenderEscape:<pre class="line-numbers language-html" data-language="html"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>body</span><span class="token punctuation">></span></span>
<span class="token comment">&lt;!-- here goes the rest of the page --></span>
<span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>body</span><span class="token punctuation">></span></span><span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span></span></code></pre>:hexoPostRenderEscape-->
```

`<!--hexoPostRenderEscape:` & `:hexoPostRenderEscape-->` is added by Hexo to avoid missing paragraph issue.

> Why they are needed, what is "missing paragraph" issue: https://github.com/hexojs/hexo/pull/4171#discussion_r387542843

However, instead of ignoring the comment, `marked.js.org` will add extra `<p>` tag:

```
<!--hexoPostRenderEscape:<pre class="line-numbers language-html" data-language="html"><code class="language-html"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;</span>body</span><span class="token punctuation">></span></span>
  <span class="token comment">&lt;!-- here goes the rest of the page --></span>
<p><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>body</span><span class="token punctuation">&gt;</span></span><span aria-hidden="true" class="line-numbers-rows"><span></span><span></span><span></span></span></code></pre>:hexoPostRenderEscape--&gt;</p>
```

With extra `<p>` tag the code block is now broken and `:hexoPostRenderEscape--&gt;` can not be matched & removed.

> Ref: marked.js demo: https://marked.js.org/demo/

So to prevent `marked.js` from breaking the html, the PR reverts the behavior introduced by #4254 

The performance is not affected.

## How to test

```sh
git clone -b fix-4460 https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.

cc @jerryc127.
