### PR TITLE
Generate draft assets in draft mode

### DIFF
--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -145,6 +145,21 @@ module.exports = ctx => {
     ]));
   }
 
+  function shouldSkipAsset(post, asset) {
+    if (!ctx._showDrafts()) {
+      if (post.published === false && asset) {
+        // delete existing draft assets if draft posts are hidden
+        asset.remove();
+      }
+      if (post.published === false) {
+        // skip draft assets if draft posts are hidden
+        return true;
+      }
+    }
+
+    return asset !== undefined; // skip already existing assets
+  }
+
   function scanAssetDir(post) {
     if (!ctx.config.post_asset_folder) return;
 
@@ -164,8 +179,7 @@ module.exports = ctx => {
       const id = join(assetDir, item).substring(baseDirLength).replace(/\\/g, '/');
       const asset = PostAsset.findById(id);
 
-      if (asset) return post.published === false ? asset.remove() : undefined; // delete if already exist
-      else if (post.published === false) return undefined; // skip assets for unpulished posts and
+      if (shouldSkipAsset(post, asset)) return undefined;
 
       return PostAsset.save({
         _id: id,
@@ -192,8 +206,7 @@ module.exports = ctx => {
 
     // TODO: Better post searching
     const post = Post.toArray().find(post => file.source.startsWith(post.asset_dir));
-
-    if (post != null && post.published) {
+    if (post != null && (post.published || ctx._showDrafts())) {
       return PostAsset.save({
         _id: id,
         slug: file.source.substring(post.asset_dir.length),

--- a/test/scripts/processors/post.js
+++ b/test/scripts/processors/post.js
@@ -959,11 +959,22 @@ describe('post', () => {
       writeFile(file.source, body),
       writeFile(assetPath, '')
     ]);
+
+    // drafts disabled - no draft assets should be generated
     await process(file);
     const post = Post.findOne({ source: file.path });
 
     post.published.should.be.false;
     should.not.exist(PostAsset.findById(assetId));
+
+    // drafts enabled - all assets should be generated
+    hexo.config.render_drafts = true;
+    await process(file);
+
+    should.exist(PostAsset.findById(assetId));
+
+    hexo.config.render_drafts = false;
+
     post.remove();
 
     await Promise.all([


### PR DESCRIPTION
## What does it do?

Since #3489, no draft assets are generated. This is the desired behavior when not rendering draft posts. But when working on drafts, the according assets are never rendered. This change checks if draft posts should be rendered, and if this is the case, the assets will not be deleted.

## How to test

I validated this fix by

- Running `hexo clean && rm -rf public/ && hexo generate` - Draft assets are not generated (as before)
- Running `hexo clean && rm -rf public/ && hexo generate --draft` - Draft assets are generated
- Running `hexo server --draft` - Draft assets are generated
- Adjusting the existing unit test

Fixes: #4556

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
