### PR TITLE
fix: plugin loading conflict with @vercel/nft

### DIFF
--- a/lib/hexo/index.js
+++ b/lib/hexo/index.js
@@ -23,8 +23,8 @@ const Locals = require('./locals');
 const defaultConfig = require('./default_config');
 const loadDatabase = require('./load_database');
 const multiConfigPath = require('./multi_config_path');
-const { sync } = require('resolve');
 const { deepMerge, full_url_for } = require('hexo-util');
+let resolveSync; // = require('resolve');
 
 const libDir = dirname(__dirname);
 const dbVersion = 1;
@@ -180,7 +180,7 @@ class Hexo extends EventEmitter {
       const query = {};
 
       if (!this.config.future) {
-        query.date = {$lte: Date.now()};
+        query.date = { $lte: Date.now() };
       }
 
       if (!this._showDrafts()) {
@@ -194,7 +194,7 @@ class Hexo extends EventEmitter {
       const query = {};
 
       if (!this.config.future) {
-        query.date = {$lte: Date.now()};
+        query.date = { $lte: Date.now() };
       }
 
       return db.model('Page').find(query);
@@ -241,7 +241,7 @@ class Hexo extends EventEmitter {
       'load_config', // Load config
       'load_theme_config', // Load alternate theme config
       'load_plugins' // Load external plugins & scripts
-    ], name => require(`./${name}`)(this)).then(() => this.execFilter('after_init', null, {context: this})).then(() => {
+    ], name => require(`./${name}`)(this)).then(() => this.execFilter('after_init', null, { context: this })).then(() => {
       // Ready to go!
       this.emit('ready');
     });
@@ -265,12 +265,19 @@ class Hexo extends EventEmitter {
 
   resolvePlugin(name, basedir) {
     try {
-      // Try to resolve the plugin with the resolve.sync.
-      return sync(name, { basedir });
+      // Try to resolve the plugin with the Node.js's built-in require.resolve.
+      return require.resolve(name, { paths: [basedir] });
     } catch (err) {
-      // There was an error (likely the plugin wasn't found), so return a possibly
-      // non-existing path that a later part of the resolution process will check.
-      return join(basedir, 'node_modules', name);
+      try {
+        // There was an error (likely the node_modules is corrupt or from early version of npm)
+        // Use Hexo prior 6.0.0's behavior (resolve.sync) to resolve the plugin.
+        resolveSync = resolveSync || require('resolve').sync;
+        return resolveSync(name, { basedir });
+      } catch (err) {
+        // There was an error (likely the plugin wasn't found), so return a possibly
+        // non-existing path that a later part of the resolution process will check.
+        return join(basedir, 'node_modules', name);
+      }
     }
   }
 
@@ -314,7 +321,7 @@ class Hexo extends EventEmitter {
       ]);
     }).then(() => {
       mergeCtxThemeConfig(this);
-      return this._generate({cache: false});
+      return this._generate({ cache: false });
     }).asCallback(callback);
   }
 
@@ -329,7 +336,7 @@ class Hexo extends EventEmitter {
       // enable cache when run hexo server
       useCache = true;
     }
-    this._watchBox = debounce(() => this._generate({cache: useCache}), 100);
+    this._watchBox = debounce(() => this._generate({ cache: useCache }), 100);
 
     return loadDatabase(this).then(() => {
       this.log.info('Start processing');
@@ -347,7 +354,7 @@ class Hexo extends EventEmitter {
         mergeCtxThemeConfig(this);
       });
 
-      return this._generate({cache: useCache});
+      return this._generate({ cache: useCache });
     }).asCallback(callback);
   }
 
@@ -421,7 +428,7 @@ class Hexo extends EventEmitter {
         return path;
       }
 
-      return this.execFilter('template_locals', new Locals(path, data), {context: this})
+      return this.execFilter('template_locals', new Locals(path, data), { context: this })
         .then(locals => { route.set(path, createLoadThemeRoute(generatorResult, locals, this)); })
         .thenReturn(path);
     }).then(newRouteList => {
@@ -446,12 +453,12 @@ class Hexo extends EventEmitter {
     this.emit('generateBefore');
 
     // Run before_generate filters
-    return this.execFilter('before_generate', this.locals.get('data'), {context: this})
+    return this.execFilter('before_generate', this.locals.get('data'), { context: this })
       .then(() => this._routerReflesh(this._runGenerators(), useCache)).then(() => {
         this.emit('generateAfter');
 
         // Run after_generate filters
-        return this.execFilter('after_generate', null, {context: this});
+        return this.execFilter('after_generate', null, { context: this });
       }).finally(() => {
         this._isGenerating = false;
       });
@@ -460,13 +467,13 @@ class Hexo extends EventEmitter {
   exit(err) {
     if (err) {
       this.log.fatal(
-        {err},
+        { err },
         'Something\'s wrong. Maybe you can find the solution here: %s',
         underline('https://hexo.io/docs/troubleshooting.html')
       );
     }
 
-    return this.execFilter('before_exit', null, {context: this}).then(() => {
+    return this.execFilter('before_exit', null, { context: this }).then(() => {
       this.emit('exit', err);
     });
   }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Hexo uses browserify's `resolve` to resolve a path of a plugin by default, which is incompatible with [`@vercel/nft`](https://github.com/vercel/nft). See also: https://github.com/vercel/nft/issues/257

So we use Node.js's built-in `require.resolve` by default (which is compatible with `@vercel/nft`), fallback to `resolve.sync` only when the module is not found (or other errors).

Since there are no other significant behavior differences (from hexo's usage) between `resolve.sync` and `require.resolve`, we should drop `resolve` from dependency in the future.

## How to test

```sh
git clone -b fix-plugin-resolve https://github.com/sukkaw/hexo.git
cd hexo
npm install
npm test
```

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
