### PR TITLE
Fix author Object object on open_graph helper function

### DIFF
--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -100,7 +100,12 @@ function listTagsHelperFactory(tags, options) {
       tags = this.site.tags;
     }
 
-    return [tags.toArray(), options];
+    /**
+     * Sometimes tags.toArray is not function,
+     * using validate to fix it
+     */
+    if (typeof tags.toArray === 'function') return [tags.toArray(), options];
+    return [options];
   };
 
   return moize(listTagsHelper.bind(this), {

--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -104,8 +104,10 @@ function listTagsHelperFactory(tags, options) {
      * Sometimes tags.toArray is not function,
      * using validate to fix it
      */
-    if (typeof tags.toArray === 'function') return [tags.toArray(), options];
-    return [options];
+    if (typeof tags.toArray !== 'function') {
+      console.log(options);
+    }
+    return [tags.toArray(), options];
   };
 
   return moize(listTagsHelper.bind(this), {

--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -99,14 +99,6 @@ function listTagsHelperFactory(tags, options) {
       options = tags;
       tags = this.site.tags;
     }
-
-    /**
-     * Sometimes tags.toArray is not function,
-     * using validate to fix it
-     */
-    if (typeof tags.toArray !== 'function') {
-      console.log(options);
-    }
     return [tags.toArray(), options];
   };
 

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -70,28 +70,7 @@ function openGraphHelper(options = {}) {
   const date = options.date !== false ? options.date || page.date : false;
   const updated = options.updated !== false ? options.updated || page.updated : false;
   const language = options.language || page.lang || page.language || config.language;
-
-  /**
-   * Fix author [object object]
-   */
-  let author = options.author || config.author;
-  if (typeof author === 'object') {
-    // noinspection JSUnresolvedVariable
-    if (typeof author.nick === 'string') {
-      // noinspection JSUnresolvedVariable
-      author = author.nick;
-    }
-    // noinspection JSUnresolvedVariable
-    if (typeof author.nickname === 'string') {
-      // noinspection JSUnresolvedVariable
-      author = author.nickname;
-    }
-    // noinspection JSUnresolvedVariable
-    if (typeof author.name === 'string') {
-      // noinspection JSUnresolvedVariable
-      author = author.name;
-    }
-  }
+  const author = options.author || config.author;
 
   if (!Array.isArray(images)) images = [images];
 
@@ -165,7 +144,20 @@ function openGraphHelper(options = {}) {
   }
 
   if (author) {
-    result += og('article:author', author);
+
+    /**
+     * Fix author [object object]
+     */
+    console.log(typeof author);
+    let authorName = author.name;
+    if (typeof author.nick === 'string') {
+      authorName = author.nick;
+    } else if (typeof author.nickname === 'string') {
+      authorName = author.nickname;
+    } else if (typeof author.name === 'string') {
+      authorName = author.name;
+    }
+    result += og('article:author', authorName);
   }
 
   if (keywords) {

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -70,7 +70,28 @@ function openGraphHelper(options = {}) {
   const date = options.date !== false ? options.date || page.date : false;
   const updated = options.updated !== false ? options.updated || page.updated : false;
   const language = options.language || page.lang || page.language || config.language;
-  const author = options.author || config.author;
+
+  /**
+   * Fix author [object object]
+   */
+  let author = options.author || config.author;
+  if (typeof author === 'object') {
+    // noinspection JSUnresolvedVariable
+    if (typeof author.nick === 'string') {
+      // noinspection JSUnresolvedVariable
+      author = author.nick;
+    }
+    // noinspection JSUnresolvedVariable
+    if (typeof author.nickname === 'string') {
+      // noinspection JSUnresolvedVariable
+      author = author.nickname;
+    }
+    // noinspection JSUnresolvedVariable
+    if (typeof author.name === 'string') {
+      // noinspection JSUnresolvedVariable
+      author = author.name;
+    }
+  }
 
   if (!Array.isArray(images)) images = [images];
 

--- a/lib/plugins/helper/open_graph.js
+++ b/lib/plugins/helper/open_graph.js
@@ -146,16 +146,17 @@ function openGraphHelper(options = {}) {
   if (author) {
 
     /**
-     * Fix author [object object]
+     * Fix author [object object], only get author name
      */
-    console.log(typeof author);
-    let authorName = author.name;
-    if (typeof author.nick === 'string') {
-      authorName = author.nick;
-    } else if (typeof author.nickname === 'string') {
-      authorName = author.nickname;
-    } else if (typeof author.name === 'string') {
-      authorName = author.name;
+    let authorName = author;
+    if (typeof author === 'object') {
+      if (typeof author.nick === 'string') {
+        authorName = author.nick;
+      } else if (typeof author.nickname === 'string') {
+        authorName = author.nickname;
+      } else if (typeof author.name === 'string') {
+        authorName = author.name;
+      }
     }
     result += og('article:author', authorName);
   }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

fix open_graph helper on og:meta (article:author) Object Object
Currently, many themes use front matter:
```yaml
author: # author object each pages or posts
  nick/nickname/name: "name author"
  url: "http://web.tld/page/profile.html"
```
The above configuration useful to create an author name with a hyperlink that will lead to the `about me` page or a page related to the article's author profile (seo internal/author link/schema jsonld).
**example**
```html
<a href="{{ page.author.url }}" alt="{{ page.author.name }}" rel="author">{{ page.author.name }}</a>
```
```ejs
<script type="application/ld+json">
{
  "@context": "https://schema.org/",
  "@type": "Person",
  "name": "{{ page.author.name }}"
... and so on
}
</script>
```

## How to test

I test it on my web using `hexo server` and `hexo generate` (https://www.webmanajemen.com repo https://github.com/dimaslanjaka/dimaslanjaka.github.io branch `compiler`), with hexo branch (forked) in folder packages/hexo.
```sh
# alert: this hexo site using submodules as packages with my other hexo plugin inside, and this hexo site contains more than 650 posts. It will taking long time to cloned.
git clone --single-branch --branch compiler https://github.com/dimaslanjaka/dimaslanjaka.github.io.git
cd dimaslanjaka.github.io
npm install
npx hexo server
# open browser http://localhost:4000
# visit one article
# view-source the page, and view the `meta[property="article:author"]` tag
```

## Screenshots

Theme code:

![image](https://user-images.githubusercontent.com/12471057/140989151-6e481831-c800-4e4d-9e88-cfd884702eb5.png)

Before:

![image](https://user-images.githubusercontent.com/12471057/140987163-735af25d-5a0a-4329-bb68-43ee2edcc0c3.png)

After:

![image](https://user-images.githubusercontent.com/12471057/141109712-7476b5f5-8cff-4b32-b6e8-e2b322c87c03.png)

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
