### PR TITLE
fix(router): convert string to buffer in route stream

### DIFF
--- a/lib/hexo/router.js
+++ b/lib/hexo/router.js
@@ -14,11 +14,28 @@ class RouteStream extends Readable {
     this.modified = data.modified;
   }
 
+  // Assume we only accept Buffer, plain object, or string
+  _toBuffer(data) {
+    if (data instanceof Buffer) {
+      return data;
+    }
+    if (typeof data === 'object') {
+      data = JSON.stringify(data);
+    }
+    if (typeof data === 'string') {
+      return Buffer.from(data); // Assume string is UTF-8 encoded string
+    }
+    return null;
+  }
+
   _read() {
     const data = this._data;
 
     if (typeof data !== 'function') {
-      this.push(data);
+      const bufferData = this._toBuffer(data);
+      if (bufferData) {
+        this.push(bufferData);
+      }
       this.push(null);
       return;
     }
@@ -40,13 +57,11 @@ class RouteStream extends Readable {
         data.on('error', err => {
           this.emit('error', err);
         });
-      } else if (data instanceof Buffer || typeof data === 'string') {
-        this.push(data);
-        this.push(null);
-      } else if (typeof data === 'object') {
-        this.push(JSON.stringify(data));
-        this.push(null);
       } else {
+        const bufferData = this._toBuffer(data);
+        if (bufferData) {
+          this.push(bufferData);
+        }
         this.push(null);
       }
     }).catch(err => {

--- a/test/scripts/console/generate.js
+++ b/test/scripts/console/generate.js
@@ -261,6 +261,27 @@ describe('generate', () => {
     });
   });
 
+  it('should generate all files when bail option is set to true and no errors', async () => {
+    // Test cases for hexojs/hexo#4499
+    hexo.extend.generator.register('resource', () =>
+      [
+        {
+          path: 'resource-1',
+          data: 'string'
+        },
+        {
+          path: 'resource-2',
+          data: {}
+        },
+        {
+          path: 'resource-3',
+          data: () => Promise.resolve(Buffer.from('string'))
+        }
+      ]
+    );
+    return generate({ bail: true });
+  });
+
   it('should generate all files even when concurrency is set', async () => {
     await generate({ concurrency: 1 });
     return generate({ concurrency: 2 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fix #4499. `hexo g` fails when `--bail` is set and there is dynamically generated content from Hexo generators. The root cause of this problem is that the `writeFile` function in `lib/plugins/console/generate.js` tries to concatenate strings generated from `RouteStream`s as buffers. The fix is to convert these strings to buffers beforehand in the `RouteStream`.

## How to test

```sh
git clone -b BRANCH https://github.com/ppoffice/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

Not applicable.

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
