### PR TITLE
feat: support 'disableNunjucks' in front-matter

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -259,6 +259,9 @@ class Post {
       }
     }
 
+    // front-matter overrides renderer's option
+    if (typeof data.disableNunjucks === 'boolean') disableNunjucks = data.disableNunjucks;
+
     const cacheObj = new PostRenderCache();
 
     return promise.then(content => {

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -749,6 +749,55 @@ describe('Post', () => {
     data.content.should.not.eql(content.toUpperCase());
   });
 
+  it('render() - (disableNunjucks === true) - front-matter', async () => {
+    const renderer = hexo.render.renderer.get('markdown');
+    renderer.disableNunjucks = true;
+
+    try {
+      const data = await post.render(null, {
+        content: fixture.content,
+        engine: 'markdown',
+        disableNunjucks: false
+      });
+      data.content.trim().should.eql(fixture.expected);
+    } finally {
+      renderer.disableNunjucks = false;
+    }
+  });
+
+  it('render() - (disableNunjucks === false) - front-matter', async () => {
+    const renderer = hexo.render.renderer.get('markdown');
+    renderer.disableNunjucks = false;
+
+    try {
+      const data = await post.render(null, {
+        content: fixture.content,
+        engine: 'markdown',
+        disableNunjucks: true
+      });
+      data.content.trim().should.eql(fixture.expected_disable_nunjucks);
+    } finally {
+      renderer.disableNunjucks = false;
+    }
+  });
+
+  // Only boolean type of front-matter's disableNunjucks is valid
+  it('render() - (disableNunjucks === null) - front-matter', async () => {
+    const renderer = hexo.render.renderer.get('markdown');
+    renderer.disableNunjucks = true;
+
+    try {
+      const data = await post.render(null, {
+        content: fixture.content,
+        engine: 'markdown',
+        disableNunjucks: null
+      });
+      data.content.trim().should.eql(fixture.expected_disable_nunjucks);
+    } finally {
+      renderer.disableNunjucks = false;
+    }
+  });
+
   // #2321
   it('render() - allow backtick code block in "blockquote" tag plugin', async () => {
     const code = 'alert("Hello world")';


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Requested by https://github.com/hexojs/hexo/issues/3259 cc @noraj 

Although the behavior of ```` `{{ }}` ```` (with backtick wrap) is now working as expected since v5, user may want to use `{{ }}` without backtick wrap for certain articles (post/page). With this PR, when `disableNunjucks` are disabled globally (default) or through a [renderer](https://github.com/hexojs/hexo-renderer-marked/pull/166), user can enable it per article; at the same time, it is also possible to disable it per article even when it is enabled globally.

enabling `disableNunjucks` will disable processing of `{{ }}` / `{% %}` and [tag plugins](https://hexo.io/docs/tag-plugins).


## How to test

```sh
git clone -b fm-disable-nunjucks https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
