### PR TITLE
refactor: prepare for migration to typescript

### DIFF
--- a/lib/extend/index.js
+++ b/lib/extend/index.js
@@ -1,12 +1,16 @@
 'use strict';
 
-exports.Console = require('./console');
-exports.Deployer = require('./deployer');
-exports.Filter = require('./filter');
-exports.Generator = require('./generator');
-exports.Helper = require('./helper');
-exports.Injector = require('./injector');
-exports.Migrator = require('./migrator');
-exports.Processor = require('./processor');
-exports.Renderer = require('./renderer');
-exports.Tag = require('./tag');
+const Console = require('./console');
+const Deployer = require('./deployer');
+const Filter = require('./filter');
+const Generator = require('./generator');
+const Helper = require('./helper');
+const Injector = require('./injector');
+const Migrator = require('./migrator');
+const Processor = require('./processor');
+const Renderer = require('./renderer');
+const Tag = require('./tag');
+
+module.exports = {
+  Console, Deployer, Filter, Generator, Helper, Injector, Migrator, Processor, Renderer, Tag
+};

--- a/lib/hexo/scaffold.js
+++ b/lib/hexo/scaffold.js
@@ -26,7 +26,7 @@ class Scaffold {
       if (!exist) return [];
 
       return listDir(scaffoldDir, {
-        ignoreFilesRegex: /^_|\/_/
+        ignorePattern: /^_|\/_/
       });
     }).map(item => ({
       name: item.substring(0, item.length - extname(item).length),

--- a/lib/models/index.js
+++ b/lib/models/index.js
@@ -1,12 +1,16 @@
 'use strict';
 
-exports.Asset = require('./asset');
-exports.Cache = require('./cache');
-exports.Category = require('./category');
-exports.Data = require('./data');
-exports.Page = require('./page');
-exports.Post = require('./post');
-exports.PostAsset = require('./post_asset');
-exports.PostCategory = require('./post_category');
-exports.PostTag = require('./post_tag');
-exports.Tag = require('./tag');
+const Asset = require('./asset');
+const Cache = require('./cache');
+const Category = require('./category');
+const Data = require('./data');
+const Page = require('./page');
+const Post = require('./post');
+const PostAsset = require('./post_asset');
+const PostCategory = require('./post_category');
+const PostTag = require('./post_tag');
+const Tag = require('./tag');
+
+module.exports = {
+  Asset, Cache, Category, Data, Page, Post, PostAsset, PostCategory, PostTag, Tag
+};

--- a/lib/plugins/console/generate.js
+++ b/lib/plugins/console/generate.js
@@ -133,7 +133,7 @@ class Generater {
     // Check the public folder
     return stat(publicDir).then(stats => {
       if (!stats.isDirectory()) {
-        throw new Error('%s is not a directory', magenta(tildify(publicDir)));
+        throw new Error(`${magenta(tildify(publicDir))} is not a directory`);
       }
     }).catch(err => {
       // Create public folder if not exists

--- a/lib/plugins/console/list/index.js
+++ b/lib/plugins/console/list/index.js
@@ -1,13 +1,14 @@
 'use strict';
 
 const abbrev = require('abbrev');
+const page = require('./page');
+const post = require('./post');
+const route = require('./route');
+const tag = require('./tag');
+const category = require('./category');
 
 const store = {
-  page: require('./page'),
-  post: require('./post'),
-  route: require('./route'),
-  tag: require('./tag'),
-  category: require('./category')
+  page, post, route, tag, category
 };
 
 const alias = abbrev(Object.keys(store));

--- a/lib/plugins/helper/number_format.js
+++ b/lib/plugins/helper/number_format.js
@@ -30,7 +30,7 @@ function numberFormatHelper(num, options = {}) {
       const afterLast = after[precision];
       const last = parseInt(after[precision - 1], 10);
 
-      afterResult = after.substring(0, precision - 1) + (afterLast < 5 ? last : last + 1);
+      afterResult = after.substring(0, precision - 1) + (Number(afterLast) < 5 ? last : last + 1);
     } else {
       afterResult = after;
       for (let i = 0, len = precision - afterLength; i < len; i++) {
@@ -39,7 +39,7 @@ function numberFormatHelper(num, options = {}) {
     }
 
     after = afterResult;
-  } else if (precision === 0 || precision === '0') {
+  } else if (precision === 0) {
     after = '';
   }
 

--- a/lib/plugins/tag/img.js
+++ b/lib/plugins/tag/img.js
@@ -13,7 +13,7 @@ const rMeta = /["']?([^"']+)?["']?\s*["']?([^"']+)?["']?/;
 */
 module.exports = ctx => {
 
-  return function imgTag(args, content) {
+  return function imgTag(args) {
     const classes = [];
     let src, width, height, title, alt;
 


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Convert some `require`s to top level. They will be the static import after https://github.com/hexojs/hexo/pull/5092
Some lazyload `require`s e.g. `if (!highlight) highlight = require('hexo-util').highlight;` are left untouched.

And, found some possible bugs in #5092 
lib/plugins/console/generate.js 9ba40f4dd5894c20905a5380020833da8275015a
lib/hexo/scaffold.js 3323364f3a81b539f303f6dec4ae666bb3c34dcc

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
