### PR TITLE
refactor: native Array.flat()

### DIFF
--- a/lib/plugins/helper/css.js
+++ b/lib/plugins/helper/css.js
@@ -3,23 +3,10 @@
 const { htmlTag, url_for } = require('hexo-util');
 const { default: moize } = require('moize');
 
-const flatten = function(arr, result = []) {
-  for (const i in arr) {
-    const value = arr[i];
-    if (Array.isArray(value)) {
-      flatten(value, result);
-    } else {
-      result.push(value);
-    }
-  }
-  return result;
-};
-
 function cssHelper(...args) {
   let result = '\n';
 
-  flatten(args).forEach(item => {
-    // Old syntax
+  args.flat(Infinity).forEach(item => {
     if (typeof item === 'string' || item instanceof String) {
       let path = item;
       if (!path.endsWith('.css')) {
@@ -27,7 +14,7 @@ function cssHelper(...args) {
       }
       result += `<link rel="stylesheet" href="${url_for.call(this, path)}">\n`;
     } else {
-      // New syntax
+      // Custom attributes
       item.href = url_for.call(this, item.href);
       if (!item.href.endsWith('.css')) item.href += '.css';
       result += htmlTag('link', { rel: 'stylesheet', ...item }) + '\n';

--- a/lib/plugins/helper/js.js
+++ b/lib/plugins/helper/js.js
@@ -3,25 +3,10 @@
 const { htmlTag, url_for } = require('hexo-util');
 const { default: moize } = require('moize');
 
-/* flatten() to be replaced by Array.flat()
-after Node 10 has reached EOL */
-const flatten = function(arr, result = []) {
-  for (const i in arr) {
-    const value = arr[i];
-    if (Array.isArray(value)) {
-      flatten(value, result);
-    } else {
-      result.push(value);
-    }
-  }
-  return result;
-};
-
 function jsHelper(...args) {
   let result = '\n';
 
-  flatten(args).forEach(item => {
-    // Old syntax
+  args.flat(Infinity).forEach(item => {
     if (typeof item === 'string' || item instanceof String) {
       let path = item;
       if (!path.endsWith('.js')) {
@@ -29,7 +14,7 @@ function jsHelper(...args) {
       }
       result += `<script src="${url_for.call(this, path)}"></script>\n`;
     } else {
-      // New syntax
+      // Custom attributes
       item.src = url_for.call(this, item.src);
       if (!item.src.endsWith('.js')) item.src += '.js';
       result += htmlTag('script', { ...item }, '') + '\n';


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

- Node 12+ feature
  * related #4378 
- remove misleading "old syntax"
  * "old syntax" implies deprecation,
    but in this case, it's just different syntax
- renews #4409 @2997ms 
  * This PR uses `Array.flat(Infinity)` which flattens nesting regardless of depth, otherwise it only flattens one depth.

``` js
const arr = [1,2,3,[4,[5,6]]
const flatten = arr.flat()
// [1,2,3,4,[5,6]

const flatten = arr.flat(Infinity)
// [1, 2, 3, 4, 5, 6]
```

## How to test

```sh
git clone -b array-flat https://github.com/curbengh/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
  * Existing test case already covered.
- [x] Passed the CI test.
   * Both files still retain 100% coverage.