### PR TITLE
fix(#1490): if `post_asset_folder` is set, restrict renderable files to default file extension

### DIFF
--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -241,7 +241,14 @@ module.exports = ctx => {
 
       if (!result || isHiddenFile(result.path)) return;
 
+      //checks only if there is a renderer for the file type or if is included in skip_render
       result.renderable = ctx.render.isRenderable(path) && !isMatch(path, ctx.config.skip_render);
+
+      //if post_asset_folder is set, restrict renderable files to default file extension 
+      if (result.renderable && ctx.config.post_asset_folder) {
+        result.renderable = (extname(ctx.config.new_post_name) === extname(path));
+      }
+
       return result;
     }),
 

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -241,10 +241,10 @@ module.exports = ctx => {
 
       if (!result || isHiddenFile(result.path)) return;
 
-      //checks only if there is a renderer for the file type or if is included in skip_render
+      // checks only if there is a renderer for the file type or if is included in skip_render
       result.renderable = ctx.render.isRenderable(path) && !isMatch(path, ctx.config.skip_render);
 
-      //if post_asset_folder is set, restrict renderable files to default file extension 
+      // if post_asset_folder is set, restrict renderable files to default file extension
       if (result.renderable && ctx.config.post_asset_folder) {
         result.renderable = (extname(ctx.config.new_post_name) === extname(path));
       }

--- a/test/scripts/processors/post.js
+++ b/test/scripts/processors/post.js
@@ -88,6 +88,18 @@ describe('post', () => {
     hexo.config.skip_render = ['_posts/foo/**'];
     pattern.match('_posts/foo/bar.html').should.have.property('renderable', false);
     hexo.config.skip_render = [];
+
+    // Skip render in the subdir assets if post_asset_folder is enabled
+    hexo.config.post_asset_folder = true;
+    pattern.match('_posts/foo/subdir/bar.html').should.have.property('renderable', false);
+    pattern.match('_posts/foo/subdir/bar.css').should.have.property('renderable', false);
+    pattern.match('_posts/foo/subdir/bar.js').should.have.property('renderable', false);
+    hexo.config.post_asset_folder = false;
+
+    // Render in the subdir assets if post_asset_folder is disabled
+    pattern.match('_posts/foo/subdir/bar.html').should.have.property('renderable', true);
+    pattern.match('_posts/foo/subdir/bar.css').should.have.property('renderable', true);
+    pattern.match('_posts/foo/subdir/bar.js').should.have.property('renderable', true);
   });
 
   it('asset - post_asset_folder disabled', async () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

It alleviates the problem on the rendering asset files as posts, if `post_asset_folder` is set to `true`, by restricting the rendered file types to the default new post type (`new_post_name`). 

Caveat: Doesn't work with MD files as assets, when your default file type is MD. 

It is not a final solution, as it would be better to identify to subfolder as asset folder in this stage of code execution.

## How to test

```sh
git clone -b BRANCH https://github.com/USER/hexo.git
cd hexo
npm install
npm test
```

1. Set `post_asset_folder` to `true` in `_config.yml`
2. Create new post
3. Create subfolder (without leading underscore!) in newly created asset folder for the post
4. Copy a HTML, JS or CSS file into the subfolder
5. run `hexo generate`

None of the subfolders files should be rendered as post, as it will be in the current version. They will be treated as real assets.

