### PR TITLE
Refactor types

### DIFF
--- a/lib/box/index.ts
+++ b/lib/box/index.ts
@@ -182,7 +182,7 @@ class Box extends EventEmitter {
     }).thenReturn(path);
   }
 
-  watch(callback) {
+  watch(callback?) {
     if (this.isWatching()) {
       return BlueBirdPromise.reject(new Error('Watcher has already started.')).asCallback(callback);
     }

--- a/lib/extend/console.ts
+++ b/lib/extend/console.ts
@@ -15,7 +15,11 @@ type Option = Partial<{
   }[];
 }>
 
-type AnyFn = (args: any[]) => any;
+interface Args {
+  _: string[];
+  [key: string]: string | boolean | string[];
+}
+type AnyFn = (args: Args) => any;
 interface StoreFunction extends AnyFn {
   desc?: string;
   options?: Option;

--- a/lib/extend/console.ts
+++ b/lib/extend/console.ts
@@ -3,6 +3,8 @@ import abbrev from 'abbrev';
 
 type Option = Partial<{
   usage: string;
+  desc: string;
+  init: boolean;
   arguments: {
       name: string;
       desc: string;

--- a/lib/extend/console.ts
+++ b/lib/extend/console.ts
@@ -1,17 +1,34 @@
 import Promise from 'bluebird';
 import abbrev from 'abbrev';
 
-/**
- * Console plugin option
- * @typedef {Object} Option
- * @property {String} usage - The usage of a console command
- * @property {{name: String, desc: String}[]} arguments - The description of each argument of a console command
- * @property {{name: String, desc: String}[]} options - The description of each option of a console command
- */
+type Option = Partial<{
+  usage: string;
+  arguments: {
+      name: string;
+      desc: string;
+    }[];
+  options: {
+    name: string;
+    desc: string;
+  }[];
+}>
+
+type AnyFn = (args: any[]) => any;
+interface StoreFunction extends AnyFn {
+  desc?: string;
+  options?: Option;
+}
+
+interface Store {
+  [key: string]: StoreFunction
+}
+interface Alias {
+  [key: string]: string
+}
 
 class Console {
-  public store: any;
-  public alias: any;
+  public store: Store;
+  public alias: Alias;
 
   constructor() {
     this.store = {};
@@ -21,9 +38,9 @@ class Console {
   /**
    * Get a console plugin function by name
    * @param {String} name - The name of the console plugin
-   * @returns {Function} - The console plugin function
+   * @returns {StoreFunction} - The console plugin function
    */
-  get(name) {
+  get(name: string): StoreFunction {
     name = name.toLowerCase();
     return this.store[this.alias[name]];
   }
@@ -37,9 +54,13 @@ class Console {
    * @param {String} name - The name of console plugin to be registered
    * @param {String} desc - More detailed information about a console command
    * @param {Option} options - The description of each option of a console command
-   * @param {Function} fn - The console plugin to be registered
+   * @param {AnyFn} fn - The console plugin to be registered
    */
-  register(name, desc, options, fn) {
+  register(name: string, fn: AnyFn): void
+  register(name: string, desc: string, fn: AnyFn): void
+  register(name: string, options: Option, fn: AnyFn): void
+  register(name: string, desc: string, options: Option, fn: AnyFn): void
+  register(name: string, desc: string | Option | AnyFn, options?: Option | AnyFn, fn?: AnyFn) {
     if (!name) throw new TypeError('name is required');
 
     if (!fn) {
@@ -74,10 +95,10 @@ class Console {
       fn = Promise.method(fn);
     }
 
-    const c = fn;
+    const c = fn as StoreFunction;
     this.store[name.toLowerCase()] = c;
-    c.options = options;
-    c.desc = desc;
+    c.options = options as Option;
+    c.desc = desc as string;
 
     this.alias = abbrev(Object.keys(this.store));
   }

--- a/lib/extend/deployer.ts
+++ b/lib/extend/deployer.ts
@@ -1,7 +1,17 @@
 import Promise from 'bluebird';
 
+interface StoreFunction {
+  (deployArg: {
+    type: string;
+    [key: string]: any
+  }) : any;
+}
+interface Store {
+  [key: string]: StoreFunction
+}
+
 class Deployer {
-  public store: any;
+  public store: Store;
 
   constructor() {
     this.store = {};
@@ -15,7 +25,7 @@ class Deployer {
     return this.store[name];
   }
 
-  register(name: string, fn) {
+  register(name: string, fn: StoreFunction) {
     if (!name) throw new TypeError('name is required');
     if (typeof fn !== 'function') throw new TypeError('fn must be a function');
 

--- a/lib/extend/filter.ts
+++ b/lib/extend/filter.ts
@@ -8,7 +8,7 @@ const typeAlias = {
 
 interface FilterOptions {
   context?: any;
-  args?: any;
+  args?: any[];
 }
 
 interface StoreFunction {
@@ -34,8 +34,11 @@ class Filter {
     return this.store[type] || [];
   }
 
-  register(fn: StoreFunction, priority: number);
-  register(type?: string | StoreFunction, fn?: StoreFunction | number, priority?: number) {
+  register(fn: StoreFunction): void
+  register(fn: StoreFunction, priority: number): void
+  register(type: string, fn: StoreFunction): void
+  register(type: string, fn: StoreFunction, priority: number): void
+  register(type: string | StoreFunction, fn?: StoreFunction | number, priority?: number) {
     if (!priority) {
       if (typeof type === 'function') {
         priority = fn as number;
@@ -72,7 +75,7 @@ class Filter {
     if (index !== -1) list.splice(index, 1);
   }
 
-  exec(type: string, data, options: FilterOptions = {}) {
+  exec(type: string, data: any[], options: FilterOptions = {}) {
     const filters = this.list(type);
     if (filters.length === 0) return Promise.resolve(data);
 
@@ -87,7 +90,7 @@ class Filter {
     })).then(() => args[0]);
   }
 
-  execSync(type: string, data, options: FilterOptions = {}) {
+  execSync(type: string, data: any[], options: FilterOptions = {}) {
     const filters = this.list(type);
     const filtersLen = filters.length;
     if (filtersLen === 0) return data;

--- a/lib/extend/filter.ts
+++ b/lib/extend/filter.ts
@@ -12,7 +12,7 @@ interface FilterOptions {
 }
 
 interface StoreFunction {
-  (...args: any[]): any;
+  (data?: any, ...args: any[]): any;
   priority?: number;
 }
 

--- a/lib/extend/generator.ts
+++ b/lib/extend/generator.ts
@@ -1,8 +1,16 @@
 import Promise from 'bluebird';
 
+interface StoreFunction {
+  (...args: any[]): any;
+}
+
+interface Store {
+  [key: string]: StoreFunction
+}
+
 class Generator {
-  public id: any;
-  public store: any;
+  public id: number;
+  public store: Store;
 
   constructor() {
     this.id = 0;
@@ -17,9 +25,11 @@ class Generator {
     return this.store[name];
   }
 
-  register(name, fn) {
+  register(fn: StoreFunction): void
+  register(name: string, fn: StoreFunction): void
+  register(name: string | StoreFunction, fn?: StoreFunction) {
     if (!fn) {
-      if (typeof name === 'function') {
+      if (typeof name === 'function') { // fn
         fn = name;
         name = `generator-${this.id++}`;
       } else {
@@ -28,7 +38,7 @@ class Generator {
     }
 
     if (fn.length > 1) fn = Promise.promisify(fn);
-    this.store[name] = Promise.method(fn);
+    this.store[name as string] = Promise.method(fn);
   }
 }
 

--- a/lib/extend/generator.ts
+++ b/lib/extend/generator.ts
@@ -1,7 +1,21 @@
 import Promise from 'bluebird';
 
+interface BaseObj {
+  path: string;
+  data: any;
+  layout?: string;
+}
+type ReturnType = BaseObj | BaseObj[];
+type GeneratorReturnType = ReturnType | Promise<ReturnType>;
+
+interface GeneratorFunction {
+  (locals: object): GeneratorReturnType;
+}
+
+type StoreFunctionReturn = Promise<ReturnType>;
+
 interface StoreFunction {
-  (...args: any[]): any;
+  (locals: object): StoreFunctionReturn;
 }
 
 interface Store {
@@ -25,9 +39,9 @@ class Generator {
     return this.store[name];
   }
 
-  register(fn: StoreFunction): void
-  register(name: string, fn: StoreFunction): void
-  register(name: string | StoreFunction, fn?: StoreFunction) {
+  register(fn: GeneratorFunction): void
+  register(name: string, fn: GeneratorFunction): void
+  register(name: string | GeneratorFunction, fn?: GeneratorFunction) {
     if (!fn) {
       if (typeof name === 'function') { // fn
         fn = name;

--- a/lib/extend/helper.ts
+++ b/lib/extend/helper.ts
@@ -1,5 +1,5 @@
 interface StoreFunction {
-  (...args: any[]): any;
+  (...args: any[]): string;
 }
 
 interface Store {

--- a/lib/extend/helper.ts
+++ b/lib/extend/helper.ts
@@ -1,32 +1,41 @@
+interface StoreFunction {
+  (...args: any[]): any;
+}
+
+interface Store {
+  [key: string]: StoreFunction
+}
+
+
 class Helper {
-  public store: any;
+  public store: Store;
 
   constructor() {
     this.store = {};
   }
 
   /**
-   * @returns {Object} - The plugin store
+   * @returns {Store} - The plugin store
    */
-  list() {
+  list(): Store {
     return this.store;
   }
 
   /**
    * Get helper plugin function by name
    * @param {String} name - The name of the helper plugin
-   * @returns {Function}
+   * @returns {StoreFunction}
    */
-  get(name: string) {
+  get(name: string): StoreFunction {
     return this.store[name];
   }
 
   /**
    * Register a helper plugin
    * @param {String} name - The name of the helper plugin
-   * @param {Function} fn - The helper plugin function
+   * @param {StoreFunction} fn - The helper plugin function
    */
-  register(name: string, fn) {
+  register(name: string, fn: StoreFunction) {
     if (!name) throw new TypeError('name is required');
     if (typeof fn !== 'function') throw new TypeError('fn must be a function');
 

--- a/lib/extend/injector.ts
+++ b/lib/extend/injector.ts
@@ -1,7 +1,15 @@
 import { Cache } from 'hexo-util';
 
+type Entry = 'head_begin' | 'head_end' | 'body_begin' | 'body_end';
+
+type Store = {
+  [key in Entry]: {
+    [key: string]: Set<unknown>;
+  };
+};
+
 class Injector {
-  public store: any;
+  public store: Store;
   public cache: any;
   public page: any;
 
@@ -20,21 +28,21 @@ class Injector {
     return this.store;
   }
 
-  get(entry, to = 'default') {
+  get(entry: Entry, to = 'default') {
     return Array.from(this.store[entry][to] || []);
   }
 
-  getText(entry, to = 'default') {
+  getText(entry: Entry, to = 'default') {
     const arr = this.get(entry, to);
     if (!arr || !arr.length) return '';
     return arr.join('');
   }
 
-  getSize(entry) {
+  getSize(entry: Entry) {
     return this.cache.apply(`${entry}-size`, Object.keys(this.store[entry]).length);
   }
 
-  register(entry, value, to = 'default') {
+  register(entry: Entry, value: string | (() => string), to = 'default') {
     if (!entry) throw new TypeError('entry is required');
     if (typeof value === 'function') value = value();
 

--- a/lib/extend/migrator.ts
+++ b/lib/extend/migrator.ts
@@ -1,7 +1,14 @@
 import Promise from 'bluebird';
+interface StoreFunction {
+  (args: any): any
+}
+
+interface Store {
+  [key: string]: StoreFunction
+}
 
 class Migrator {
-  public store: any;
+  public store: Store;
 
   constructor() {
     this.store = {};
@@ -15,7 +22,7 @@ class Migrator {
     return this.store[name];
   }
 
-  register(name: string, fn) {
+  register(name: string, fn: StoreFunction) {
     if (!name) throw new TypeError('name is required');
     if (typeof fn !== 'function') throw new TypeError('fn must be a function');
 

--- a/lib/extend/processor.ts
+++ b/lib/extend/processor.ts
@@ -1,8 +1,9 @@
 import Promise from 'bluebird';
 import { Pattern } from 'hexo-util';
+import File from '../box/file';
 
 interface StoreFunction {
-  (args: any): any
+  (file: File): any
 }
 
 type Store = {
@@ -41,7 +42,7 @@ class Processor {
     }
 
     this.store.push({
-      pattern: new Pattern(pattern),
+      pattern: new Pattern(pattern as patternType),
       process: fn
     });
   }

--- a/lib/extend/processor.ts
+++ b/lib/extend/processor.ts
@@ -1,8 +1,18 @@
 import Promise from 'bluebird';
 import { Pattern } from 'hexo-util';
 
+interface StoreFunction {
+  (args: any): any
+}
+
+type Store = {
+    pattern: Pattern;
+    process: StoreFunction
+  }[];
+
+type patternType = Exclude<ConstructorParameters<typeof Pattern>[0], ((str: string) => string)>;
 class Processor {
-  public store: any;
+  public store: Store;
 
   constructor() {
     this.store = [];
@@ -12,7 +22,9 @@ class Processor {
     return this.store;
   }
 
-  register(pattern, fn) {
+  register(fn: StoreFunction): void;
+  register(pattern: patternType, fn: StoreFunction): void;
+  register(pattern: patternType | StoreFunction, fn?: StoreFunction) {
     if (!fn) {
       if (typeof pattern === 'function') {
         fn = pattern;

--- a/lib/extend/processor.ts
+++ b/lib/extend/processor.ts
@@ -1,6 +1,6 @@
 import Promise from 'bluebird';
 import { Pattern } from 'hexo-util';
-import File from '../box/file';
+import type File from '../box/file';
 
 interface StoreFunction {
   (file: File): any

--- a/lib/extend/renderer.ts
+++ b/lib/extend/renderer.ts
@@ -1,46 +1,90 @@
 import { extname } from 'path';
 import Promise from 'bluebird';
 
-const getExtname = str => {
+const getExtname = (str: string) => {
   if (typeof str !== 'string') return '';
 
   const ext = extname(str) || str;
   return ext.startsWith('.') ? ext.slice(1) : ext;
 };
 
+interface StoreSyncFunction {
+  (
+    data: {
+      path?: string;
+      text: string;
+    },
+    options: object,
+    // callback: (err: Error, value: string) => any
+  ): any;
+  output?: string;
+  compile?: (local: object) => string;
+}
+interface StoreFunction {
+  (
+    data: {
+      path?: string;
+      text: string;
+    },
+    options: object,
+  ): Promise<any>;
+  (
+    data: {
+      path?: string;
+      text: string;
+    },
+    options: object,
+    callback: (err: Error, value: string) => any
+  ): void;
+  output?: string;
+  compile?: (local: object) => string;
+  disableNunjucks?: boolean;
+}
+
+interface SyncStore {
+  [key: string]: StoreSyncFunction;
+}
+interface Store {
+  [key: string]: StoreFunction;
+}
+
 class Renderer {
-  public store: any;
-  public storeSync: any;
+  public store: Store;
+  public storeSync: SyncStore;
 
   constructor() {
     this.store = {};
     this.storeSync = {};
   }
 
-  list(sync) {
+  list(sync: boolean) {
     return sync ? this.storeSync : this.store;
   }
 
-  get(name, sync?) {
+  get(name: string, sync?: boolean) {
     const store = this[sync ? 'storeSync' : 'store'];
 
     return store[getExtname(name)] || store[name];
   }
 
-  isRenderable(path) {
+  isRenderable(path: string) {
     return Boolean(this.get(path));
   }
 
-  isRenderableSync(path) {
+  isRenderableSync(path: string) {
     return Boolean(this.get(path, true));
   }
 
-  getOutput(path) {
+  getOutput(path: string) {
     const renderer = this.get(path);
     return renderer ? renderer.output : '';
   }
 
-  register(name, output, fn, sync) {
+  register(name: string, output: string, fn: StoreFunction): void;
+  register(name: string, output: string, fn: StoreFunction, sync: false): void;
+  register(name: string, output: string, fn: StoreSyncFunction, sync: true): void;
+  register(name: string, output: string, fn: StoreFunction | StoreSyncFunction, sync: boolean): void;
+  register(name: string, output: string, fn: StoreFunction | StoreSyncFunction, sync?: boolean) {
     if (!name) throw new TypeError('name is required');
     if (!output) throw new TypeError('output is required');
     if (typeof fn !== 'function') throw new TypeError('fn must be a function');
@@ -53,7 +97,8 @@ class Renderer {
       this.storeSync[name].output = output;
 
       this.store[name] = Promise.method(fn);
-      this.store[name].disableNunjucks = fn.disableNunjucks;
+      // eslint-disable-next-line no-extra-parens
+      this.store[name].disableNunjucks = (fn as StoreFunction).disableNunjucks;
     } else {
       if (fn.length > 2) fn = Promise.promisify(fn);
       this.store[name] = fn;

--- a/lib/extend/syntax_highlight.ts
+++ b/lib/extend/syntax_highlight.ts
@@ -1,10 +1,32 @@
-interface Options {
-  context?: any;
-  args?: any;
+import Hexo from '../hexo';
+
+export interface HighlightOptions {
+  // plulgins/filter/before_post_render/backtick_code_block
+  lang: string,
+  caption: string,
+  lines_length?: number,
+  firstLineNumber?: string | number
+
+
+  language_attr?: boolean;
+  firstLine?: number;
+  line_number?: boolean;
+  line_threshold?: number;
+  mark?: number[];
+  wrap?: boolean;
+
+}
+
+interface HighlightExecArgs {
+  context?: Hexo;
+  args?: [
+    content: string,
+    options: HighlightOptions,
+  ];
 }
 
 interface StoreFunction {
-  (...args: any[]): any;
+  (content: string, options: HighlightOptions): string;
   priority?: number;
 }
 
@@ -29,7 +51,7 @@ class SyntaxHighlight {
     return name && this.store[name];
   }
 
-  exec(name: string, options: Options) {
+  exec(name: string, options: HighlightExecArgs): string {
     const fn = this.store[name];
 
     if (!fn) throw new TypeError(`syntax highlighter ${name} is not registered`);
@@ -40,4 +62,4 @@ class SyntaxHighlight {
   }
 }
 
-export = SyntaxHighlight;
+export default SyntaxHighlight;

--- a/lib/extend/syntax_highlight.ts
+++ b/lib/extend/syntax_highlight.ts
@@ -1,4 +1,4 @@
-import Hexo from '../hexo';
+import type Hexo from '../hexo';
 
 export interface HighlightOptions {
   // plulgins/filter/before_post_render/backtick_code_block

--- a/lib/extend/syntax_highlight.ts
+++ b/lib/extend/syntax_highlight.ts
@@ -1,28 +1,26 @@
 import type Hexo from '../hexo';
 
 export interface HighlightOptions {
+  lang: string | undefined,
+  caption: string | undefined,
+  lines_length: number,
+
   // plulgins/filter/before_post_render/backtick_code_block
-  lang: string,
-  caption: string,
-  lines_length?: number,
   firstLineNumber?: string | number
 
-
-  language_attr?: boolean;
+  // plugins/tag/code.ts
+  language_attr?: boolean | undefined;
   firstLine?: number;
-  line_number?: boolean;
-  line_threshold?: number;
+  line_number?: boolean | undefined;
+  line_threshold?: number | undefined;
   mark?: number[];
-  wrap?: boolean;
+  wrap?: boolean | undefined;
 
 }
 
 interface HighlightExecArgs {
   context?: Hexo;
-  args?: [
-    content: string,
-    options: HighlightOptions,
-  ];
+  args?: [string, HighlightOptions];
 }
 
 interface StoreFunction {

--- a/lib/hexo/index.ts
+++ b/lib/hexo/index.ts
@@ -117,6 +117,25 @@ interface Query {
   published?: boolean;
 }
 
+interface Extend {
+  console: Console,
+  deployer: Deployer,
+  filter: Filter,
+  generator: Generator,
+  helper: Helper,
+  highlight: Highlight,
+  injector: Injector,
+  migrator: Migrator,
+  processor: Processor,
+  renderer: Renderer,
+  tag: Tag
+}
+
+type DefaultConfigType = typeof defaultConfig;
+interface Config extends DefaultConfigType {
+  [key: string]: any;
+}
+
 // Node.js internal APIs
 declare module 'module' {
   function _nodeModulePaths(path: string): string[];
@@ -126,32 +145,31 @@ declare module 'module' {
 }
 
 class Hexo extends EventEmitter {
-  public base_dir: any;
-  public public_dir: any;
-  public source_dir: any;
-  public plugin_dir: any;
-  public script_dir: any;
-  public scaffold_dir: any;
-  public theme_dir: any;
-  public theme_script_dir: any;
+  public base_dir: string;
+  public public_dir: string;
+  public source_dir: string;
+  public plugin_dir: string;
+  public script_dir: string;
+  public scaffold_dir: string;
+  public theme_dir: string;
+  public theme_script_dir: string;
   public env: any;
-  public extend: any;
-  public config: any;
-  public log: any;
-  public render: any;
-  public route: any;
-  public post: any;
-  public scaffold: any;
-  public _dbLoaded: any;
-  public _isGenerating: any;
+  public extend: Extend;
+  public config: Config;
+  public log: ReturnType<typeof logger>;
+  public render: Render;
+  public route: Router;
+  public post: Post;
+  public scaffold: Scaffold;
+  public _dbLoaded: boolean;
+  public _isGenerating: boolean;
   public database: Database;
-  public config_path: any;
-  public source: any;
-  public theme: any;
-  public locals: any;
-  public version: any;
-  public emit: any;
-  public _watchBox: any;
+  public config_path: string;
+  public source: Source;
+  public theme: Theme;
+  public locals: Locals;
+  public version: string;
+  public _watchBox: () => void;
   public page: any;
   public path: any;
   public url: any;

--- a/lib/plugins/console/index.ts
+++ b/lib/plugins/console/index.ts
@@ -1,4 +1,6 @@
-export = function(ctx) {
+import Hexo from '../../hexo';
+
+export = function(ctx: Hexo) {
   const { console } = ctx.extend;
 
   console.register('clean', 'Remove generated files and cache.', require('./clean'));

--- a/lib/plugins/console/index.ts
+++ b/lib/plugins/console/index.ts
@@ -1,4 +1,4 @@
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 export = function(ctx: Hexo) {
   const { console } = ctx.extend;

--- a/lib/plugins/filter/index.ts
+++ b/lib/plugins/filter/index.ts
@@ -1,4 +1,6 @@
-export = ctx => {
+import Hexo from '../../hexo';
+
+export = (ctx: Hexo) => {
   const { filter } = ctx.extend;
 
   require('./after_render')(ctx);

--- a/lib/plugins/filter/index.ts
+++ b/lib/plugins/filter/index.ts
@@ -1,4 +1,4 @@
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {
   const { filter } = ctx.extend;

--- a/lib/plugins/generator/asset.ts
+++ b/lib/plugins/generator/asset.ts
@@ -3,7 +3,7 @@ import { exists, createReadStream } from 'hexo-fs';
 import Promise from 'bluebird';
 import { extname } from 'path';
 import { magenta } from 'picocolors';
-import warehouse from 'warehouse';
+import type warehouse from 'warehouse';
 
 interface Data {
   modified: boolean;

--- a/lib/plugins/generator/index.ts
+++ b/lib/plugins/generator/index.ts
@@ -1,4 +1,6 @@
-export = ctx => {
+import Hexo from '../../hexo';
+
+export = (ctx: Hexo) => {
   const { generator } = ctx.extend;
 
   generator.register('asset', require('./asset'));

--- a/lib/plugins/generator/index.ts
+++ b/lib/plugins/generator/index.ts
@@ -1,4 +1,4 @@
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {
   const { generator } = ctx.extend;

--- a/lib/plugins/helper/index.ts
+++ b/lib/plugins/helper/index.ts
@@ -1,4 +1,4 @@
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {
   const { helper } = ctx.extend;

--- a/lib/plugins/helper/index.ts
+++ b/lib/plugins/helper/index.ts
@@ -1,4 +1,6 @@
-export = ctx => {
+import Hexo from '../../hexo';
+
+export = (ctx: Hexo) => {
   const { helper } = ctx.extend;
 
   const date = require('./date');

--- a/lib/plugins/highlight/index.ts
+++ b/lib/plugins/highlight/index.ts
@@ -1,4 +1,6 @@
-module.exports = ctx => {
+import Hexo from '../../hexo';
+
+module.exports = (ctx: Hexo) => {
   const { highlight } = ctx.extend;
 
   highlight.register('highlight.js', require('./highlight'));

--- a/lib/plugins/highlight/index.ts
+++ b/lib/plugins/highlight/index.ts
@@ -1,4 +1,4 @@
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 module.exports = (ctx: Hexo) => {
   const { highlight } = ctx.extend;

--- a/lib/plugins/injector/index.ts
+++ b/lib/plugins/injector/index.ts
@@ -1,4 +1,4 @@
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {
   // eslint-disable-next-line no-unused-vars

--- a/lib/plugins/injector/index.ts
+++ b/lib/plugins/injector/index.ts
@@ -1,4 +1,6 @@
-export = ctx => {
+import Hexo from '../../hexo';
+
+export = (ctx: Hexo) => {
   // eslint-disable-next-line no-unused-vars
   const { injector } = ctx.extend;
 };

--- a/lib/plugins/processor/index.ts
+++ b/lib/plugins/processor/index.ts
@@ -1,4 +1,4 @@
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {
   const { processor } = ctx.extend;

--- a/lib/plugins/processor/index.ts
+++ b/lib/plugins/processor/index.ts
@@ -1,7 +1,9 @@
-export = ctx => {
+import Hexo from '../../hexo';
+
+export = (ctx: Hexo) => {
   const { processor } = ctx.extend;
 
-  function register(name) {
+  function register(name: string) {
     const obj = require(`./${name}`)(ctx);
     processor.register(obj.pattern, obj.process);
   }

--- a/lib/plugins/renderer/index.ts
+++ b/lib/plugins/renderer/index.ts
@@ -1,4 +1,4 @@
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 export = (ctx: Hexo) => {
   const { renderer } = ctx.extend;

--- a/lib/plugins/renderer/index.ts
+++ b/lib/plugins/renderer/index.ts
@@ -1,4 +1,6 @@
-export = ctx => {
+import Hexo from '../../hexo';
+
+export = (ctx: Hexo) => {
   const { renderer } = ctx.extend;
 
   const plain = require('./plain');

--- a/lib/plugins/tag/index.ts
+++ b/lib/plugins/tag/index.ts
@@ -1,5 +1,5 @@
 import moize from 'moize';
-import Hexo from '../../hexo';
+import type Hexo from '../../hexo';
 
 export default (ctx: Hexo) => {
   const { tag } = ctx.extend;

--- a/lib/plugins/tag/index.ts
+++ b/lib/plugins/tag/index.ts
@@ -1,6 +1,7 @@
 import moize from 'moize';
+import Hexo from '../../hexo';
 
-export default ctx => {
+export default (ctx: Hexo) => {
   const { tag } = ctx.extend;
 
   const blockquote = require('./blockquote')(ctx);

--- a/package.json
+++ b/package.json
@@ -66,12 +66,13 @@
     "warehouse": "^5.0.0"
   },
   "devDependencies": {
+    "0x": "^5.1.2",
     "@easyops/git-exec-and-restage": "^1.0.4",
     "@types/bluebird": "^3.5.37",
     "@types/node": "^18.11.8",
+    "@types/nunjucks": "^3.2.2",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
-    "0x": "^5.1.2",
     "c8": "^7.12.0",
     "chai": "^4.3.6",
     "cheerio": "0.22.0",


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Add types to Hexo class and extend apis.

Only types are changed except for `lib/extend/tag.ts`, where I added an intermediate variable. All these changes should have no effect on runtime behavior.

This may help plugin authors who can now add hexo as devdependency and add `declare var hexo: import("hexo")` to `global.d.ts` to get better type inference.

## Screenshots

After adds

![image](https://user-images.githubusercontent.com/43703639/227890843-d20b4372-962a-491b-9d12-cf544f4c4993.png)

I can get better type inference like this:

![image](https://user-images.githubusercontent.com/43703639/227890760-0da42911-a07c-498d-93cb-0d23970ff810.png)

which used to be just any type.

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
