### PR TITLE
fix(post): escape swig full tag with args

### DIFF
--- a/lib/hexo/post.js
+++ b/lib/hexo/post.js
@@ -70,6 +70,7 @@ class PostRenderEscape {
     let output = '';
 
     let swig_tag_name_begin = false;
+    let swig_tag_name_end = false;
     let swig_tag_name = '';
     let swig_full_tag_start_buffer = '';
 
@@ -93,6 +94,7 @@ class PostRenderEscape {
             swig_tag_name = '';
             swig_full_tag_start_buffer = '';
             swig_tag_name_begin = false; // Mark if it is the first non white space char in the swig tag
+            swig_tag_name_end = false;
           } else {
             output += char;
           }
@@ -116,7 +118,7 @@ class PostRenderEscape {
           swig_full_tag_start_buffer = swig_full_tag_start_buffer + char;
 
           if (isNonWhiteSpaceChar(char)) {
-            if (!swig_tag_name_begin) {
+            if (!swig_tag_name_begin && !swig_tag_name_end) {
               swig_tag_name_begin = true;
             }
 
@@ -126,6 +128,7 @@ class PostRenderEscape {
           } else {
             if (swig_tag_name_begin === true) {
               swig_tag_name_begin = false;
+              swig_tag_name_end = true;
             }
           }
         }

--- a/test/fixtures/post_render.js
+++ b/test/fixtures/post_render.js
@@ -32,7 +32,7 @@ exports.expected = [
   '<blockquote>',
   '<p>quote content 1</p>\n',
   '</blockquote>\n\n',
-  '<blockquote><p>quote content 2</p>',
+  '<blockquote><p>quote content 2</p>\n',
   '<footer><strong>Hello World</strong></footer></blockquote>'
 ].join('');
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

1. For the following content
```
{% mermaid graph TD %}
A[Hard] -->|Text| B(Round)
B --> C{Decision}
C -->|One| D[Result 1]
C -->|Two| E[Result 2]
{% endmermaid %}
```

The current state machine implementation will parse `{% mermaid graph TD %}` and `{% endmermaid %}` as two separate in-line swig tags (https://github.com/hexojs/hexo/pull/4780)

2. And according to the static analysis from lgtm, `swig_tag_name_begin` on line 123 of `lib/hexo/post.js` is always true
https://lgtm.com/projects/g/hexojs/hexo?mode=list

Both issues are resolved in this pull request.

## How to test

```sh
git clone -b swig https://github.com/hexojs/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
