### PR TITLE
Feature: When execute filter's callback, add new parameters.

### DIFF
--- a/lib/extend/filter.js
+++ b/lib/extend/filter.js
@@ -62,6 +62,7 @@ class Filter {
     const ctx = options.context;
     const args = options.args || [];
 
+    args.push(data);
     args.unshift(data);
 
     return Promise.each(filters, filter => Reflect.apply(Promise.method(filter), ctx, args).then(result => {
@@ -78,6 +79,7 @@ class Filter {
     const ctx = options.context;
     const args = options.args || [];
 
+    args.push(data);
     args.unshift(data);
 
     for (let i = 0, len = filtersLen; i < len; i++) {

--- a/test/scripts/extend/filter.js
+++ b/test/scripts/extend/filter.js
@@ -94,13 +94,15 @@ describe('Filter', () => {
   it('exec()', async () => {
     const f = new Filter();
 
-    const filter1 = spy(data => {
+    const filter1 = spy((data, origin) => {
       data.should.eql('');
+      origin.should.eql('');
       return data + 'foo';
     });
 
-    const filter2 = spy(data => {
+    const filter2 = spy((data, origin) => {
       data.should.eql('foo');
+      origin.should.eql('');
       return data + 'bar';
     });
 
@@ -117,13 +119,15 @@ describe('Filter', () => {
   it('exec() - pointer', async () => {
     const f = new Filter();
 
-    const filter1 = spy(data => {
+    const filter1 = spy((data, origin) => {
       data.should.eql({});
+      origin.should.eql({});
       data.foo = 1;
     });
 
-    const filter2 = spy(data => {
+    const filter2 = spy((data, origin) => {
       data.should.eql({foo: 1});
+      origin.should.eql({foo: 1});
       data.bar = 2;
     });
 
@@ -140,14 +144,16 @@ describe('Filter', () => {
   it('exec() - args', async () => {
     const f = new Filter();
 
-    const filter1 = spy((data, arg1, arg2) => {
+    const filter1 = spy((data, arg1, arg2, arg3) => {
       arg1.should.eql(1);
       arg2.should.eql(2);
+      arg3.should.eql({});
     });
 
-    const filter2 = spy((data, arg1, arg2) => {
+    const filter2 = spy((data, arg1, arg2, arg3) => {
       arg1.should.eql(1);
       arg2.should.eql(2);
+      arg3.should.eql({});
     });
 
     f.register('test', filter1);
@@ -180,13 +186,15 @@ describe('Filter', () => {
   it('execSync()', () => {
     const f = new Filter();
 
-    const filter1 = spy(data => {
+    const filter1 = spy((data, origin) => {
       data.should.eql('');
+      origin.should.eql('');
       return data + 'foo';
     });
 
-    const filter2 = spy(data => {
+    const filter2 = spy((data, origin) => {
       data.should.eql('foo');
+      origin.should.eql('');
       return data + 'bar';
     });
 
@@ -202,13 +210,15 @@ describe('Filter', () => {
   it('execSync() - pointer', () => {
     const f = new Filter();
 
-    const filter1 = spy(data => {
+    const filter1 = spy((data, origin) => {
       data.should.eql({});
+      origin.should.eql({});
       data.foo = 1;
     });
 
-    const filter2 = spy(data => {
+    const filter2 = spy((data, origin) => {
       data.should.eql({foo: 1});
+      origin.should.eql({foo: 1});
       data.bar = 2;
     });
 
@@ -224,14 +234,16 @@ describe('Filter', () => {
   it('execSync() - args', () => {
     const f = new Filter();
 
-    const filter1 = spy((data, arg1, arg2) => {
+    const filter1 = spy((data, arg1, arg2, arg3) => {
       arg1.should.eql(1);
       arg2.should.eql(2);
+      arg3.should.eql({});
     });
 
-    const filter2 = spy((data, arg1, arg2) => {
+    const filter2 = spy((data, arg1, arg2, arg3) => {
       arg1.should.eql(1);
       arg2.should.eql(2);
+      arg3.should.eql({});
     });
 
     f.register('test', filter1);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

When a callback to a registered filter is executed, the parameters passed to the filter are those that have been processed by other filters.  The filter executed later may be missing related information. 

For example, the internal hexo filter(`lib\plugins\filter\post_permalink.js`) get `Post Object`  as parameter. 
After this filter run, return a `permalink` and dismisses other `Post` properties.
And then, other filter after this will lose `Post` info and only get a  `permalink` parameter without any `Post` info:

```js
// before
hexo.extend.filter.register('post_permalink', function(data){
  // only `2021/07/22/hello` without other info about the post.
  console.log(data); 
  return data;
});
```

The code try to solve this, give a  new params to filter callback, The filter can get the origin info before other filter process:

```js
// after
hexo.extend.filter.register('post_permalink', function(data, post){
// get more params.
  console.log(data, post); 
  return data;
});
```




## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
