### PR TITLE
feat(tag/post_link): throw on post_link error

### DIFF
--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -12,7 +12,6 @@ const { postFindOneFactory } = require('./');
  */
 module.exports = ctx => {
   return function postLinkTag(args) {
-    const error = `<a href="#">Post not found: ${args.join(' ') || 'Invalid post_link'}</a>`;
     const slug = args.shift();
     if (!slug) {
       throw new Error('Post not found: no slug for post_link.');
@@ -26,7 +25,9 @@ module.exports = ctx => {
     }
 
     const post = postFindOneFactory(ctx)({ slug });
-    if (!post) return error;
+    if (!post) {
+      throw new Error(`Post not found: post_link ${slug}.`);
+    }
 
     let title = args.length ? args.join(' ') : post.title;
     const attrTitle = escapeHTML(title);

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -14,7 +14,9 @@ module.exports = ctx => {
   return function postLinkTag(args) {
     const error = `<a href="#">Post not found: ${args.join(' ') || 'Invalid post_link'}</a>`;
     const slug = args.shift();
-    if (!slug) return error;
+    if (!slug) {
+      throw new Error('Post not found: no slug for post_link.');
+    }
 
     let escape = args[args.length - 1];
     if (escape === 'true' || escape === 'false') {

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -14,7 +14,7 @@ module.exports = ctx => {
   return function postLinkTag(args) {
     const slug = args.shift();
     if (!slug) {
-      throw new Error('Post not found: no slug for post_link.');
+      throw new Error(`Post not found: "${slug}" doesn't exist for {% post_link %}`);
     }
 
     let escape = args[args.length - 1];

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -61,7 +61,7 @@ describe('post_link', () => {
     should.throw(() => postLink([]), Error, /Post not found: no slug for post_link\./);
   });
 
-  it('post not found', () => {
-    postLink(['bar']).should.eql('<a href="#">Post not found: bar</a>');
+  it('should throw if post not found', () => {
+    should.throw(() => postLink(['bar']), Error, /Post not found: post_link bar\./);
   });
 });

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -57,8 +57,8 @@ describe('post_link', () => {
       .should.eql('<a href="/title-with-tag/" title="This is a &lt;b&gt;Bold&lt;&#x2F;b&gt; &quot;statement&quot;">This is a <b>Bold</b> "statement"</a>');
   });
 
-  it('no slug', () => {
-    postLink([]).should.eql('<a href="#">Post not found: Invalid post_link</a>');
+  it('should throw if no slug', () => {
+    should.throw(() => postLink([]), Error, /Post not found: no slug for post_link\./);
   });
 
   it('post not found', () => {

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -58,7 +58,7 @@ describe('post_link', () => {
   });
 
   it('should throw if no slug', () => {
-    should.throw(() => postLink([]), Error, /Post not found: no slug for post_link\./);
+    should.throw(() => postLink([]), Error, /Post not found: "undefined" doesn't exist for \{% post_link %\}/);
   });
 
   it('should throw if post not found', () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Throws an error if `post_link` receives no slug, or finds no post.

## Why?

Is it ever okay to push a broken link? CI should fail if the author pushes a broken link (perhaps after a post filename change). 

## Pull request tasks

- [x] Add test cases for the changes.

## Related
The open issue: https://github.com/hexojs/hexo/issues/4937