### PR TITLE
refactor: replace url.resolve() with String.replace()

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -119,7 +119,7 @@ function openGraphHelper(options = {}) {
   images = images.map(path => {
     if (!parse(path).host) {
       // resolve `path`'s absolute path relative to current page's url
-      // `path` can be both absolute (starts with `/`) or relative.
+      // `path` can be both absolute (starts with `http://`) or relative (starts with `/`).
       return resolve(url || config.url, path);
     }
 

--- a/lib/plugins/tag/asset_img.js
+++ b/lib/plugins/tag/asset_img.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { resolve } = require('url');
 const img = require('./img');
 const { encodeURL } = require('hexo-util');
 
@@ -20,7 +19,7 @@ module.exports = ctx => {
     for (let i = 0; i < len; i++) {
       const asset = PostAsset.findOne({post: this._id, slug: args[i]});
       if (asset) {
-        args[i] = encodeURL(resolve('/', asset.path));
+        args[i] = encodeURL(('/' + asset.path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
         return img(ctx)(args);
       }
     }

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { encodeURL, escapeHTML } = require('hexo-util');
-const { resolve } = require('url');
 
 /**
  * Asset link tag
@@ -30,7 +29,7 @@ module.exports = ctx => {
     const attrTitle = escapeHTML(title);
     if (escape === 'true') title = attrTitle;
 
-    const link = encodeURL(resolve(ctx.config.root, asset.path));
+    const link = encodeURL((ctx.config.root + asset.path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
 
     return `<a href="${link}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { resolve } = require('url');
 const { encodeURL } = require('hexo-util');
 
 /**
@@ -19,7 +18,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const path = encodeURL(resolve(ctx.config.root, asset.path));
+    const path = encodeURL((ctx.config.root + asset.path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
 
     return path;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { encodeURL, escapeHTML } = require('hexo-util');
-const { resolve } = require('url');
 
 /**
  * Post link tag
@@ -31,7 +30,7 @@ module.exports = ctx => {
     const attrTitle = escapeHTML(title);
     if (escape === 'true') title = attrTitle;
 
-    const link = encodeURL(resolve(ctx.config.root, post.path));
+    const link = encodeURL((ctx.config.root + post.path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
 
     return `<a href="${link}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { resolve } = require('url');
 const { encodeURL } = require('hexo-util');
 
 /**
@@ -19,7 +18,7 @@ module.exports = ctx => {
     const post = Post.findOne({slug});
     if (!post) return;
 
-    const link = encodeURL(resolve(ctx.config.root, post.path));
+    const link = encodeURL((ctx.config.root + post.path).replace(/\\/g, '/').replace(/\/{2,}/g, '/'));
 
     return link;
   };


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
[`url.resolve()`](https://nodejs.org/api/url.html#url_url_resolve_from_to) is a legacy API, so it's best to avoid it if possible, `String.replace()` is also 6x faster.


## How to test

```sh
git clone -b resolve-path-string-replace https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
