### PR TITLE
perf(backtick_code): avoid duplicated escaping

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -11,36 +11,44 @@ const { copyDir, exists, listDir, mkdirs, readFile, rmdir, unlink, writeFile } =
 const { parse: yfmParse, split: yfmSplit, stringify: yfmStringify } = require('hexo-front-matter');
 const preservedKeys = ['title', 'slug', 'path', 'layout', 'date', 'content'];
 
-const rPlaceholder = /(?:<|&lt;)!--\uFFFC(\d+)--(?:>|&gt;)/g;
-const rHexoPostRenderEscape = /<!--hexoPostRenderEscape:([\s\S]+?):hexoPostRenderEscape-->/g;
+const rHexoPostRenderEscape = /<hexoPostRenderCodeBlock>([\s\S]+?)<\/hexoPostRenderCodeBlock>/g;
 const rSwigVarAndComment = /{[{#][\s\S]+?[}#]}/g;
 const rSwigFullBlock = /{% *(\S+?)(?: *| +.+?)%}[\s\S]+?{% *end\1 *%}/g;
 const rSwigBlock = /{%[\s\S]+?%}/g;
 
-const _escapeContent = (cache, str) => `<!--\uFFFC${cache.push(str) - 1}-->`;
+const rSwigPlaceHolder = /(?:<|&lt;)!--swig\uFFFC(\d+)--(?:>|&gt;)/g;
+const rCodeBlockPlaceHolder = /(?:<|&lt;)!--code\uFFFC(\d+)--(?:>|&gt;)/g;
+
+const _escapeContent = (cache, flag, str) => `<!--${flag}\uFFFC${cache.push(str) - 1}-->`;
+
+const _restoreContent = cache => (_, index) => {
+  assert(cache[index]);
+  const value = cache[index];
+  cache[index] = null;
+  return value;
+};
 
 class PostRenderCache {
   constructor() {
     this.cache = [];
   }
 
-  loadContent(str) {
-    const restored = str.replace(rPlaceholder, (_, index) => {
-      assert(this.cache[index]);
-      const value = this.cache[index];
-      this.cache[index] = null;
-      return value;
-    });
+  restoreAllSwigTags(str) {
+    const restored = str.replace(rSwigPlaceHolder, _restoreContent(this.cache));
     if (restored === str) return restored;
-    return this.loadContent(restored); // self-recursive for nexted escaping
+    return this.restoreAllSwigTags(restored); // self-recursive for nexted escaping
   }
 
-  escapeContent(str) {
-    return str.replace(rHexoPostRenderEscape, (_, content) => _escapeContent(this.cache, content));
+  restoreCodeBlocks(str) {
+    return str.replace(rCodeBlockPlaceHolder, _restoreContent(this.cache));
+  }
+
+  escapeCodeBlocks(str) {
+    return str.replace(rHexoPostRenderEscape, (_, content) => _escapeContent(this.cache, 'code', content));
   }
 
   escapeAllSwigTags(str) {
-    const escape = _str => _escapeContent(this.cache, _str);
+    const escape = _str => _escapeContent(this.cache, 'swig', _str);
     return str.replace(rSwigVarAndComment, escape) // Remove swig comment first to reduce string size being matched next
       .replace(rSwigFullBlock, escape) // swig full block must escaped before swig block to avoid confliction
       .replace(rSwigBlock, escape);
@@ -248,7 +256,7 @@ class Post {
       // Run "before_post_render" filters
       return ctx.execFilter('before_post_render', data, { context: ctx });
     }).then(() => {
-      data.content = cacheObj.escapeContent(data.content);
+      data.content = cacheObj.escapeCodeBlocks(data.content);
       // Escape all Nunjucks/Swig tags
       if (!disableNunjucks) {
         data.content = cacheObj.escapeAllSwigTags(data.content);
@@ -266,7 +274,7 @@ class Post {
         toString: true,
         onRenderEnd(content) {
           // Replace cache data with real contents
-          data.content = cacheObj.loadContent(content);
+          data.content = cacheObj.restoreAllSwigTags(content);
 
           // Return content after replace the placeholders
           if (disableNunjucks) return data.content;
@@ -276,7 +284,7 @@ class Post {
         }
       }, options);
     }).then(content => {
-      data.content = content;
+      data.content = cacheObj.restoreCodeBlocks(content);
 
       // Run "after_post_render" filters
       return ctx.execFilter('after_post_render', data, { context: ctx });

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -92,9 +92,9 @@ function backtickCodeBlock(data) {
     }
 
     return start
-      + '<!--hexoPostRenderEscape:'
+      + '<hexoPostRenderCodeBlock>'
       + escapeSwigTag(content)
-      + ':hexoPostRenderEscape-->'
+      + '</hexoPostRenderCodeBlock>'
       + end;
   });
 }

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -98,7 +98,7 @@ describe('Backtick code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code, {lang: 'js'}) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + highlight(code, {lang: 'js'}) + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - without language name', () => {
@@ -113,7 +113,7 @@ describe('Backtick code block', () => {
     const expected = highlight(code);
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - without language name - ignore tab character', () => {
@@ -128,7 +128,7 @@ describe('Backtick code block', () => {
     const expected = highlight(code);
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - title', () => {
@@ -146,7 +146,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - url', () => {
@@ -164,7 +164,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - link text', () => {
@@ -182,7 +182,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - indent', () => {
@@ -202,7 +202,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - line number false', () => {
@@ -222,7 +222,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - line number false, don`t first_line_number always1', () => {
@@ -243,7 +243,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - line number false, don`t care first_line_number inilne', () => {
@@ -264,7 +264,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - line number true', () => {
@@ -284,7 +284,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - line number, first_line_number always1, js=', () => {
@@ -306,7 +306,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - line number, first_line_number inline, js', () => {
@@ -328,7 +328,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - line number, first_line_number inline, js=1', () => {
@@ -350,7 +350,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - line number, first_line_number inline, js=2', () => {
@@ -372,7 +372,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - tab replace', () => {
@@ -398,7 +398,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('highlightjs - wrap', () => {
@@ -413,7 +413,7 @@ describe('Backtick code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code, { lang: 'js', wrap: false }) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + highlight(code, { lang: 'js', wrap: false }) + '</hexoPostRenderCodeBlock>');
 
     hexo.config.highlight.wrap = true;
   });
@@ -431,7 +431,7 @@ describe('Backtick code block', () => {
     };
     codeBlock(data);
 
-    data.content.should.eql('```foo```\n\n<!--hexoPostRenderEscape:' + highlight(code, {}) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('```foo```\n\n<hexoPostRenderCodeBlock>' + highlight(code, {}) + '</hexoPostRenderCodeBlock>');
   });
 
   // test for Issue #4190
@@ -449,7 +449,7 @@ describe('Backtick code block', () => {
     };
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + highlight(code + '\nfoo```\n\nbar```\nbaz', {}) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + highlight(code + '\nfoo```\n\nbar```\nbaz', {}) + '</hexoPostRenderCodeBlock>');
 
   });
 
@@ -466,7 +466,7 @@ describe('Backtick code block', () => {
 
     codeBlock(data);
 
-    data.content.should.eql('<!--hexoPostRenderEscape:' + prism(code, {lang: 'js'}) + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + prism(code, {lang: 'js'}) + '</hexoPostRenderCodeBlock>');
   });
 
   it('prismjs - without language name', () => {
@@ -483,7 +483,7 @@ describe('Backtick code block', () => {
     const expected = prism(code);
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
 
@@ -501,7 +501,7 @@ describe('Backtick code block', () => {
     const expected = prism(code);
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('prismjs - indent', () => {
@@ -520,7 +520,7 @@ describe('Backtick code block', () => {
     const expected = prism(code, { lang: 'js' });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('prismjs - line number false', () => {
@@ -542,7 +542,7 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 
   it('prismjs - tab replace', () => {
@@ -570,6 +570,6 @@ describe('Backtick code block', () => {
     });
 
     codeBlock(data);
-    data.content.should.eql('<!--hexoPostRenderEscape:' + expected + ':hexoPostRenderEscape-->');
+    data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

In #4418 I have introduced the code escaping during tag plugins rendering. In #4472 I have brought back the backtick code block escaping during markdown rendering.

To avoid duplicated escaping, the PR will only restore escaped backtick code block after tag plugin rendering is finished,

The performance improves by 2%.

## How to test

```sh
git clone -b refactor-codeblock-escape https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
