### PR TITLE
doc(extend/console): add jsdoc

### DIFF
--- a/lib/extend/console.js
+++ b/lib/extend/console.js
@@ -35,8 +35,8 @@ class Console {
    * Register a console plugin
    * @param {String} name - The name of console plugin to be registered
    * @param {String} desc - More detailed information about a console command
-   * @param {Option} options - The description of each option of a console command.
-   * @param {Function} fn
+   * @param {Option} options - The description of each option of a console command
+   * @param {Function} fn - The console plugin to be registered
    */
   register(name, desc, options, fn) {
     if (!name) throw new TypeError('name is required');

--- a/lib/extend/console.js
+++ b/lib/extend/console.js
@@ -3,12 +3,25 @@
 const Promise = require('bluebird');
 const abbrev = require('abbrev');
 
+/**
+ * Console plugin option
+ * @typedef {Object} Option
+ * @property {String} usage - The usage of a console command
+ * @property {{name: String, desc: String}[]} arguments - The description of each argument of a console command
+ * @property {{name: String, desc: String}[]} options - The description of each option of a console command
+ */
+
 class Console {
   constructor() {
     this.store = {};
     this.alias = {};
   }
 
+  /**
+   * Get a console plugin function by name
+   * @param {String} name - The name of the console plugin
+   * @returns {Function} - The console plugin function
+   */
   get(name) {
     name = name.toLowerCase();
     return this.store[this.alias[name]];
@@ -18,6 +31,13 @@ class Console {
     return this.store;
   }
 
+  /**
+   * Register a console plugin
+   * @param {String} name - The name of console plugin to be registered
+   * @param {String} desc - More detailed information about a console command
+   * @param {Option} options - The description of each option of a console command.
+   * @param {Function} fn
+   */
   register(name, desc, options, fn) {
     if (!name) throw new TypeError('name is required');
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

#4136 

Before we migrate Hexo to typescript, we could first bring up JSDoc. It will not only help the migration later but also provides the autocompletion for those plugin developers.

cc @septs

## How to test

```sh
git clone -b jsdoc-type-extend-console https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
