### PR TITLE
fix(tag): show source file in unformatted error message

### DIFF
--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -160,6 +160,8 @@ const getContext = (lines, errLine, location, type) => {
  * @return {Error}    New error object with embedded context
  */
 const formatNunjucksError = (err, input, source = '') => {
+  err.stack = err.stack.replace('(unknown path)', source ? magenta(source) : '');
+
   const match = err.message.match(/Line (\d+), Column \d+/);
   if (!match) return err;
   const errLine = parseInt(match[1], 10);

--- a/lib/extend/tag.js
+++ b/lib/extend/tag.js
@@ -160,7 +160,7 @@ const getContext = (lines, errLine, location, type) => {
  * @return {Error}    New error object with embedded context
  */
 const formatNunjucksError = (err, input, source = '') => {
-  err.stack = err.stack.replace('(unknown path)', source ? magenta(source) : '');
+  err.message = err.message.replace('(unknown path)', source ? magenta(source) : '');
 
   const match = err.message.match(/Line (\d+), Column \d+/);
   if (!match) return err;
@@ -168,7 +168,7 @@ const formatNunjucksError = (err, input, source = '') => {
   if (isNaN(errLine)) return err;
 
   // trim useless info from Nunjucks Error
-  const splited = err.message.replace('(unknown path)', source ? magenta(source) : '').split('\n');
+  const splited = err.message.split('\n');
 
   const e = new Error();
   e.name = 'Nunjucks Error';
@@ -245,7 +245,9 @@ class Tag {
         options,
         cb
       );
-    }).catch(err => Promise.reject(formatNunjucksError(err, str, source)))
+    }).catch(err => {
+      return Promise.reject(formatNunjucksError(err, str, source));
+    })
       .asCallback(callback);
   }
 }

--- a/test/scripts/extend/tag_errors.js
+++ b/test/scripts/extend/tag_errors.js
@@ -124,4 +124,26 @@ describe('Tag Errors', () => {
       err.message.should.contains(source);
     }
   });
+
+  it('source file path 2', async () => {
+    const source = '_posts/hello-world.md';
+    const tag = new Tag();
+
+    tag.register('test',
+      (args, content) => {},
+      { ends: true });
+
+    const body = [
+      '{% test %}',
+      '${#var}',
+      '{% endtest %}'
+    ].join('\n');
+
+    try {
+      await tag.render(body, { source });
+    } catch (err) {
+      err.should.have.property('stack');
+      err.stack.should.contains(source);
+    }
+  });
 });

--- a/test/scripts/extend/tag_errors.js
+++ b/test/scripts/extend/tag_errors.js
@@ -142,8 +142,8 @@ describe('Tag Errors', () => {
     try {
       await tag.render(body, { source });
     } catch (err) {
-      err.should.have.property('stack');
-      err.stack.should.contains(source);
+      err.should.have.property('message');
+      err.message.should.contains(source);
     }
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Error caused by the following example is not formatted by `formatNunjucksError()` (because err.message doesn't contain `Line x, Column y`), so the error message still shows `(unknown path)` which is not helpful. This PR replace it with source path.

```
{% test %}
${#var}
{% endtest %}
```


## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
