### PR TITLE
fix(#1099): hexo server error when changing the config

### DIFF
--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -206,7 +206,12 @@ function parseFilename(config, path) {
   const data = permalink.parse(path);
 
   if (data) {
-    return data;
+    if (data.title !== undefined) {
+      return data;
+    }
+    return Object.assign(data, {
+      title: slugize(path)
+    });
   }
 
   return {

--- a/test/scripts/processors/post.js
+++ b/test/scripts/processors/post.js
@@ -402,6 +402,34 @@ describe('post', () => {
     ]);
   });
 
+  it('post - parse unusual file name', async () => {
+    const body = [
+      'title: "Hello world"',
+      '---'
+    ].join('\n');
+
+    const file = newFile({
+      path: '20060102.html',
+      published: true,
+      type: 'create',
+      renderable: true
+    });
+
+    hexo.config.new_post_name = ':year:month:day';
+
+    await writeFile(file.source, body);
+    await process(file);
+    const post = Post.findOne({ source: file.path });
+
+    post.slug.should.eql('20060102');
+    post.date.format('YYYY-MM-DD').should.eql('2006-01-02');
+
+    return Promise.all([
+      post.remove(),
+      unlink(file.source)
+    ]);
+  });
+
   it('post - extra data in file name', async () => {
     const body = [
       'title: "Hello world"',


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Fix #1099.

When `new_post_name` lacks `:title`, `new_post_name` is used as the slug.

## Screenshots

_None._

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
