### PR TITLE
Add line threshold option for codeblocks

### DIFF
--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -34,7 +34,7 @@ function parseArgs(args) {
   const _else = [];
   const len = args.length;
   let lang,
-    line_number, wrap;
+    line_number, line_threshold, wrap;
   let firstLine = 1;
   const mark = [];
   for (let i = 0; i < len; i++) {
@@ -54,6 +54,9 @@ function parseArgs(args) {
         break;
       case 'line_number':
         line_number = value === 'true';
+        break;
+      case 'line_threshold':
+        if (!isNaN(value)) line_threshold = +value;
         break;
       case 'first_line':
         if (!isNaN(value)) firstLine = +value;
@@ -105,6 +108,7 @@ function parseArgs(args) {
     firstLine,
     caption,
     line_number,
+    line_threshold,
     mark,
     wrap
   };
@@ -134,14 +138,23 @@ module.exports = ctx => function codeTag(args, content) {
     return `<pre><code>${escapeHTML(content)}</code></pre>`;
   }
 
-  const { lang, firstLine, caption, line_number, mark, wrap } = parseArgs(args);
+  const { lang, firstLine, caption, line_number, line_threshold, mark, wrap } = parseArgs(args);
 
   if (prismjsCfg.enable) {
+    const shouldUseLineNumbers = typeof line_number !== 'undefined' ? line_number : prismjsCfg.line_number;
+    let surpassesLineThreshold;
+
+    if (typeof line_threshold !== 'undefined') {
+      surpassesLineThreshold = content.split('\n').length > line_threshold;
+    } else {
+      surpassesLineThreshold = content.split('\n').length > (prismjsCfg.line_threshold || 0);
+    }
+
     const prismjsOption = {
       lang,
       firstLine,
       caption,
-      lineNumber: typeof line_number !== 'undefined' ? line_number : prismjsCfg.line_number,
+      lineNumber: shouldUseLineNumbers && surpassesLineThreshold,
       mark,
       tab: prismjsCfg.tab_replace,
       isPreprocess: prismjsCfg.preprocess
@@ -151,11 +164,23 @@ module.exports = ctx => function codeTag(args, content) {
 
     content = prismHighlight(content, prismjsOption);
   } else {
+    const shouldUseLineNumbers = typeof line_number !== 'undefined'
+      ? line_number : hljsCfg.line_number;
+    let surpassesLineThreshold;
+
+    if (typeof line_threshold !== 'undefined') {
+      surpassesLineThreshold
+        = content.split('\n').length > line_threshold;
+    } else {
+      surpassesLineThreshold
+        = content.split('\n').length > (hljsCfg.line_threshold || 0);
+    }
+
     const hljsOption = {
       lang: typeof lang !== 'undefined' ? lang : '',
       firstLine,
       caption,
-      gutter: typeof line_number !== 'undefined' ? line_number : hljsCfg.line_number,
+      gutter: shouldUseLineNumbers && surpassesLineThreshold,
       hljs: hljsCfg.hljs,
       mark,
       tab: hljsCfg.tab_replace,

--- a/lib/plugins/tag/include_code.js
+++ b/lib/plugins/tag/include_code.js
@@ -60,22 +60,6 @@ module.exports = ctx => function includeCodeTag(args) {
   const hljsCfg = ctx.config.highlight || {};
   const prismjsCfg = ctx.config.prismjs || {};
 
-  const hljsOptions = {
-    lang,
-    caption,
-    gutter: hljsCfg.line_number,
-    hljs: hljsCfg.hljs,
-    tab: hljsCfg.tab_replace
-  };
-
-  const prismjsOptions = {
-    lang,
-    caption,
-    lineNumber: prismjsCfg.line_number,
-    tab: prismjsCfg.tab_replace,
-    isPreprocess: prismjsCfg.preprocess
-  };
-
   return exists(src).then(exist => {
     if (exist) return readFile(src);
   }).then(code => {
@@ -85,10 +69,32 @@ module.exports = ctx => function includeCodeTag(args) {
     code = lines.slice(from, to).join('\n').trim();
 
     if (prismjsCfg.enable) {
+      const line_threshold = prismjsCfg.line_threshold
+        ? prismjsCfg.line_threshold : 0;
+
+      const prismjsOptions = {
+        lang,
+        caption,
+        lineNumber: prismjsCfg.line_number && lines.length > line_threshold,
+        tab: prismjsCfg.tab_replace,
+        isPreprocess: prismjsCfg.preprocess
+      };
+
       if (!prismHighlight) prismHighlight = require('hexo-util').prismHighlight;
 
       return prismHighlight(code, prismjsOptions);
     } else if (hljsCfg.enable) {
+      const line_threshold = hljsCfg.line_threshold
+        ? hljsCfg.line_threshold : 0;
+
+      const hljsOptions = {
+        lang,
+        caption,
+        gutter: hljsCfg.line_number && lines.length > line_threshold,
+        hljs: hljsCfg.hljs,
+        tab: hljsCfg.tab_replace
+      };
+
       if (!highlight) highlight = require('hexo-util').highlight;
 
       return highlight(code, hljsOptions);

--- a/test/scripts/tags/code.js
+++ b/test/scripts/tags/code.js
@@ -68,6 +68,21 @@ describe('code', () => {
       }));
     });
 
+    it('line_threshold', () => {
+      let result = code('line_number:false line_threshold:1', fixture);
+      result.should.eql(highlight(fixture, {
+        gutter: false
+      }));
+      result = code('line_number:true line_threshold:1', fixture);
+      result.should.eql(highlight(fixture, {
+        gutter: true
+      }));
+      result = code('line_number:true line_threshold:3', fixture);
+      result.should.eql(highlight(fixture, {
+        gutter: false
+      }));
+    });
+
     it('highlight disable', () => {
       const result = code('highlight:false', fixture);
       result.should.eql('<pre><code>' + escapeHTML(fixture) + '</code></pre>');
@@ -199,6 +214,21 @@ describe('code', () => {
       result = code('line_number:true', fixture);
       result.should.eql(prism(fixture, {
         lineNumber: true
+      }));
+    });
+
+    it('line_threshold', () => {
+      let result = code('line_number:false line_threshold:1', fixture);
+      result.should.eql(prism(fixture, {
+        lineNumber: false
+      }));
+      result = code('line_number:true line_threshold:1', fixture);
+      result.should.eql(prism(fixture, {
+        lineNumber: true
+      }));
+      result = code('line_number:true line_threshold:3', fixture);
+      result.should.eql(prism(fixture, {
+        lineNumber: false
       }));
     });
 


### PR DESCRIPTION
Addresses #4516 

## What does it do?

Accepts an optional threshold to only show line numbers as long as the numbers of lines of the code block exceed such threshold.

## How to test

```sh
git clone -b issue-4516 https://github.com/dbelokon/hexo.git
cd hexo
npm install
npm test
```

## Screenshots

I don't have any screenshots, yet.

## Pull request tasks

- [X] Add test cases for the changes.
- [ ] Passed the CI test.
