### PR TITLE
refactor:  use the `WHATWG URL API` instead of `url.resolve`

### DIFF
--- a/lib/plugins/tag/asset_img.js
+++ b/lib/plugins/tag/asset_img.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { resolve } = require('url');
 const img = require('./img');
 const { encodeURL } = require('hexo-util');
 
@@ -20,7 +19,7 @@ module.exports = ctx => {
     for (let i = 0; i < len; i++) {
       const asset = PostAsset.findOne({post: this._id, slug: args[i]});
       if (asset) {
-        args[i] = encodeURL(resolve('/', asset.path));
+        args[i] = encodeURL(new URL(asset.path, ctx.config.url).pathname);
         return img(ctx)(args);
       }
     }

--- a/lib/plugins/tag/asset_link.js
+++ b/lib/plugins/tag/asset_link.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { encodeURL, escapeHTML } = require('hexo-util');
-const { resolve } = require('url');
 
 /**
  * Asset link tag
@@ -30,7 +29,7 @@ module.exports = ctx => {
     const attrTitle = escapeHTML(title);
     if (escape === 'true') title = attrTitle;
 
-    const link = encodeURL(resolve(ctx.config.root, asset.path));
+    const link = encodeURL(new URL(asset.path, ctx.config.url).pathname);
 
     return `<a href="${link}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/asset_path.js
+++ b/lib/plugins/tag/asset_path.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { resolve } = require('url');
 const { encodeURL } = require('hexo-util');
 
 /**
@@ -19,7 +18,7 @@ module.exports = ctx => {
     const asset = PostAsset.findOne({post: this._id, slug});
     if (!asset) return;
 
-    const path = encodeURL(resolve(ctx.config.root, asset.path));
+    const path = encodeURL(new URL(asset.path, ctx.config.url).pathname);
 
     return path;
   };

--- a/lib/plugins/tag/post_link.js
+++ b/lib/plugins/tag/post_link.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { encodeURL, escapeHTML } = require('hexo-util');
-const { resolve } = require('url');
 const { postFindOneFactory } = require('./');
 
 /**
@@ -35,7 +34,7 @@ module.exports = ctx => {
     const attrTitle = escapeHTML(post.title);
     if (escape === 'true') title = escapeHTML(title);
 
-    const link = encodeURL(resolve(ctx.config.root, post.path));
+    const link = encodeURL(new URL(post.path, ctx.config.url).pathname);
 
     return `<a href="${link}" title="${attrTitle}">${title}</a>`;
   };

--- a/lib/plugins/tag/post_path.js
+++ b/lib/plugins/tag/post_path.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const { resolve } = require('url');
 const { encodeURL } = require('hexo-util');
 const { postFindOneFactory } = require('./');
 
@@ -19,7 +18,7 @@ module.exports = ctx => {
     const post = factory({ slug }) || factory({ title: slug });
     if (!post) return;
 
-    const link = encodeURL(resolve(ctx.config.root, post.path));
+    const link = encodeURL(new URL(post.path, ctx.config.url).pathname);
 
     return link;
   };


### PR DESCRIPTION
## What does it do?

Closes: #4479 

We just use `new URL`. No need to use `String.replace()` as #4479.

```sh
$ node

> new URL("/test", "https://example.com").pathname
'/test'
> new URL("test", "https://example.com").pathname
'/test'
> new URL("test", "https://example.com/").pathname
'/test'
> new URL("/test", "https://example.com/").pathname
'/test'
```

## Screenshots

N/A

## Pull request tasks

- [ ] ~~Add test cases for the changes.~~
- [x] Passed the CI test.
