### PR TITLE
fix(load_plugins): ignore plugin whose name is started with "hexo-theme"

### DIFF
--- a/lib/hexo/load_plugins.js
+++ b/lib/hexo/load_plugins.js
@@ -12,16 +12,6 @@ module.exports = ctx => {
 };
 
 function loadModuleList(ctx) {
-  let customThemeName;
-
-  if (ctx.config) {
-    const { theme } = ctx.config;
-
-    if (theme) {
-      customThemeName = String(theme);
-    }
-  }
-
   const packagePath = join(ctx.base_dir, 'package.json');
 
   // Make sure package.json exists
@@ -37,11 +27,11 @@ function loadModuleList(ctx) {
       return deps.concat(devDeps);
     });
   }).filter(name => {
-    // Ignore plugin whose name endswith "hexo-theme-[ctx.config.theme]"
-    if (name.endsWith(`hexo-theme-${customThemeName}`)) return false;
-
     // Ignore plugins whose name is not started with "hexo-"
     if (!/^hexo-|^@[^/]+\/hexo-/.test(name)) return false;
+
+    // Ignore plugin whose name is started with "hexo-theme"
+    if (/^hexo-theme-|^@[^/]+\/hexo-theme-/.test(name)) return false;
 
     // Ignore typescript definition file that is started with "@types/"
     if (name.startsWith('@types/')) return false;


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

When there are multiple hexo themes in package.json, the ones that are not activated will be loaded as plugins, which will cause errors

See also https://github.com/hexojs/hexo/pull/4111

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
