### PR TITLE
refactor: drop `use_date_for_updated` option for `updated_option`

### DIFF
--- a/lib/hexo/default_config.js
+++ b/lib/hexo/default_config.js
@@ -65,7 +65,6 @@ module.exports = {
   time_format: 'HH:mm:ss',
   updated_option: 'mtime',
   // * mtime: file modification date (default)
-  // * date: use_date_for_updated
   // * empty: no more update
   // Pagination
   per_page: 10,

--- a/lib/hexo/validate_config.js
+++ b/lib/hexo/validate_config.js
@@ -23,11 +23,6 @@ module.exports = ctx => {
     throw new TypeError('Invalid config detected: "root" should not be empty!');
   }
 
-  // Soft deprecate use_date_for_updated
-  if (typeof config.use_date_for_updated === 'boolean') {
-    log.warn('Deprecated config detected: "use_date_for_updated" is deprecated, please use "updated_option" instead. See https://hexo.io/docs/configuration for more details.');
-  }
-
   // Soft deprecate external_link Boolean
   if (typeof config.external_link === 'boolean') {
     log.warn('Deprecated config detected: "external_link" with a Boolean value is deprecated. See https://hexo.io/docs/configuration for more details.');

--- a/lib/plugins/processor/asset.js
+++ b/lib/plugins/processor/asset.js
@@ -33,8 +33,7 @@ function processPage(ctx, file) {
   const doc = Page.findOne({source: path});
   const { config } = ctx;
   const { timezone: timezoneCfg } = config;
-  // Deprecated: use_date_for_updated will be removed in future
-  const updated_option = config.use_date_for_updated === true ? 'date' : config.updated_option;
+  const updated_option = config.updated_option;
 
   if (file.type === 'skip' && doc) {
     return;

--- a/lib/plugins/processor/post.js
+++ b/lib/plugins/processor/post.js
@@ -70,8 +70,7 @@ function processPost(ctx, file) {
   const doc = Post.findOne({source: file.path});
   const { config } = ctx;
   const { timezone: timezoneCfg } = config;
-  // Deprecated: use_date_for_updated will be removed in future
-  const updated_option = config.use_date_for_updated === true ? 'date' : config.updated_option;
+  const updated_option = config.updated_option;
   let categories, tags;
 
   if (file.type === 'skip' && doc) {

--- a/test/scripts/hexo/validate_config.js
+++ b/test/scripts/hexo/validate_config.js
@@ -101,15 +101,6 @@ describe('Validate config', () => {
     }
   });
 
-  it('config.use_date_for_updated - depreacte', () => {
-    hexo.config.use_date_for_updated = true;
-
-    validateConfig(hexo);
-
-    logSpy.calledOnce.should.be.true;
-    logSpy.calledWith('Deprecated config detected: "use_date_for_updated" is deprecated, please use "updated_option" instead. See https://hexo.io/docs/configuration for more details.').should.be.true;
-  });
-
   it('config.external_link - depreacte Boolean value', () => {
     hexo.config.external_link = false;
 

--- a/test/scripts/processors/asset.js
+++ b/test/scripts/processors/asset.js
@@ -359,63 +359,6 @@ describe('asset', () => {
     ]);
   });
 
-  it('page - use_date_for_updated as fallback', async () => {
-    const body = [
-      'date: 2011-4-5 14:19:19',
-      '---'
-    ].join('\n');
-
-    const file = newFile({
-      path: 'hello.njk',
-      type: 'create',
-      renderable: true
-    });
-
-    hexo.config.use_date_for_updated = true;
-
-    await writeFile(file.source, body);
-    await process(file);
-    const stats = await stat(file.source);
-    const page = Page.findOne({source: file.path});
-
-    page.updated.toDate().should.eql(page.date.toDate());
-    page.updated.toDate().should.not.eql(stats.mtime);
-
-    await Promise.all([
-      page.remove(),
-      unlink(file.source)
-    ]);
-  });
-
-  it('page - ignore updated_option when use_date_for_updated is set', async () => {
-    const body = [
-      'date: 2011-4-5 14:19:19',
-      '---'
-    ].join('\n');
-
-    const file = newFile({
-      path: 'hello.njk',
-      type: 'create',
-      renderable: true
-    });
-
-    hexo.config.use_date_for_updated = true;
-    hexo.config.updated_option = 'mtime';
-
-    await writeFile(file.source, body);
-    await process(file);
-    const stats = await stat(file.source);
-    const page = Page.findOne({source: file.path});
-
-    page.updated.toDate().should.eql(page.date.toDate());
-    page.updated.toDate().should.not.eql(stats.mtime);
-
-    await Promise.all([
-      page.remove(),
-      unlink(file.source)
-    ]);
-  });
-
   it('page - permalink', async () => {
     const body = [
       'title: "Hello world"',

--- a/test/scripts/processors/post.js
+++ b/test/scripts/processors/post.js
@@ -622,66 +622,6 @@ describe('post', () => {
     ]);
   });
 
-  it('post - use use_date_for_updated as a fallback', async () => {
-    const body = [
-      'title: "Hello world"',
-      '---'
-    ].join('\n');
-
-    const file = newFile({
-      path: 'foo.html',
-      published: true,
-      type: 'create',
-      renderable: true
-    });
-
-    hexo.config.use_date_for_updated = true;
-
-    await writeFile(file.source, body);
-    const stats = await file.stat();
-    await process(file);
-    const post = Post.findOne({ source: file.path });
-
-    post.date.toDate().setMilliseconds(0).should.eql(stats.birthtime.setMilliseconds(0));
-    post.updated.toDate().setMilliseconds(0).should.eql(stats.birthtime.setMilliseconds(0));
-
-    return Promise.all([
-      post.remove(),
-      unlink(file.source)
-    ]);
-  });
-
-  it('post - ignore updated_option when use_date_for_updated is set', async () => {
-    const body = [
-      'date: 2011-4-5 14:19:19',
-      'title: "Hello world"',
-      '---'
-    ].join('\n');
-
-    const file = newFile({
-      path: 'foo.html',
-      published: true,
-      type: 'create',
-      renderable: true
-    });
-
-    hexo.config.use_date_for_updated = true;
-    hexo.config.updated_option = 'mtime';
-
-    await writeFile(file.source, body);
-    const stats = await file.stat();
-    await process(file);
-    const post = Post.findOne({ source: file.path });
-
-    post.updated.toDate().setMilliseconds(0).should.eql(post.date.toDate().setMilliseconds(0));
-    post.updated.toDate().setMilliseconds(0).should.not.eql(stats.mtime.setMilliseconds(0));
-
-    return Promise.all([
-      post.remove(),
-      unlink(file.source)
-    ]);
-  });
-
   it('post - photo is an alias for photos', async () => {
     const body = [
       'title: "Hello world"',


### PR DESCRIPTION
## What does it do?

Breaking Change

`use_date_for_updated` should be dropped next major bump (v7.0.0)

> https://hexo.io/docs/configuration#Date-x2F-Time-format

## Screenshots

N/A

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
