### PR TITLE
Fix js-yaml tags for v4.0.0+

### DIFF
--- a/lib/plugins/renderer/yaml.js
+++ b/lib/plugins/renderer/yaml.js
@@ -2,9 +2,10 @@
 
 const yaml = require('js-yaml');
 const { escape } = require('hexo-front-matter');
+const schema = yaml.DEFAULT_SCHEMA.extend(require('js-yaml-js-types').all);
 
 function yamlHelper(data) {
-  return yaml.load(escape(data.text));
+  return yaml.load(escape(data.text), { schema });
 }
 
 module.exports = yamlHelper;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "hexo-log": "^3.0.0",
     "hexo-util": "^2.4.0",
     "js-yaml": "^4.0.0",
+    "js-yaml-js-types": "^1.0.0",
     "micromatch": "^4.0.2",
     "moize": "^6.1.0",
     "moment": "^2.22.2",


### PR DESCRIPTION
Repair backwards compatibility https://github.com/nodeca/js-yaml/blob/master/migrate_v3_to_v4.md
with a bunch of plugins that use these yaml tags.

e.g.: https://github.com/lavas-project/hexo-pwa#options uses these yaml tags in the routes `!!js/regexp`

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fixes backwards compatibility for some plugins that make use of js-yaml tags.

This broke since the hexo 5.4.0 release that bumps `js-yaml` to v4.0.0.

See: 
https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md#400---2021-01-03
and
https://github.com/nodeca/js-yaml/blob/master/migrate_v3_to_v4.md

for details.

> ⚠️ This fix is required for both the 5.x release as well the 6.x release.
