### PR TITLE
Support additional options for Backtick Code Block

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -48,11 +48,11 @@ module.exports = ctx => {
           case 'line_threshold':
             if (!isNaN(value)) line_threshold = +value;
             break;
+          case 'language_attr':
+            language_attr = value === 'true';
+            break;
           case 'first_line':
             if (!isNaN(value)) firstLine = +value;
-            break;
-          case 'wrap':
-            wrap = value === 'true';
             break;
           case 'mark': {
             for (const cur of value.split(',')) {
@@ -75,10 +75,9 @@ module.exports = ctx => {
             }
             break;
           }
-          case 'language_attr': {
-            language_attr = value === 'true';
+          case 'wrap':
+            wrap = value === 'true';
             break;
-          }
           default: {
             _else.push(args[i]);
           }

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -27,7 +27,8 @@ module.exports = ctx => {
       const _else = [];
       const mark = [];
 
-      let language_attr, line_number, line_threshold, wrap;
+      let language_attr, line_number, line_threshold, wrap,
+        match, caption;
       let firstLine = 1;
 
       for (let i = 0; i < len; i++) {
@@ -84,10 +85,10 @@ module.exports = ctx => {
         }
       }
 
-      const lang = _else[0];
-      _else.shift(0)
+      // probably '' but hexo-util.PrismUtil need undefined in order to be assigned to 'none'
+      const lang = _else[0] || undefined;
+      _else.shift(0);
       const arg = _else.join(' ');
-      let match, caption = '';
 
       if ((match = arg.match(rCaptionUrlTitle)) != null) {
         caption = `<span>${match[1]}</span><a href="${match[2]}">${match[3]}</a>`;

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -1,8 +1,9 @@
 'use strict';
 
 const rBacktick = /^((?:[^\S\r\n]*>){0,3}[^\S\r\n]*)(`{3,}|~{3,})[^\S\r\n]*((?:.*?[^`\s])?)[^\S\r\n]*\n((?:[\s\S]*?\n)?)(?:(?:[^\S\r\n]*>){0,3}[^\S\r\n]*)\2[^\S\r\n]?(\n+|$)/gm;
-const rAllOptions = /([^\s]+)\s+(.+?)\s+(https?:\/\/\S+|\/\S+)\s*(.+)?/;
-const rLangCaption = /([^\s]+)\s*(.+)?/;
+const rCaptionUrlTitle = /(\S[\S\s]*)\s+(https?:\/\/\S+)\s+(.+)/i;
+const rCaptionUrl = /(\S[\S\s]*)\s+(https?:\/\/\S+)/i;
+const rCaption = /\S[\S\s]*/;
 
 const escapeSwigTag = str => str.replace(/{/g, '&#123;').replace(/}/g, '&#125;');
 
@@ -19,23 +20,82 @@ module.exports = ctx => {
       if (!ctx.extend.highlight.query(ctx.config.syntax_highlighter)) return escapeSwigTag($0);
 
       // Extract language and caption of code blocks
-      const args = _args.split('=').shift();
-      let lang, caption;
+      const shiftedArgs = _args.split('=').shift();
+      const args = shiftedArgs.split(/\s+/);
+      const len = args.length;
 
-      if (args) {
-        const match = rAllOptions.exec(args) || rLangCaption.exec(args);
+      const _else = [];
+      const mark = [];
 
-        if (match) {
-          lang = match[1];
+      let language_attr, line_number, line_threshold, wrap;
+      let firstLine = 1;
 
-          if (match[2]) {
-            caption = `<span>${match[2]}</span>`;
+      for (let i = 0; i < len; i++) {
+        const colon = args[i].indexOf(':');
 
-            if (match[3]) {
-              caption += `<a href="${match[3]}">${match[4] ? match[4] : 'link'}</a>`;
+        if (colon === -1) {
+          _else.push(args[i]);
+          continue;
+        }
+
+        const key = args[i].slice(0, colon);
+        const value = args[i].slice(colon + 1);
+
+        switch (key) {
+          case 'line_number':
+            line_number = value === 'true';
+            break;
+          case 'line_threshold':
+            if (!isNaN(value)) line_threshold = +value;
+            break;
+          case 'first_line':
+            if (!isNaN(value)) firstLine = +value;
+            break;
+          case 'wrap':
+            wrap = value === 'true';
+            break;
+          case 'mark': {
+            for (const cur of value.split(',')) {
+              const hyphen = cur.indexOf('-');
+              if (hyphen !== -1) {
+                let a = +cur.slice(0, hyphen);
+                let b = +cur.slice(hyphen + 1);
+                if (Number.isNaN(a) || Number.isNaN(b)) continue;
+                if (b < a) { // switch a & b
+                  const temp = a;
+                  a = b;
+                  b = temp;
+                }
+
+                for (; a <= b; a++) {
+                  mark.push(a);
+                }
+              }
+              if (!isNaN(cur)) mark.push(+cur);
             }
+            break;
+          }
+          case 'language_attr': {
+            language_attr = value === 'true';
+            break;
+          }
+          default: {
+            _else.push(args[i]);
           }
         }
+      }
+
+      const lang = _else[0];
+      _else.shift(0)
+      const arg = _else.join(' ');
+      let match, caption = '';
+
+      if ((match = arg.match(rCaptionUrlTitle)) != null) {
+        caption = `<span>${match[1]}</span><a href="${match[2]}">${match[3]}</a>`;
+      } else if ((match = arg.match(rCaptionUrl)) != null) {
+        caption = `<span>${match[1]}</span><a href="${match[2]}">link</a>`;
+      } else if ((match = arg.match(rCaption)) != null) {
+        caption = `<span>${match[0]}</span>`;
       }
 
       // PR #3765
@@ -49,7 +109,13 @@ module.exports = ctx => {
       const options = {
         lang,
         caption,
-        lines_length: content.split('\n').length
+        lines_length: content.split('\n').length,
+        line_number,
+        line_threshold,
+        language_attr,
+        firstLine,
+        mark,
+        wrap
       };
       // setup line number by inline
       _args = _args.replace('=+', '=');

--- a/lib/plugins/filter/before_post_render/backtick_code_block.js
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.js
@@ -25,9 +25,8 @@ module.exports = ctx => {
       const len = args.length;
 
       const _else = [];
-      const mark = [];
 
-      let language_attr, line_number, line_threshold, wrap,
+      let language_attr, line_number, line_threshold, mark, wrap,
         match, caption;
       let firstLine = 1;
 
@@ -55,27 +54,9 @@ module.exports = ctx => {
           case 'first_line':
             if (!isNaN(value)) firstLine = +value;
             break;
-          case 'mark': {
-            for (const cur of value.split(',')) {
-              const hyphen = cur.indexOf('-');
-              if (hyphen !== -1) {
-                let a = +cur.slice(0, hyphen);
-                let b = +cur.slice(hyphen + 1);
-                if (Number.isNaN(a) || Number.isNaN(b)) continue;
-                if (b < a) { // switch a & b
-                  const temp = a;
-                  a = b;
-                  b = temp;
-                }
-
-                for (; a <= b; a++) {
-                  mark.push(a);
-                }
-              }
-              if (!isNaN(cur)) mark.push(+cur);
-            }
+          case 'mark':
+            mark = value;
             break;
-          }
           case 'wrap':
             wrap = value === 'true';
             break;

--- a/lib/plugins/highlight/highlight.js
+++ b/lib/plugins/highlight/highlight.js
@@ -11,6 +11,30 @@ module.exports = function highlightFilter(code, options) {
   const gutter = shouldUseLineNumbers && surpassesLineThreshold;
   const languageAttr = typeof options.language_attr === 'undefined' ? hljsCfg.language_attr : options.language_attr;
 
+  let _mark;
+  if (options.mark) {
+    _mark = [];
+
+    for (const cur of options.mark.split(',')) {
+      const hyphen = cur.indexOf('-');
+      if (hyphen !== -1) {
+        let a = +cur.slice(0, hyphen);
+        let b = +cur.slice(hyphen + 1);
+        if (Number.isNaN(a) || Number.isNaN(b)) continue;
+        if (b < a) { // switch a & b
+          const temp = a;
+          a = b;
+          b = temp;
+        }
+
+        for (; a <= b; a++) {
+          _mark.push(a);
+        }
+      }
+      if (!isNaN(cur)) _mark.push(+cur);
+    }
+  }
+
   const hljsOptions = {
     autoDetect: hljsCfg.auto_detect,
     caption: options.caption,
@@ -19,7 +43,7 @@ module.exports = function highlightFilter(code, options) {
     hljs: hljsCfg.hljs,
     lang: options.lang,
     languageAttr,
-    mark: options.mark,
+    mark: _mark,
     tab: hljsCfg.tab_replace,
     wrap: hljsCfg.wrap
   };

--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -55,11 +55,11 @@ function parseArgs(args) {
       case 'line_threshold':
         if (!isNaN(value)) line_threshold = +value;
         break;
+      case 'language_attr':
+        language_attr = value === 'true';
+        break;
       case 'first_line':
         if (!isNaN(value)) firstLine = +value;
-        break;
-      case 'wrap':
-        wrap = value === 'true';
         break;
       case 'mark': {
         for (const cur of value.split(',')) {
@@ -82,10 +82,9 @@ function parseArgs(args) {
         }
         break;
       }
-      case 'language_attr': {
-        language_attr = value === 'true';
+      case 'wrap':
+        wrap = value === 'true';
         break;
-      }
       default: {
         _else.push(args[i]);
       }

--- a/lib/plugins/tag/code.js
+++ b/lib/plugins/tag/code.js
@@ -31,9 +31,8 @@ function parseArgs(args) {
   const _else = [];
   const len = args.length;
   let lang, language_attr,
-    line_number, line_threshold, wrap;
+    line_number, line_threshold, mark, wrap;
   let firstLine = 1;
-  const mark = [];
   for (let i = 0; i < len; i++) {
     const colon = args[i].indexOf(':');
 
@@ -61,27 +60,9 @@ function parseArgs(args) {
       case 'first_line':
         if (!isNaN(value)) firstLine = +value;
         break;
-      case 'mark': {
-        for (const cur of value.split(',')) {
-          const hyphen = cur.indexOf('-');
-          if (hyphen !== -1) {
-            let a = +cur.slice(0, hyphen);
-            let b = +cur.slice(hyphen + 1);
-            if (Number.isNaN(a) || Number.isNaN(b)) continue;
-            if (b < a) { // switch a & b
-              const temp = a;
-              a = b;
-              b = temp;
-            }
-
-            for (; a <= b; a++) {
-              mark.push(a);
-            }
-          }
-          if (!isNaN(cur)) mark.push(+cur);
-        }
+      case 'mark':
+        mark = value;
         break;
-      }
       case 'wrap':
         wrap = value === 'true';
         break;

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -184,6 +184,26 @@ describe('Backtick code block', () => {
       data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
     });
 
+    it('additional options', () => {
+      const data = {
+        content: [
+          '``` js Hello world https://hexo.io/ Hexo mark:1,2-3 wrap:false',
+          code,
+          '```'
+        ].join('\n')
+      };
+
+      const expected = highlight(code, {
+        lang: 'js',
+        caption: '<span>Hello world</span><a href="https://hexo.io/">Hexo</a>',
+        mark: [1, 2, 3],
+        wrap: false
+      });
+
+      codeBlock(data);
+      data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
+    });
+
     it('indent', () => {
       const indentCode = code.split('\n').map(line => '  ' + line).join('\n');
 
@@ -630,6 +650,61 @@ describe('Backtick code block', () => {
       const expected = prism(code, {
         lang: 'js',
         caption: '<span>Hello world</span>'
+      });
+
+      codeBlock(data);
+      data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
+    });
+
+    it('url', () => {
+      const data = {
+        content: [
+          '``` js Hello world https://hexo.io/',
+          code,
+          '```'
+        ].join('\n')
+      };
+
+      const expected = prism(code, {
+        lang: 'js',
+        caption: '<span>Hello world</span><a href="https://hexo.io/">link</a>'
+      });
+
+      codeBlock(data);
+      data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
+    });
+
+    it('link text', () => {
+      const data = {
+        content: [
+          '``` js Hello world https://hexo.io/ Hexo',
+          code,
+          '```'
+        ].join('\n')
+      };
+
+      const expected = prism(code, {
+        lang: 'js',
+        caption: '<span>Hello world</span><a href="https://hexo.io/">Hexo</a>'
+      });
+
+      codeBlock(data);
+      data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
+    });
+
+    it('additional options', () => {
+      const data = {
+        content: [
+          '``` js Hello world https://hexo.io/ Hexo mark:1,2-3',
+          code,
+          '```'
+        ].join('\n')
+      };
+
+      const expected = prism(code, {
+        lang: 'js',
+        caption: '<span>Hello world</span><a href="https://hexo.io/">Hexo</a>',
+        mark: [1, 2, 3]
       });
 
       codeBlock(data);

--- a/test/scripts/filters/backtick_code_block.js
+++ b/test/scripts/filters/backtick_code_block.js
@@ -693,6 +693,8 @@ describe('Backtick code block', () => {
     });
 
     it('additional options', () => {
+      hexo.config.prismjs.preprocess = false;
+
       const data = {
         content: [
           '``` js Hello world https://hexo.io/ Hexo mark:1,2-3',
@@ -704,7 +706,9 @@ describe('Backtick code block', () => {
       const expected = prism(code, {
         lang: 'js',
         caption: '<span>Hello world</span><a href="https://hexo.io/">Hexo</a>',
-        mark: [1, 2, 3]
+        isPreprocess: false,
+        firstLine: 1,
+        mark: '1,2-3'
       });
 
       codeBlock(data);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Support additional options for Backtick Code Block.

## Screenshots

Before:

![Before](https://github.com/hexojs/hexo/assets/8691151/ea053454-cf69-4da8-9e45-3739ff648c7d)

After:

![After](https://github.com/hexojs/hexo/assets/8691151/c7184202-b8f4-4487-8d02-0b2cee3cbdf8)

Source markdown:

![Markdown](https://github.com/hexojs/hexo/assets/8691151/f56b47dc-fea1-4b8b-867d-b4817dcc11fc)


## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.

Issue #4830 

Syntax of Backtick Code Block is:

```
[language] [title] [url] [link text] [additional options]
```

I was going to simply use split spaces to extract it, but the problem is... If do it with this way, then won't be able to use spaces in the title and link text, which is barely ok, but not what I want.

1. the first one [language] is sure there's no spaces
2. the second one [title] might have spaces
3. the third one [url] must be a link
4. the fourth one [link text] might have spaces
5. the fifth one [additional options] must have a colon and probably have spaces

It also would be chaos to matching with regex too, although I did write:

```javascript
/(\w+)\s+(.+?)\s+(?=http)([\S]+)\s+(.+?)\s+((?:\w+:\S+\s*)+)/

.exec('java title https://google.com google mark:1,4-7,10 wrap:true');

[
  'java title https://google.com google mark:1,4-7,10 wrap:true',
  'java',
  'title',
  'https://google.com',
  'google',
  'mark:1,4-7,10 wrap:true',
  index: 0,
  input: 'java title https://google.com google mark:1,4-7,10 wrap:true',
  groups: undefined
]

.exec('python Backtick Code Syntax https://flask.palletsprojects.com/en/2.3.x/ Flask Docs mark:1,5-7 wrap:true')

[
  'python Backtick Code Syntax https://flask.palletsprojects.com/en/2.3.x/ Flask Docs mark:1,5-7 wrap:true',
  'python',
  'Backtick Code Syntax',
  'https://flask.palletsprojects.com/en/2.3.x/',
  'Flask Docs',
  'mark:1,5-7 wrap:true',
  index: 0,
  input: 'python Backtick Code Syntax https://flask.palletsprojects.com/en/2.3.x/ Flask Docs mark:1,5-7 wrap:true',
  groups: undefined
]
```

In the end I decided to use the same code logic as the Code Block Plugin(lib/plugins/tag/code.js), which is simpler and easier to synchronise updates and maintain.
