### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/plugins/helper/number_format.js
+++ b/lib/plugins/helper/number_format.js
@@ -13,10 +13,10 @@ function numberFormatHelper(num, options = {}) {
     const beforeLength = before.length;
     const beforeFirst = beforeLength % 3;
 
-    if (beforeFirst) beforeArr.push(before.substr(0, beforeFirst));
+    if (beforeFirst) beforeArr.push(before.slice(0, beforeFirst));
 
     for (let i = beforeFirst; i < beforeLength; i += 3) {
-      beforeArr.push(before.substr(i, 3));
+      beforeArr.push(before.slice(i, i + 3));
     }
 
     before = beforeArr.join(delimiter);
@@ -30,7 +30,7 @@ function numberFormatHelper(num, options = {}) {
       const afterLast = after[precision];
       const last = parseInt(after[precision - 1], 10);
 
-      afterResult = after.substr(0, precision - 1) + (afterLast < 5 ? last : last + 1);
+      afterResult = after.substring(0, precision - 1) + (afterLast < 5 ? last : last + 1);
     } else {
       afterResult = after;
       for (let i = 0, len = precision - afterLength; i < len; i++) {

--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -68,8 +68,8 @@ function parseArgs(args) {
         for (const cur of value.split(',')) {
           const hyphen = cur.indexOf('-');
           if (hyphen !== -1) {
-            let a = +cur.substr(0, hyphen);
-            let b = +cur.substr(hyphen + 1);
+            let a = +cur.slice(0, hyphen);
+            let b = +cur.slice(hyphen + 1);
             if (Number.isNaN(a) || Number.isNaN(b)) continue;
             if (b < a) { // switch a & b
               const temp = a;


### PR DESCRIPTION
## What does it do?

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.


## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
