### PR TITLE
fix: avoid escaping front-matter if unnecessary

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -55,14 +55,14 @@ class PostRenderCache {
   }
 }
 
-const prepareFrontMatter = data => {
+const prepareFrontMatter = (data, jsonMode) => {
   for (const [key, item] of Object.entries(data)) {
     if (moment.isMoment(item)) {
       data[key] = item.utc().format('YYYY-MM-DD HH:mm:ss');
     } else if (moment.isDate(item)) {
       data[key] = moment.utc(item).format('YYYY-MM-DD HH:mm:ss');
     } else if (typeof item === 'string') {
-      data[key] = `"${item}"`;
+      if (jsonMode || item.includes(':') || item.startsWith('#') || item.startsWith('!!')) data[key] = `"${item}"`;
     }
   }
 
@@ -139,8 +139,9 @@ class Post {
     let splited;
 
     return this._getScaffold(data.layout).then(scaffold => {
-      const frontMatter = prepareFrontMatter({ ...data });
       splited = yfmSplit(scaffold);
+      const jsonMode = splited.separator.startsWith(';');
+      const frontMatter = prepareFrontMatter({ ...data }, jsonMode);
 
       return tag.render(splited.data, frontMatter);
     }).then(frontMatter => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Fixes #4511 

a value of yml front-matter needs to be wrapped with double-quote when it contains ":", starts with "#" (comment) or [yaml tag](https://github.com/nodeca/js-yaml#supported-yaml-types):

``` yml
---
title: unsafe: value
title: #unsafetoo
title: !!js/regexp /dangerous/
---
```

Otherwise, it's not necessary so that #4511 use case can be supported.

## How to test

```sh
git clone -b optiona-escape https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
