### PR TITLE
Hexo 6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hexo",
-  "version": "5.4.0",
+  "version": "6.0.0",
   "description": "A fast, simple & powerful blog framework, powered by Node.js.",
   "main": "lib/hexo",
   "bin": {


### PR DESCRIPTION
Following the breaking change on list_tags, I propose to release a v6 of Hexo
cf https://github.com/hexojs/hexo/commit/042f86294691f7a18ab27b853dd7066d6aed1408

I checked, and this was the only commit to release v5:  https://github.com/hexojs/hexo/commit/14890743dd00e1a1e7c4bd9c7ef632f609d35a4c

I would also suggest to update all dependencies that are not yet updated before releasing v6 (devDependencies)

Anyone wanted to add something to the v6 ?

We should also prepare a blog post to announce the release :)