### PR TITLE
Prefix anchors by post path

### DIFF
--- a/lib/plugins/filter/after_post_render/anchor.js
+++ b/lib/plugins/filter/after_post_render/anchor.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { url_for } = require('hexo-util');
+const rAnchorHref = /(?<=<[^>]* href=")#[^"]+(?="[^>]*>)/g;
+
+function prefixAnchor(data) {
+  if (!data.path) return;
+  data.content = data.content.replace(rAnchorHref, href => url_for.call(this, data.path + href));
+}
+
+module.exports = prefixAnchor;

--- a/lib/plugins/filter/after_post_render/index.js
+++ b/lib/plugins/filter/after_post_render/index.js
@@ -3,6 +3,7 @@
 module.exports = ctx => {
   const { filter } = ctx.extend;
 
+  filter.register('after_post_render', require('./anchor'));
   filter.register('after_post_render', require('./external_link'));
   filter.register('after_post_render', require('./excerpt'));
 };


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Resolve #1302 by using post path and `url_for` on post anchors.

## How to test
Test cases will be added later. Code below fails currently.

```sh
git clone -b prefix-anchor https://github.com/PaperStrike/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
