### PR TITLE
fix(box): check for invalid file

### DIFF
--- a/lib/box/index.js
+++ b/lib/box/index.js
@@ -78,8 +78,9 @@ class Box extends EventEmitter {
   }
 
   _readDir(base, prefix = '') {
+    const { context: ctx } = this;
     const results = [];
-    return readDirWalker(base, results, this.ignore, prefix)
+    return readDirWalker(ctx, base, results, this.ignore, prefix)
       .return(results)
       .map(path => this._checkFileStatus(path))
       .map(file => this._processFile(file.type, file.path).return(file.path));
@@ -155,7 +156,7 @@ class Box extends EventEmitter {
         path
       });
     }).catch(err => {
-      ctx.log.error({err}, 'Process failed: %s', magenta(path));
+      ctx.log.error({ err }, 'Process failed: %s', magenta(path));
     }).finally(() => {
       this._processingFiles[path] = false;
     }).thenReturn(path);
@@ -245,21 +246,28 @@ function isIgnoreMatch(path, ignore) {
   return path && ignore && ignore.length && isMatch(path, ignore);
 }
 
-function readDirWalker(base, results, ignore, prefix) {
+function readDirWalker(ctx, base, results, ignore, prefix) {
   if (isIgnoreMatch(base, ignore)) return Promise.resolve();
 
   return Promise.map(readdir(base).catch(err => {
+    ctx.log.error({ err }, 'Failed to read directory: %s', base);
     if (err && err.code === 'ENOENT') return [];
     throw err;
   }), async path => {
     const fullpath = join(base, path);
-    const stats = await stat(fullpath);
+    const stats = await stat(fullpath).catch(err => {
+      ctx.log.error({ err }, 'Failed to stat file: %s', fullpath);
+      if (err && err.code === 'ENOENT') return null;
+      throw err;
+    });
     const prefixdPath = `${prefix}${path}`;
-    if (stats.isDirectory()) {
-      return readDirWalker(fullpath, results, ignore, `${prefixdPath}/`);
-    }
-    if (!isIgnoreMatch(fullpath, ignore)) {
-      results.push(prefixdPath);
+    if (stats) {
+      if (stats.isDirectory()) {
+        return readDirWalker(ctx, fullpath, results, ignore, `${prefixdPath}/`);
+      }
+      if (!isIgnoreMatch(fullpath, ignore)) {
+        results.push(prefixdPath);
+      }
     }
   });
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Issue resolved: https://github.com/hexojs/hexo/issues/5166

`const stats = stat(fullpath)` returns undefined when `fullpath` is an invalid symbolic link. Calling `stats.isDirectory()` breaks the processing of other valid files.

This pull request aims to display an error message indicating the invalid file.

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
