### PR TITLE
feat(open_graph): different URLs for `og:image` and `twitter:image`

### DIFF
--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -158,7 +158,13 @@ function openGraphHelper(options = {}) {
 
   result += meta('twitter:card', twitterCard);
 
-  if (images.length) {
+  if (options.twitter_image) {
+    let twitter_image = options.twitter_image;
+    if (!parse(twitter_image).host) {
+      twitter_image = resolve(url || config.url, twitter_image);
+    }
+    result += meta('twitter:image', twitter_image, false);
+  } else if (images.length) {
     result += meta('twitter:image', images[0], false);
   }
 

--- a/test/scripts/helpers/open_graph.js
+++ b/test/scripts/helpers/open_graph.js
@@ -317,6 +317,36 @@ describe('open_graph', () => {
     result.should.have.string(meta({property: 'og:image', content: urlFn.resolve(config.url, '/foo/bar/test.jpg')}));
   });
 
+  it('twitter_image - default same as og:image', () => {
+    const result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    }, {images: 'image.jpg'});
+
+    result.should.have.string(meta({name: 'twitter:image', content: hexo.config.url + '/image.jpg'}));
+  });
+
+  it('twitter_image - different URLs for og:image and twitter:image', () => {
+    const result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    }, {twitter_image: 'twitter.jpg', images: 'image.jpg'});
+
+    result.should.have.string(meta({name: 'twitter:image', content: hexo.config.url + '/twitter.jpg'}));
+  });
+
+  it('images - twitter_image absolute url', () => {
+    const result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    }, {twitter_image: 'https://hexo.io/twitter.jpg', images: 'image.jpg'});
+
+    result.should.have.string(meta({name: 'twitter:image', content: 'https://hexo.io/twitter.jpg'}));
+  });
+
   it('site_name - options', () => {
     const result = openGraph.call({
       page: {},


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fixed to be able to set different URLs for `og:image` and `twitter:image`.

### Motivation

There is no aspect ratio specification in `og:image`.

On the other hand, `twitter:image` has an aspect ratio regulation according to the value of `twitter:card`.

* [summary_large_image](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary-card-with-large-image)
    > Images for this Card support an **aspect ratio of 2:1** with minimum dimensions of 300x157 or maximum of 4096x4096 pixels. 
* [summary](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary)
    > Images for this Card support an **aspect ratio of 1:1** with minimum dimensions of 144x144 or maximum of 4096x4096 pixels.

We want to optimize the image display when an article is shared on SNS. For example, `og:image` should be set to an image that can be cropped anywhere, and `twitter:image` should be set to an image optimized for the aspect ratio of the card.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
