### PR TITLE
list_tags: span element & custom class for label

### DIFF
--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -14,7 +14,7 @@ function listTagsHelper(tags, options) {
   const { style = 'list', transform, separator = ', ', suffix = '' } = options;
   const showCount = Object.prototype.hasOwnProperty.call(options, 'show_count') ? options.show_count : true;
   const classStyle = typeof style === 'string' ? `-${style}` : '';
-  let className, ulClass, liClass, aClass, countClass;
+  let className, ulClass, liClass, aClass, labelClass, countClass, labelSpan;
   if (typeof options.class !== 'undefined') {
     if (typeof options.class === 'string') {
       className = options.class;
@@ -25,13 +25,19 @@ function listTagsHelper(tags, options) {
     ulClass = options.class.ul || `${className}${classStyle}`;
     liClass = options.class.li || `${className}${classStyle}-item`;
     aClass = options.class.a || `${className}${classStyle}-link`;
+    labelClass = options.class.label || `${className}${classStyle}-label`;
     countClass = options.class.count || `${className}${classStyle}-count`;
+
+    labelSpan = !!Object.prototype.hasOwnProperty.call(options.class, 'label');
   } else {
     className = 'tag';
     ulClass = `${className}${classStyle}`;
     liClass = `${className}${classStyle}-item`;
     aClass = `${className}${classStyle}-link`;
+    labelClass = `${className}${classStyle}-label`;
     countClass = `${className}${classStyle}-count`;
+
+    labelSpan = false;
   }
   const orderby = options.orderby || 'name';
   const order = options.order || 1;
@@ -69,7 +75,11 @@ function listTagsHelper(tags, options) {
       if (i) result += separator;
 
       result += `<a class="${aClass}" href="${url_for.call(this, tag.path)}${suffix}" rel="tag">`;
-      result += transform ? transform(tag.name) : tag.name;
+      if (labelSpan) {
+        result += `<span class="${labelClass}">${transform ? transform(tag.name) : tag.name}</span>`;
+      } else {
+        result += transform ? transform(tag.name) : tag.name;
+      }
 
       if (showCount) {
         result += `<span class="${countClass}">${tag.length}</span>`;

--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -28,7 +28,7 @@ function listTagsHelper(tags, options) {
     labelClass = options.class.label || `${className}${classStyle}-label`;
     countClass = options.class.count || `${className}${classStyle}-count`;
 
-    labelSpan = !!Object.prototype.hasOwnProperty.call(options.class, 'label');
+    labelSpan = Object.prototype.hasOwnProperty.call(options.class, 'label');
   } else {
     className = 'tag';
     ulClass = `${className}${classStyle}`;

--- a/test/scripts/helpers/list_tags.js
+++ b/test/scripts/helpers/list_tags.js
@@ -116,6 +116,25 @@ describe('list_tags', () => {
     ].join(''));
   });
 
+  it('custom class not list', () => {
+    const result = listTags({
+      style: false,
+      show_count: true,
+      separator: '',
+      class: {
+        a: 'tempor',
+        label: 'lorem',
+        count: 'dolor'
+      }
+    });
+
+    result.should.eql([
+      '<a class="tempor" href="/tags/bar/" rel="tag"><span class="lorem">bar</span><span class="dolor">1</span></a>',
+      '<a class="tempor" href="/tags/baz/" rel="tag"><span class="lorem">baz</span><span class="dolor">2</span></a>',
+      '<a class="tempor" href="/tags/foo/" rel="tag"><span class="lorem">foo</span><span class="dolor">1</span></a>'
+    ].join(''));
+  });
+
   it('orderby', () => {
     const result = listTags({
       orderby: 'length'


### PR DESCRIPTION
## What does it do?

When `style` is not `list` with `show_count` the pseudo HTML is

```html
<a class="a">
    raw label
    <span class="count">count</span>
</a>
```

I implemented a way to customize the label too to something like

```html
<a class="a">
    <span class="label">raw label</span>
    <span class="count">count</span>
</a>
```

This is 100% backward compatible, for style = list there is not change, and if `option.class.label` is not set there is no span to not break the actual behavior. The new customization only appear when  `option.class.label` is set.

## How to test

```sh
git clone -b list_tags/label https://github.com/noraj/hexo.git
cd hexo
npm install
npm test
```

Put this in a template:

```pug
list_tags({show_count: true, class: {a: 'tempor', count: 'dolor', label: 'lorem'}, style: false, separator: ''})
```

## Screenshots

My use case was for Bulma CSS [addons tags](https://bulma.io/documentation/elements/tag/#list-of-tags) that is not possible without 2 spans.

I use this

```pug
list_tags({orderby: 'name', order: 1, show_count: true, class: {a: '', count: 'tag is-primary', label: 'tag is-dark'}, style: false, separator: ''})
```

![image](https://user-images.githubusercontent.com/16578570/99151112-37072900-2699-11eb-8de8-44b7eca908f8.png)


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test. (yes error are not due to my code introduction)
- [x] documentation https://github.com/hexojs/site/pull/1564
