### PR TITLE
expose `escape_html` helper method for string manipulation to templates

### DIFF
--- a/lib/plugins/helper/format.js
+++ b/lib/plugins/helper/format.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { stripHTML, wordWrap, truncate } = require('hexo-util');
+const { stripHTML, wordWrap, truncate, escapeHTML } = require('hexo-util');
 const titlecase = require('titlecase');
 
 exports.strip_html = stripHTML;
@@ -14,3 +14,6 @@ exports.word_wrap = wordWrap;
 exports.wordWrap = wordWrap;
 
 exports.truncate = truncate;
+
+exports.escape_html = escapeHTML;
+exports.escapeHTML = escapeHTML;

--- a/lib/plugins/helper/index.js
+++ b/lib/plugins/helper/index.js
@@ -15,13 +15,14 @@ module.exports = ctx => {
 
   helper.register('search_form', require('./search_form'));
 
-  const { strip_html, trim, titlecase, word_wrap, truncate } = require('./format');
+  const { strip_html, trim, titlecase, word_wrap, truncate, escape_html } = require('./format');
 
   helper.register('strip_html', strip_html);
   helper.register('trim', trim);
   helper.register('titlecase', titlecase);
   helper.register('word_wrap', word_wrap);
   helper.register('truncate', truncate);
+  helper.register('escape_html', escape_html);
 
   helper.register('fragment_cache', require('./fragment_cache')(ctx));
 

--- a/test/scripts/helpers/escape_html.js
+++ b/test/scripts/helpers/escape_html.js
@@ -1,0 +1,17 @@
+'use strict';
+
+describe('escape_html', () => {
+  const { escapeHTML } = require('../../../lib/plugins/helper/format');
+
+  it('default', () => {
+    escapeHTML('<p class="foo">Hello "world".</p>').should.eql('&lt;p class&#x3D;&quot;foo&quot;&gt;Hello &quot;world&quot;.&lt;&#x2F;p&gt;');
+  });
+
+  it('str must be a string', () => {
+    escapeHTML.should.throw('str must be a string!');
+  });
+
+  it('avoid double escape', () => {
+    escapeHTML('&lt;foo>bar</foo&gt;').should.eql('&lt;foo&gt;bar&lt;&#x2F;foo&gt;');
+  });
+});

--- a/test/scripts/helpers/index.js
+++ b/test/scripts/helpers/index.js
@@ -4,6 +4,7 @@ describe('Helpers', () => {
   require('./debug');
   require('./css');
   require('./date');
+  require('./escape_html');
   require('./favicon_tag');
   require('./feed_tag');
   require('./fragment_cache');


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Expose the `escape_html` utility function from [https://github.com/hexojs/hexo-util/blob/master/lib/escape_html.js](https://github.com/hexojs/hexo-util/blob/master/lib/escape_html.js) so it can be called in templates.

## How to test

Testing may not be necessary? Covered in [https://github.com/hexojs/hexo-util/blob/master/test/escape_html.spec.js](https://github.com/hexojs/hexo-util/blob/master/test/escape_html.spec.js) already.

Other `hexo-util` functions, like `strip_html`, `trim`, `titlecase`, `word_wrap`, `truncate` are untested.

## Pull request tasks

- [ ] Passed the CI test.
