### PR TITLE
Allow overriding landscape theme sidebar config

### DIFF
--- a/lib/hexo/load_theme_config.js
+++ b/lib/hexo/load_theme_config.js
@@ -27,8 +27,9 @@ module.exports = ctx => {
     // ctx.config.theme_config should have highest priority
     // If ctx.config.theme_config exists, then merge it with _config.[theme].yml
     // If ctx.config.theme_config doesn't exist, set it to _config.[theme].yml
+    const override = config.override || {} // Allow overriding upstream
     ctx.config.theme_config = ctx.config.theme_config
-      ? deepMerge(config, ctx.config.theme_config) : config;
+      ? Object.assign(deepMerge(config, ctx.config.theme_config), override) : config;
   });
 };
 


### PR DESCRIPTION
Landscape provides a fully loaded config, there is no clean way to get a minimal config without **hard** forking the theme.

This allows a cleaner way over overriding theme configs.

#3890
#4154
https://github.com/hexojs/hexo-theme-landscape/issues/102

In most inheritance models, class methods are fully superseded by the extending class, pyYaml supports this model.

Alternatively we could use a database migration model, where the config has a theme version and schema version and merges are done based on that.

This PR just works with the present situation.

<!--
Thank you for saving the baby Pandas
-->

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
- [x] was written on a phone.
