### PR TITLE
feat(load_plugin): ignore pkg name endswith theme name

### DIFF
--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -37,14 +37,14 @@ function loadModuleList(ctx) {
       return deps.concat(devDeps);
     });
   }).filter(name => {
-    // Ignore plugin whose name is "hexo-theme-[ctx.config.theme]"
-    if (name === `hexo-theme-${customThemeName}`) return false;
+    // Ignore plugin whose name endswith "hexo-theme-[ctx.config.theme]"
+    if (name.endsWith(`hexo-theme-${customThemeName}`)) return false;
 
     // Ignore plugins whose name is not started with "hexo-"
     if (!/^hexo-|^@[^/]+\/hexo-/.test(name)) return false;
 
     // Ignore typescript definition file that is started with "@types/"
-    if (/^@types\//.test(name)) return false;
+    if (name.startsWith('@types/')) return false;
 
     // Make sure the plugin exists
     const path = ctx.resolvePlugin(name);

--- a/test/scripts/hexo/load_plugins.js
+++ b/test/scripts/hexo/load_plugins.js
@@ -124,6 +124,24 @@ describe('Load plugins', () => {
     return fs.unlink(path);
   });
 
+  it('ignore plugin whose name endswith "hexo-theme-[hexo.config.theme]"', async () => {
+    hexo.config.theme = 'test_theme';
+
+    const script = 'hexo._script_test = true';
+    const name = '@hexojs/hexo-theme-test_theme';
+    const path = join(hexo.plugin_dir, name, 'index.js');
+
+    await Promise.all([
+      createPackageFile(name),
+      fs.writeFile(path, script)
+    ]);
+    await loadPlugins(hexo);
+
+    should.not.exist(hexo._script_test);
+    delete hexo.config.theme;
+    return fs.unlink(path);
+  });
+
   it('ignore plugins whose name is not started with "hexo-"', async () => {
     const script = 'hexo._script_test = true';
     const name = 'another-plugin';


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The first part of #4496. Prevent `@user/hexo-theme-[name]` being loaded as a plugin.

## How to test

```sh
git clone -b npm-theme-owner https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
