### PR TITLE
fix(disableNunjucks): query both async and sync versions of renderer

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -247,7 +247,17 @@ class Post {
     }
 
     // disable Nunjucks when the renderer specify that.
-    const disableNunjucks = ext && ctx.render.renderer.get(ext) && !!ctx.render.renderer.get(ext).disableNunjucks;
+    let disableNunjucks = false;
+    let extRenderer = ext && ctx.render.renderer.get(ext);
+    if (extRenderer) {
+      disableNunjucks = Boolean(extRenderer.disableNunjucks);
+      if (!Object.prototype.hasOwnProperty.call(extRenderer, 'disableNunjucks')) {
+        extRenderer = ctx.render.renderer.get(ext, true);
+        if (extRenderer) {
+          disableNunjucks = Boolean(extRenderer.disableNunjucks);
+        }
+      }
+    }
 
     const cacheObj = new PostRenderCache();
 
@@ -258,7 +268,7 @@ class Post {
     }).then(() => {
       data.content = cacheObj.escapeCodeBlocks(data.content);
       // Escape all Nunjucks/Swig tags
-      if (!disableNunjucks) {
+      if (disableNunjucks === false) {
         data.content = cacheObj.escapeAllSwigTags(data.content);
       }
 

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -742,6 +742,28 @@ describe('Post', () => {
     });
   });
 
+  // test for PR #4498
+  it('render() - (disableNunjucks === true) - sync', async () => {
+    const content = '{% link foo http://bar.com %}';
+    const loremFn = data => { return data.text.toUpperCase(); };
+    loremFn.disableNunjucks = true;
+    hexo.extend.renderer.register('coffee', 'js', loremFn, true);
+
+    const data = await post.render(null, { content, engine: 'coffee' });
+    data.content.should.eql(content.toUpperCase());
+  });
+
+  // test for PR #4498
+  it('render() - (disableNunjucks === false) - sync', async () => {
+    const content = '{% link foo http://bar.com %}';
+    const loremFn = data => { return data.text.toUpperCase(); };
+    loremFn.disableNunjucks = false;
+    hexo.extend.renderer.register('coffee', 'js', loremFn, true);
+
+    const data = await post.render(null, { content, engine: 'coffee' });
+    data.content.should.not.eql(content.toUpperCase());
+  });
+
   // test for PR #2321
   it('render() - allow backtick code block in "blockquote" tag plugin', () => {
     const code = 'alert("Hello world")';


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
A workaround to fix https://github.com/hexojs/hexo/issues/3860, `disableNunjucks` may not be reliable in synchronous mode. The issue could be due to [`Promise.method()`](https://github.com/hexojs/hexo/blob/9662366f9122192359f15861fe05574365e8465e/lib/extend/renderer.js#L53) not including `disableNunjucks` property.

Before: https://github.com/hexojs/hexo-renderer-coffeescript/pull/72/checks?check_run_id=1030164260
After: https://github.com/hexojs/hexo-renderer-coffeescript/pull/72/checks?check_run_id=1030174895


## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
