### PR TITLE
Escape HTML  by default in list_tag

### DIFF
--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { url_for } = require('hexo-util');
+const { url_for, escapeHTML } = require('hexo-util');
 
 function listTagsHelper(tags, options) {
   if (!options && (!tags || !Object.prototype.hasOwnProperty.call(tags, 'length'))) {
@@ -59,7 +59,7 @@ function listTagsHelper(tags, options) {
       result += `<li class="${liClass}">`;
 
       result += `<a class="${aClass}" href="${url_for.call(this, tag.path)}${suffix}" rel="tag">`;
-      result += transform ? transform(tag.name) : tag.name;
+      result += transform ? transform(tag.name) : escapeHTML(tag.name);
       result += '</a>';
 
       if (showCount) {


### PR DESCRIPTION
escape the HTML in Tag values. It should be text, not HTML

This is a breaking change as some people might have been relying on this use case (having html in tags) 
and documentation should be updated to explain that when using function transform, value should be escaped if needed
