### PR TITLE
feat(tags/post_link): use slug when title is empty

### DIFF
--- a/lib/plugins/tag/post_link.ts
+++ b/lib/plugins/tag/post_link.ts
@@ -27,9 +27,9 @@ export = ctx => {
       throw new Error(`Post not found: post_link ${slug}.`);
     }
 
-    let title = args.length ? args.join(' ') : post.title;
+    let title = args.length ? args.join(' ') : post.title || post.slug;
     // Let attribute be the true post title so it appears in tooltip.
-    const attrTitle = escapeHTML(post.title);
+    const attrTitle = escapeHTML(post.title || post.slug);
     if (escape === 'true') title = escapeHTML(title);
 
     const link = encodeURL(new URL(post.path, ctx.config.url).pathname);

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -22,6 +22,11 @@ describe('post_link', () => {
     source: 'fôo',
     slug: 'fôo',
     title: 'Hello world'
+  },
+  {
+    source: 'no-title',
+    slug: 'no-title',
+    title: ''
   }])));
 
   it('default', () => {
@@ -34,6 +39,10 @@ describe('post_link', () => {
 
   it('title', () => {
     postLink(['foo', 'test']).should.eql('<a href="/foo/" title="Hello world">test</a>');
+  });
+
+  it('no title', () => {
+    postLink(['no-title']).should.eql('<a href="/no-title/" title="no-title">no-title</a>');
   });
 
   it('should escape tag in title by default', () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

When using `post_link` to link a post without a title, the content of the generated link is empty.

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
