### PR TITLE
fix(post-asset): strip extensions better on permalink

### DIFF
--- a/lib/models/post_asset.js
+++ b/lib/models/post_asset.js
@@ -19,8 +19,7 @@ module.exports = ctx => {
 
     // PostAsset.path is file path relative to `public_dir`
     // no need to urlescape, #1562
-    // strip /\.html?$/ extensions on permalink, #2134
-    // compatible with hexo-abbrlink when `post_asset_folder: true`
+    // strip extensions better on permalink, #2134
     return join(dirname(post.path), post.slug, this.slug);
   });
 

--- a/lib/models/post_asset.js
+++ b/lib/models/post_asset.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const { Schema } = require('warehouse').default;
-const { join } = require('path');
+const { join, dirname } = require('path');
 
 module.exports = ctx => {
   const PostAsset = new Schema({
@@ -20,7 +20,8 @@ module.exports = ctx => {
     // PostAsset.path is file path relative to `public_dir`
     // no need to urlescape, #1562
     // strip /\.html?$/ extensions on permalink, #2134
-    return join(post.path.replace(/\.html?$/, ''), this.slug);
+    // compatible with hexo-abbrlink when `post_asset_folder: true`
+    return join(dirname(post.path), post.slug, this.slug);
   });
 
   PostAsset.virtual('source').get(function() {


### PR DESCRIPTION
## What does it do?
Fixes [#2134](https://github.com/hexojs/hexo/issues/2134)
Closes [#2881](https://github.com/hexojs/hexo/pull/2881)

A better way to strip extensions on permalink in post-asset.js
To some degree, it is possible to increase plugin compatibility.

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
