### PR TITLE
chore: use example.com for example domain

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -9,7 +9,7 @@ module.exports = {
   language: 'en',
   timezone: '',
   // URL
-  url: 'http://yoursite.com',
+  url: 'http://example.com',
   root: '/',
   permalink: ':year/:month/:day/:title/',
   permalink_defaults: {},

--- a/test/scripts/helpers/feed_tag.js
+++ b/test/scripts/helpers/feed_tag.js
@@ -4,7 +4,7 @@ describe('feed_tag', () => {
   const ctx = {
     config: {
       title: 'Hexo',
-      url: 'http://yoursite.com',
+      url: 'http://example.com',
       root: '/',
       feed: {}
     }

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -135,7 +135,7 @@ describe('open_graph', () => {
       page: {},
       config: hexo.config,
       is_post: isPost,
-      url: 'http://yoursite.com/page/index.html'
+      url: 'http://example.com/page/index.html'
     });
 
     const $ = cheerio.load(result);
@@ -151,7 +151,7 @@ describe('open_graph', () => {
       page: {},
       config: hexo.config,
       is_post: isPost,
-      url: 'http://yoursite.com/page/about.html'
+      url: 'http://example.com/page/about.html'
     });
 
     const $ = cheerio.load(result);
@@ -163,7 +163,7 @@ describe('open_graph', () => {
 
   it('url - null pretty_urls', () => {
     hexo.config.pretty_urls = null;
-    const url = 'http://yoursite.com/page/about.html';
+    const url = 'http://example.com/page/about.html';
     const result = openGraph.call({
       page: {},
       config: hexo.config,

--- a/test/scripts/models/post.js
+++ b/test/scripts/models/post.js
@@ -88,7 +88,7 @@ describe('Post', () => {
       slug
     }).then(data => {
       data.permalink.should.eql(full_url_for.call(hexo, slug));
-      hexo.config.url = 'http://yoursite.com';
+      hexo.config.url = 'http://example.com';
       return Post.removeById(data._id);
     });
   });
@@ -107,19 +107,19 @@ describe('Post', () => {
   });
 
   it('permalink_root_prefix - virtual', () => {
-    hexo.config.url = 'http://yoursite.com/root';
+    hexo.config.url = 'http://example.com/root';
     hexo.config.root = '/root/';
     return Post.insert({
       source: 'foo.md',
       slug: 'bar'
     }).then(data => {
-      data.permalink.should.eql('http://yoursite.com/root/' + data.path);
+      data.permalink.should.eql('http://example.com/root/' + data.path);
       return Post.removeById(data._id);
     });
   });
 
   it('permalink_root_prefix - virtual - when set relative_link', () => {
-    hexo.config.url = 'http://yoursite.com/root';
+    hexo.config.url = 'http://example.com/root';
     hexo.config.root = '/root/';
     hexo.config.relative_link = true;
     return Post.insert({

--- a/test/scripts/tags/img.js
+++ b/test/scripts/tags/img.js
@@ -27,7 +27,7 @@ describe('img', () => {
     let $ = cheerio.load(img(['/images/test.jpg']));
     $('img').attr('src').should.eql('/images/test.jpg');
 
-    hexo.config.url = 'http://yoursite.com/root';
+    hexo.config.url = 'http://example.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img(['/images/test.jpg']));
     $('img').attr('src').should.eql('/root/images/test.jpg');
@@ -46,7 +46,7 @@ describe('img', () => {
     $('img').attr('src').should.eql('/images/test.jpg');
     $('img').attr('class').should.eql('left');
 
-    hexo.config.url = 'http://yoursite.com/root';
+    hexo.config.url = 'http://example.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img('left /images/test.jpg'.split(' ')));
     $('img').attr('src').should.eql('/root/images/test.jpg');
@@ -66,7 +66,7 @@ describe('img', () => {
     $('img').attr('src').should.eql('/images/test.jpg');
     $('img').attr('class').should.eql('left top');
 
-    hexo.config.url = 'http://yoursite.com/root';
+    hexo.config.url = 'http://example.com/root';
     hexo.config.root = '/root/';
     $ = cheerio.load(img('left top /images/test.jpg'.split(' ')));
     $('img').attr('src').should.eql('/root/images/test.jpg');


### PR DESCRIPTION
## What does it do?

We should stop to use `yoursite.com`.
`yoursite.com` is a real company's domain.

We can use `example.com` instead of `yoursite.com`.

> [Reserved Example Second Level Domain Names](https://tools.ietf.org/html/rfc2606#section-3)

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

NONE

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
