### PR TITLE
ci: reduce the running of ci

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,19 @@
 name: Linter
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "master"
+      - "v7.0.0"
+    paths:
+      - "lib/**"
+      - "test/**"
+      - ".github/workflows/linter.yml"
+  pull_request:
+    paths:
+      - "lib/**"
+      - "test/**"
+      - ".github/workflows/linter.yml"
 
 permissions:
   contents: read
@@ -13,7 +26,7 @@ jobs:
       - name: Use Node.js 14.x
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: "14.x"
       - name: Install Dependencies
         run: npm install
       - name: Lint

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -1,6 +1,21 @@
 name: Tester
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - "master"
+      - "v7.0.0"
+    paths:
+      - "lib/**"
+      - "test/**"
+      - "package.json"
+      - ".github/workflows/tester.yml"
+  pull_request:
+    paths:
+      - "lib/**"
+      - "test/**"
+      - "package.json"
+      - ".github/workflows/tester.yml"
 
 permissions:
   contents: read
@@ -11,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ['14.x', '16.x', '18.x']
+        node-version: ["14.x", "16.x", "18.x"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -27,13 +42,13 @@ jobs:
           CI: true
   coverage:
     permissions:
-      checks: write  # for coverallsapp/github-action to create new checks
-      contents: read  # for actions/checkout to fetch code
+      checks: write # for coverallsapp/github-action to create new checks
+      contents: read # for actions/checkout to fetch code
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: ['14.x']
+        node-version: ["14.x"]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Same as #5282

## What does it do?

1. add `paths` filter. only run ci when the code changes.
2. add `branches` filter. only run ci in specified branches.


