### PR TITLE
fix(#4917): suppress YAMLException when load js-yaml

### DIFF
--- a/lib/plugins/renderer/yaml.js
+++ b/lib/plugins/renderer/yaml.js
@@ -2,7 +2,19 @@
 
 const yaml = require('js-yaml');
 const { escape } = require('hexo-front-matter');
-const schema = yaml.DEFAULT_SCHEMA.extend(require('js-yaml-js-types').all);
+const log = require('hexo-log')();
+
+let schema = {};
+// FIXME: workaround for https://github.com/hexojs/hexo/issues/4917
+try {
+  schema = yaml.DEFAULT_SCHEMA.extend(require('js-yaml-js-types').all);
+} catch (e) {
+  if (e instanceof yaml.YAMLException) {
+    log.warn('YAMLException: please see https://github.com/hexojs/hexo/issues/4917');
+  } else {
+    throw e;
+  }
+}
 
 function yamlHelper(data) {
   return yaml.load(escape(data.text), { schema });


### PR DESCRIPTION
refs: (#4917)

As I wrote in https://github.com/hexojs/hexo/issues/4917#issuecomment-1085574236 this fix is just a workaround. Not sure, but I assume this error seems incorrect version resolving of `js-yaml`.

### How to reproduce?

```sh
// git clone & checkout
$ git clone https://github.com/hexojs/hexo-generator-category.git
$ git checkout -b issue-4917 f51949900e5dbd15902b45fe4399afb634d54b21
$ git log --oneline
  f519499 (HEAD -> issue-4917) chore(ci): migrate travisCI to GitHubActions (#70)
  f233a38 chore(deps): bump hexo-pagination from 1.0.0 to 2.0.0 (#46)
  fadee1a Upgrade to GitHub-native Dependabot (#45)

// hexo@5.4.0 will be installed
$ npm install

// install hexo@6.1.0
$ npm install hexo@6.1.0

// run test
$ npm run test

> hexo-generator-category@1.0.0 test
> mocha test/index.js

YAMLException: Specified list of YAML types (or a single Type object) contains a non-Type object.
    at /mnt/c/Users/username/development/hexo/hexo-generator-category/node_modules/hexo/node_modules/js-yaml/lib/schema.js:104:13
    at Array.forEach (<anonymous>)
    at Schema.extend (/mnt/c/Users/username/development/hexo/hexo-generator-category/node_modules/hexo/node_modules/js-yaml/lib/schema.js:102:12)
    at Object.<anonymous> (/mnt/c/Users/username/development/hexo/hexo-generator-category/node_modules/hexo/lib/plugins/renderer/yaml.js:5:36)
    at Module._compile (node:internal/modules/cjs/loader:1103:14)
```

### Dependency tree

Here is the dependency tree after exec `How to reproduce?` section. Certainly, `hexo@6.1.0` depends on `js-yaml@4.1.0` and it seems no problem.

```sh
$ npm list js-yaml

hexo-generator-category@1.0.0 /mnt/c/Users/username/hexo/hexo-generator-category
├─┬ coveralls@3.1.1
│ └── js-yaml@3.14.1
├─┬ eslint@7.32.0
│ ├─┬ @eslint/eslintrc@0.4.3
│ │ └── js-yaml@3.14.1 deduped
│ └── js-yaml@3.14.1 deduped
├─┬ hexo@6.1.0
│ ├─┬ hexo-front-matter@3.0.0
│ │ └── js-yaml@4.1.0
│ └── js-yaml@4.1.0             <- should be use this. but not actually used???
├─┬ mocha@8.4.0
│ └── js-yaml@4.0.0
└─┬ nyc@15.1.0
  └─┬ @istanbuljs/load-nyc-config@1.1.0
    └── js-yaml@3.14.1 deduped
```

But, as you know exception occurs when run test. I'm not sure but it seems the `require('js-yaml')` resolves older than the `4.0.0` version of `js-yaml.`.

I don't know which is the cause `hexo`, `npm`, or `js-yaml`.

## Others

I'm going to release a patch version `6.1.1` & `5.4.1` if this PR accepts.

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
