### PR TITLE
let post_link use original post title as title attribute

### DIFF
--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -27,6 +27,7 @@ module.exports = ctx => {
     if (!post) return error;
 
     let title = args.length ? args.join(' ') : post.title;
+    // Let attribute be the true post title so it appears in tooltip.
     const attrTitle = escapeHTML(post.title);
     if (escape === 'true') title = escapeHTML(title);
 

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -27,8 +27,8 @@ module.exports = ctx => {
     if (!post) return error;
 
     let title = args.length ? args.join(' ') : post.title;
-    const attrTitle = escapeHTML(title);
-    if (escape === 'true') title = attrTitle;
+    const attrTitle = escapeHTML(post.title);
+    if (escape === 'true') title = escapeHTML(title);
 
     const link = encodeURL(resolve(ctx.config.root, post.path));
 

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -33,7 +33,7 @@ describe('post_link', () => {
   });
 
   it('title', () => {
-    postLink(['foo', 'test']).should.eql('<a href="/foo/" title="test">test</a>');
+    postLink(['foo', 'test']).should.eql('<a href="/foo/" title="Hello world">test</a>');
   });
 
   it('should escape tag in title by default', () => {
@@ -45,7 +45,7 @@ describe('post_link', () => {
   });
 
   it('should escape tag in custom title', () => {
-    postLink(['title-with-tag', '<test>', 'title', 'true']).should.eql('<a href="/title-with-tag/" title="&lt;test&gt; title">&lt;test&gt; title</a>');
+    postLink(['title-with-tag', '<test>', 'title', 'true']).should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">&lt;test&gt; title</a>');
   });
 
   it('should not escape tag in title', () => {
@@ -54,7 +54,7 @@ describe('post_link', () => {
 
   it('should not escape tag in custom title', () => {
     postLink(['title-with-tag', 'This is a <b>Bold</b> "statement"', 'false'])
-      .should.eql('<a href="/title-with-tag/" title="This is a &lt;b&gt;Bold&lt;&#x2F;b&gt; &quot;statement&quot;">This is a <b>Bold</b> "statement"</a>');
+      .should.eql('<a href="/title-with-tag/" title="&quot;Hello&quot; &lt;new world&gt;!">This is a <b>Bold</b> "statement"</a>');
   });
 
   it('no slug', () => {


### PR DESCRIPTION
## What does it do?

This PR modifies the `post_link` tag so that the "title" attribute will contain the actual post title.

I think this new behavior is better: 
* Same as the old behavior, the text will still show the title that users specified as arguments in `post_link` tag
* But once hovered, the tooltip will show full title of the actual post

In the old behavior:
* Once hovered, the tooltip will have the same content as the existing text, therefore the tooltip is not useful.

## Screenshots
The screenshot shows the new behavior, where tooltip text is the actual post title
![2022-05-18_04-18](https://user-images.githubusercontent.com/1381301/169026911-b4423b2d-f568-467a-919f-38d839dea857.png)



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
