### PR TITLE
feat(helper/tagcloud): level false to use same className for each tag

### DIFF
--- a/lib/plugins/helper/tagcloud.js
+++ b/lib/plugins/helper/tagcloud.js
@@ -21,7 +21,7 @@ function tagcloudHelper(tags, options) {
   const className = options.class;
   const showCount = options.show_count;
   const countClassName = options.count_class || 'count';
-  const level = options.level || 10;
+  const level = options.level === false ? false : options.level || 10;
   const { transform } = options;
   const separator = options.separator || ' ';
   const result = [];
@@ -62,7 +62,7 @@ function tagcloudHelper(tags, options) {
     const ratio = length ? sizes.indexOf(tag.length) / length : 0;
     const size = min + ((max - min) * ratio);
     let style = `font-size: ${parseFloat(size.toFixed(2))}${unit};`;
-    const attr = className ? ` class="${className}-${Math.round(ratio * level)}"` : '';
+    const attr = className ? ` class="${className}${level === false ? '' : '-' + Math.round(ratio * level)}"` : '';
 
     if (color) {
       const midColor = startColor.mix(endColor, ratio);

--- a/test/scripts/helpers/tagcloud.js
+++ b/test/scripts/helpers/tagcloud.js
@@ -291,6 +291,20 @@ describe('tagcloud', () => {
     ].join(' '));
   });
 
+  it('class name without level', () => {
+    const result = tagcloud({
+      class: 'tag-cloud',
+      level: false
+    });
+
+    result.should.eql([
+      '<a href="/tags/abc/" style="font-size: 13.33px;" class="tag-cloud">abc</a>',
+      '<a href="/tags/bcd/" style="font-size: 20px;" class="tag-cloud">bcd</a>',
+      '<a href="/tags/cde/" style="font-size: 16.67px;" class="tag-cloud">cde</a>',
+      '<a href="/tags/def/" style="font-size: 10px;" class="tag-cloud">def</a>'
+    ].join(' '));
+  });
+
   it('show_count', () => {
     const result = tagcloud({ show_count: true });
 


### PR DESCRIPTION

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

When I need to add the same `class` for each tag in tagcloud, such as `whitespace-nowrap` in order to prevent text wrapping and `m-4` to margin between tags, the `level` option forcing a suffix feels a bit annoying.

As a consideration of that, I tried to add a new rule - when `level: false`, no suffix is added to the class. When `level` is set to `null`/`undefined`/`0`/blank string, it won't trigger into this rule. So this change won't break prior behaviour.

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
