### PR TITLE
feat(toc): Support unnumbered headings

### DIFF
--- a/lib/plugins/helper/toc.js
+++ b/lib/plugins/helper/toc.js
@@ -28,7 +28,9 @@ function tocHelper(str, options = {}) {
     const { level, id, text } = el;
     const href = id ? `#${encodeURL(id)}` : null;
 
-    lastNumber[level - 1]++;
+    if (!el.unnumbered) {
+      lastNumber[level - 1]++;
+    }
 
     for (let i = level; i <= 5; i++) {
       lastNumber[i] = 0;
@@ -55,8 +57,7 @@ function tocHelper(str, options = {}) {
       result += `<a class="${className}-link">`;
     }
 
-
-    if (listNumber) {
+    if (listNumber && !el.unnumbered) {
       result += `<span class="${className}-number">`;
 
       for (let i = firstLevel - 1; i < level; i++) {

--- a/test/scripts/helpers/toc.js
+++ b/test/scripts/helpers/toc.js
@@ -434,4 +434,46 @@ describe('toc', () => {
 
     toc(input).should.eql('');
   });
+
+  it('unnumbered headings', () => {
+    const className = 'toc';
+
+    const input = [
+      '<h3>Title 1</h3>',
+      '<h3>Title 2</h3>',
+      '<h4>Title 2.1</h4>',
+      '<h3 data-toc-unnumbered="true">Reference</h3>'
+    ].join('');
+
+    const expected = [
+      `<ol class="${className}">`,
+      `<li class="${className}-item ${className}-level-3">`,
+      `<a class="${className}-link"><span class="${className}-number">1.</span> `,
+      `<span class="${className}-text">Title 1</span>`,
+      '</a>',
+      '</li>',
+      `<li class="${className}-item ${className}-level-3">`,
+      `<a class="${className}-link">`,
+      `<span class="${className}-number">2.</span> `,
+      `<span class="${className}-text">Title 2</span>`,
+      '</a>',
+      `<ol class="${className}-child">`,
+      `<li class="${className}-item ${className}-level-4">`,
+      `<a class="${className}-link">`,
+      `<span class="${className}-number">2.1.</span> `,
+      `<span class="${className}-text">Title 2.1</span>`,
+      '</a>',
+      '</li>',
+      '</ol>',
+      '</li>',
+      `<li class="${className}-item ${className}-level-3">`,
+      `<a class="${className}-link">`,
+      `<span class="${className}-text">Reference</span>`,
+      '</a>',
+      '</li>',
+      '</ol>'
+    ].join('');
+
+    toc(input, { list_number: true, class: className }).should.eql(expected);
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
This PR adds a new feature to hexo to control the numbering of headings by the `data-toc-unnumbered` attribute.

Using `pandoc`, code written in markdown like
```md
### Title { data-toc-unnumbered=true }
```
will be rendered as
```html
<h3 data-toc-unnumbered="true" id="title">Title</h3>
```
and finally unnumbered in TOC.


## Screenshots

![image](https://user-images.githubusercontent.com/66366855/150150008-d0ba019d-fa80-4c24-8335-48ab40df4dc2.png)

![image](https://user-images.githubusercontent.com/66366855/150150077-36c70624-fece-4060-8e77-0f336f579629.png)

![image](https://user-images.githubusercontent.com/66366855/150150145-81a39cfb-f847-4522-8a26-2ef36cc06133.png)



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.

This PR should be merged after https://github.com/hexojs/hexo-util/pull/269 merged and published with `hexo-util`.

Closes #4860.