### PR TITLE
feat: define global variable hexo

### DIFF
--- a/lib/hexo/index.ts
+++ b/lib/hexo/index.ts
@@ -598,4 +598,11 @@ Hexo.prototype.core_dir = Hexo.core_dir;
 Hexo.version = version;
 Hexo.prototype.version = Hexo.version;
 
+// define global variable
+// this useful for plugin written in typescript
+declare global {
+  // eslint-disable-next-line one-var
+  const hexo: Hexo;
+}
+
 export = Hexo;


### PR DESCRIPTION
useful for plugin written in typescript or let IDE detecting it

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Add global variable `hexo`. Since the release of TypeScript 3.4 there's a documented way to do it.
Useful for plugin written in typescript or let IDE typechecking detecting hexo.


## Screenshots
script inside `scripts` folder automated detect global hexo without setting anything on IDE.
![image](https://github.com/hexojs/hexo/assets/12471057/66d17036-e5e7-4d45-9f50-49176832e20f)
![image](https://github.com/hexojs/hexo/assets/12471057/e8cbbbcc-35de-4965-8d51-10c21e171235)

plugin using typescript.
![image](https://github.com/hexojs/hexo/assets/12471057/947fe137-067d-406e-8398-de3abf79fc5a)

demo improvement.
https://github.com/dimaslanjaka/hexo/tree/monorepo-v7/releases

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
