### PR TITLE
Remove plugins option in config

### DIFF
--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -15,11 +15,7 @@ function loadModuleList(ctx) {
   let customThemeName;
 
   if (ctx.config) {
-    const { theme, plugins } = ctx.config;
-
-    if (Array.isArray(plugins)) {
-      return Promise.resolve(plugins).filter(item => typeof item === 'string');
-    }
+    const { theme } = ctx.config;
 
     if (theme) {
       customThemeName = String(theme);

--- a/test/scripts/hexo/load_plugins.js
+++ b/test/scripts/hexo/load_plugins.js
@@ -106,28 +106,6 @@ describe('Load plugins', () => {
     });
   });
 
-  it('specify plugin list in config', () => {
-    const names = ['hexo-plugin-test', 'another-plugin'];
-    const paths = names.map(name => join(hexo.plugin_dir, name, 'index.js'));
-
-    return Promise.all([
-      createPackageFile(...names),
-      fs.writeFile(paths[0], 'hexo._script_test0 = true'),
-      fs.writeFile(paths[1], 'hexo._script_test1 = true')
-    ]).then(() => {
-      hexo.config.plugins = [names[1]];
-      return loadPlugins(hexo);
-    }).then(() => {
-      should.not.exist(hexo._script_test0);
-      hexo._script_test1.should.be.true;
-
-      delete hexo.config.plugins;
-      delete hexo._script_test1;
-
-      return Promise.map(paths, path => fs.unlink(path));
-    });
-  });
-
   it('ignore plugin whose name is "hexo-theme-[hexo.config.theme]"', async () => {
     hexo.config.theme = 'test_theme';
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Reverts https://github.com/hexojs/hexo/commit/f6407dc946c2a686731b2480ee6ed0b37f54c5f1
Issue resolved: https://github.com/hexojs/hexo/issues/1670#issuecomment-671682748
The easiest way to install local plugins is to place them in the `scripts` directory instead of `node_modules`.

## How to test

```sh
git clone -b plugins https://github.com/hexojs/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
