### PR TITLE
refactor(backtick_code): remove "~~~" support

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -2,7 +2,7 @@
 
 let highlight, prismHighlight;
 
-const rBacktick = /^((?:[^\S\r\n]*>){0,3}[^\S\r\n]*)(`{3,}|~{3,})[^\S\r\n]*((?:.*?[^`\s])?)[^\S\r\n]*\n((?:[\s\S]*?\n)?)(?:(?:[^\S\r\n]*>){0,3}[^\S\r\n]*)\2(\n+|$)/gm;
+const rBacktick = /^((?:[^\S\r\n]*>){0,3}[^\S\r\n]*)`{3,}[^\S\r\n]*((?:.*?[^`\s])?)[^\S\r\n]*\n((?:[\s\S]*?\n)?)(?:(?:[^\S\r\n]*>){0,3}[^\S\r\n]*)`{3,}(\n+|$)/gm;
 const rAllOptions = /([^\s]+)\s+(.+?)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/;
 const rLangCaption = /([^\s]+)\s*(.+)?/;
 
@@ -11,12 +11,12 @@ const escapeSwigTag = str => str.replace(/{/g, '&#123;').replace(/}/g, '&#125;')
 function backtickCodeBlock(data) {
   const dataContent = data.content;
 
-  if (!dataContent.includes('```') && !dataContent.includes('~~~')) return;
+  if (!dataContent.includes('```')) return;
 
   const hljsCfg = this.config.highlight || {};
   const prismCfg = this.config.prismjs || {};
 
-  data.content = dataContent.replace(rBacktick, ($0, start, $2, _args, _content, end) => {
+  data.content = dataContent.replace(rBacktick, ($0, start, _args, _content, end) => {
     let content = _content.replace(/\n$/, '');
 
     // neither highlight or prismjs is enabled, return escaped content directly.


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

From `rBacktick` it appears that hexo supports 2 syntax:

````
``` & ~~~
````

However, `~~~` syntax is never documented. And by removing it, the unit test could still be passed.

I am wonder `~~~` is introduced for nested code block highlight:

````
~~~
```
Look! This is an example of nested code block.
```
~~~
````

But Hexo already has a `codeblock` tag plugin, nested code block shouldn't be a problem.

The performance has been improved by 2%.

## How to test

```sh
git clone -b perf-faster-backtick-code-filter https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
