### PR TITLE
feat: handle config.root is not exist

### DIFF
--- a/lib/hexo/load_config.js
+++ b/lib/hexo/load_config.js
@@ -26,6 +26,10 @@ module.exports = async ctx => {
   ctx.log.debug('Config loaded: %s', magenta(tildify(configPath)));
 
   ctx.config = deepMerge(ctx.config, config);
+  // If root is not exist, create it by config.url
+  if (!config.root) {
+    ctx.config.root = new URL(ctx.config.url).pathname + '/';
+  }
   config = ctx.config;
 
   validateConfig(ctx);

--- a/lib/hexo/load_config.js
+++ b/lib/hexo/load_config.js
@@ -28,7 +28,9 @@ module.exports = async ctx => {
   ctx.config = deepMerge(ctx.config, config);
   // If root is not exist, create it by config.url
   if (!config.root) {
-    ctx.config.root = new URL(ctx.config.url).pathname + '/';
+    let { pathname } = new URL(ctx.config.url);
+    if (!pathname.endsWith('/')) pathname += '/';
+    ctx.config.root = pathname;
   }
   config = ctx.config;
 

--- a/test/scripts/hexo/load_config.js
+++ b/test/scripts/hexo/load_config.js
@@ -106,6 +106,27 @@ describe('Load config', () => {
     }
   });
 
+  it('handle root is not exist', async () => {
+    try {
+      const content = 'url: https://hexo.io/';
+      await writeFile(hexo.config_path, content);
+      await loadConfig(hexo);
+      hexo.config.url.should.eql('https://hexo.io');
+      hexo.config.root.should.eql('/');
+    } finally {
+      await unlink(hexo.config_path);
+    }
+    try {
+      const content = 'url: https://hexo.io/foo/';
+      await writeFile(hexo.config_path, content);
+      await loadConfig(hexo);
+      hexo.config.url.should.eql('https://hexo.io/foo');
+      hexo.config.root.should.eql('/foo/');
+    } finally {
+      await unlink(hexo.config_path);
+    }
+  });
+
   // Deprecated: config.external_link boolean option will be removed in future
   it('migrate external_link config from boolean to object - true', async () => {
     const content = 'external_link: true';


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

See this description about `url` and `root`, https://github.com/hexojs/hexo-starter/blob/3d337683d271aa28e5bebd31dd35ba12a7a2be82/_config.yml#L15

We can know that  `url` and `root` are closely related, so why do we configure it twice? `root` can be generated by `url`

```yml
# You just need to configure it
url: https://hexo.io/foo
# Not required, optional
# root: /foo/
```


## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
