### PR TITLE
feat(helper/tagcloud): show_count option (#5047)

### DIFF
--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -19,6 +19,8 @@ function tagcloudHelper(tags, options) {
   const unit = options.unit || 'px';
   const color = options.color;
   const className = options.class;
+  const showCount = options.show_count;
+  const countClassName = options.count_class || 'count';
   const level = options.level || 10;
   const { transform } = options;
   const separator = options.separator || ' ';
@@ -68,7 +70,7 @@ function tagcloudHelper(tags, options) {
     }
 
     result.push(
-      `<a href="${url_for.call(this, tag.path)}" style="${style}"${attr}>${transform ? transform(tag.name) : tag.name}</a>`
+      `<a href="${url_for.call(this, tag.path)}" style="${style}"${attr}>${transform ? transform(tag.name) : tag.name}${showCount ? `<span class="${countClassName}">${tag.length}</span>` : ''}</a>`
     );
   });
 

--- a/test/scripts/helpers/tagcloud.js
+++ b/test/scripts/helpers/tagcloud.js
@@ -290,4 +290,26 @@ describe('tagcloud', () => {
       '<a href="/tags/def/" style="font-size: 10px;" class="tag-cloud-0">def</a>'
     ].join(' '));
   });
+
+  it('show_count', () => {
+    const result = tagcloud({ show_count: true });
+
+    result.should.eql([
+      '<a href="/tags/abc/" style="font-size: 13.33px;">abc<span class="count">2</span></a>',
+      '<a href="/tags/bcd/" style="font-size: 20px;">bcd<span class="count">4</span></a>',
+      '<a href="/tags/cde/" style="font-size: 16.67px;">cde<span class="count">3</span></a>',
+      '<a href="/tags/def/" style="font-size: 10px;">def<span class="count">1</span></a>'
+    ].join(' '));
+  });
+
+  it('show_count with custom class', () => {
+    const result = tagcloud({ show_count: true, count_class: 'tag-count' });
+
+    result.should.eql([
+      '<a href="/tags/abc/" style="font-size: 13.33px;">abc<span class="tag-count">2</span></a>',
+      '<a href="/tags/bcd/" style="font-size: 20px;">bcd<span class="tag-count">4</span></a>',
+      '<a href="/tags/cde/" style="font-size: 16.67px;">cde<span class="tag-count">3</span></a>',
+      '<a href="/tags/def/" style="font-size: 10px;">def<span class="tag-count">1</span></a>'
+    ].join(' '));
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Add an option to show posts count of each tag in tagcloud helper.

This pull request resolves #5047.

## Screenshots

_None._

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
