### PR TITLE
Replace `process.mainModule` with `require.main`

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -288,21 +288,21 @@ class Hexo extends EventEmitter {
       module.filename = path;
       module.paths = Module._nodeModulePaths(path);
 
-      function require(path) {
+      function req(path) {
         return module.require(path);
       }
 
-      require.resolve = request => Module._resolveFilename(request, module);
+      req.resolve = request => Module._resolveFilename(request, module);
 
-      require.main = process.mainModule;
-      require.extensions = Module._extensions;
-      require.cache = Module._cache;
+      req.main = require.main;
+      req.extensions = Module._extensions;
+      req.cache = Module._cache;
 
       script = `(function(exports, require, module, __filename, __dirname, hexo){${script}\n});`;
 
       const fn = runInThisContext(script, path);
 
-      return fn(module.exports, require, module, path, dirname(path), this);
+      return fn(module.exports, req, module, path, dirname(path), this);
     }).asCallback(callback);
   }
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

> Deprecated: Use require.main instead.
> The process.mainModule property provides an alternative way of retrieving require.main. The difference is that if the main module changes at runtime, require.main may still refer to the original main module in modules that were required before the change occurred. Generally, it's safe to assume that the two refer to the same module.

https://nodejs.org/api/process.html#process_process_mainmodule

## How to test

```sh
git clone -b require https://github.com/hexojs/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
