### PR TITLE
fix(filter/highlight): avoid escaping curly bracket when highlight & prismjs disabled

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -11,10 +11,10 @@ const escapeSwigTag = str => str.replace(/{/g, '&#123;').replace(/}/g, '&#125;')
 function backtickCodeBlock(data) {
   const dataContent = data.content;
 
-  if (!dataContent.includes('```') && !dataContent.includes('~~~')) return;
-
   const hljsCfg = this.config.highlight || {};
   const prismCfg = this.config.prismjs || {};
+
+  if ((!dataContent.includes('```') && !dataContent.includes('~~~')) || (!hljsCfg.enable && !prismCfg.enable)) return;
 
   data.content = dataContent.replace(rBacktick, ($0, start, $2, _args, _content, end) => {
     let content = _content.replace(/\n$/, '');

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -38,43 +38,43 @@ describe('Backtick code block', () => {
     hexo.config.prismjs = defaultConfig.prismjs;
   });
 
+  it('disabled', () => {
+    const content = [
+      '``` js',
+      code,
+      '```'
+    ].join('\n');
+
+    const data = {content};
+
+    hexo.config.highlight.enable = false;
+    hexo.config.prismjs.enable = false;
+    codeBlock(data);
+    data.content.should.eql(content);
+  });
+
+  it('with no config (disabled)', () => {
+    const content = [
+      '``` js',
+      code,
+      '```'
+    ].join('\n');
+
+    const data = {content};
+
+    const oldHljsCfg = hexo.config.highlight;
+    const oldPrismCfg = hexo.config.prismjs;
+    delete hexo.config.highlight;
+    delete hexo.config.prismjs;
+
+    codeBlock(data);
+    data.content.should.eql(content);
+
+    hexo.config.highlight = oldHljsCfg;
+    hexo.config.prismjs = oldPrismCfg;
+  });
+
   describe('highlightjs', () => {
-    it('disabled', () => {
-      const content = [
-        '``` js',
-        code,
-        '```'
-      ].join('\n');
-
-      const data = {content};
-
-      hexo.config.highlight.enable = false;
-      hexo.config.prismjs.enable = false;
-      codeBlock(data);
-      data.content.should.eql(content.replace(/{/g, '&#123;').replace(/}/g, '&#125;'));
-    });
-
-    it('with no config (disabled)', () => {
-      const content = [
-        '``` js',
-        code,
-        '```'
-      ].join('\n');
-
-      const data = {content};
-
-      const oldHljsCfg = hexo.config.highlight;
-      const oldPrismCfg = hexo.config.prismjs;
-      delete hexo.config.highlight;
-      delete hexo.config.prismjs;
-
-      codeBlock(data);
-      data.content.should.eql(content.replace(/{/g, '&#123;').replace(/}/g, '&#125;'));
-
-      hexo.config.highlight = oldHljsCfg;
-      hexo.config.prismjs = oldPrismCfg;
-    });
-
     it('shorthand', () => {
       const data = {
         content: 'Hello, world!'


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Fixes #4482


## How to test

```sh
git clone -b unescape-curly-bracket https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
