### PR TITLE
test(benchmark): update hexo-many-posts repo

### DIFF
--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -168,7 +168,7 @@ async function init() {
     log.info('Setting up a dummy hexo site with 500 posts');
     await gitClone('https://github.com/hexojs/hexo-theme-unit-test.git', testDir);
     await gitClone('https://github.com/hexojs/hexo-theme-landscape', resolve(testDir, 'themes', 'landscape'));
-    await gitClone('https://github.com/SukkaLab/hexo-many-posts.git', resolve(testDir, 'source', '_posts', 'hexo-many-posts'));
+    await gitClone('https://github.com/hexojs/hexo-many-posts.git', resolve(testDir, 'source', '_posts', 'hexo-many-posts'));
   }
 
   log.info('Installing dependencies');


### PR DESCRIPTION
## What does it do?

I have transferred the `hexo-many-posts` repo to the `hexojs` org. This should provide access for @hexojs/core to change/update the benchmark suite. The PR updates the benchmark setup.

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
