### PR TITLE
Let post support multiple tags

### DIFF
--- a/lib/plugins/helper/list_tags.js
+++ b/lib/plugins/helper/list_tags.js
@@ -53,6 +53,15 @@ function listTagsHelper(tags, options) {
   // Limit the number of tags
   if (options.amount) tags = tags.limit(options.amount);
 
+  // Remove the same tags
+  const map = new Map();
+  tags.forEach(tag => {
+    if (!map.has(tag.name)) {
+      map.set(tag.name, tag);
+    }
+  });
+  tags = [...map.values()];
+
   if (style === 'list') {
     result += `<ul class="${ulClass}" itemprop="keywords">`;
 

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -151,7 +151,14 @@ function processPost(ctx, file) {
     tags = data.tags || [];
 
     if (!Array.isArray(categories)) categories = [categories];
-    if (!Array.isArray(tags)) tags = [tags];
+
+    // Split tags string to array
+    if (!Array.isArray(tags)) {
+      tags = tags.split(',');
+      if (tags && tags.length) {
+        tags = tags.map(item => item.trim());
+      }
+    }
 
     if (data.photo && !data.photos) {
       data.photos = data.photo;

--- a/test/scripts/helpers/list_tags.js
+++ b/test/scripts/helpers/list_tags.js
@@ -18,6 +18,8 @@ describe('list_tags', () => {
       {source: 'foo', slug: 'foo'},
       {source: 'bar', slug: 'bar'},
       {source: 'baz', slug: 'baz'},
+      {source: 'boo', slug: 'boo'},
+      // Add same data to test duplicate tags
       {source: 'boo', slug: 'boo'}
     ]);
     // TODO: Warehouse needs to add a mutex lock when writing data to avoid data sync problem

--- a/test/scripts/processors/post.js
+++ b/test/scripts/processors/post.js
@@ -929,6 +929,32 @@ describe('post', () => {
     ]);
   });
 
+  it('post - tags (multiple tag)', async () => {
+    const body = [
+      'title: "Hello world"',
+      'tags: foo, bar, world',
+      '---'
+    ].join('\n');
+
+    const file = newFile({
+      path: 'foo.html',
+      published: true,
+      type: 'create',
+      renderable: true
+    });
+
+    await writeFile(file.source, body);
+    await process(file);
+    const post = Post.findOne({ source: file.path });
+
+    post.tags.map(item => item.name).should.eql(['foo', 'bar', 'world']);
+
+    return Promise.all([
+      post.remove(),
+      unlink(file.source)
+    ]);
+  });
+
   it('post - post_asset_folder enabled', async () => {
     hexo.config.post_asset_folder = true;
     hexo.config.exclude = ['**.png'];


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

When I call list_tags to display tags.Posts often display the same tags repeatedly.
eg, post A has tags 'html, css' and post B has tags 'html, javascript'.Then I call list_tags, it will return ['html,css', 'html,javascript'].

I think it returns ['html','css','javascript'] will be clearer and more reasonable.

So I did the following:
1.Cut the tags string from front-matter into an array.
2.Remove the same tags between posts in list_tags.

## Screenshots

before:
![image](https://user-images.githubusercontent.com/14961134/174215048-0713d2a9-515c-411b-8572-83d42a86ecbc.png)
after:
![image](https://user-images.githubusercontent.com/14961134/174214962-efced410-d25f-4a79-9f80-c50e715103a9.png)


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
