### PR TITLE
revert: Access data files from source folder (#1969)

### DIFF
--- a/lib/hexo/index.ts
+++ b/lib/hexo/index.ts
@@ -555,7 +555,7 @@ class Hexo extends EventEmitter {
     this.emit('generateBefore');
 
     // Run before_generate filters
-    return this.execFilter('before_generate', this.locals.get('data'), { context: this })
+    return this.execFilter('before_generate', null, { context: this })
       .then(() => this._routerRefresh(this._runGenerators(), useCache)).then(() => {
         this.emit('generateAfter');
 

--- a/lib/plugins/filter/before_generate/render_post.ts
+++ b/lib/plugins/filter/before_generate/render_post.ts
@@ -1,12 +1,11 @@
 import Promise from 'bluebird';
 
-function renderPostFilter(data) {
+function renderPostFilter() {
   const renderPosts = model => {
     const posts = model.toArray().filter(post => post.content == null);
 
     return Promise.map(posts, (post: any) => {
       post.content = post._content;
-      post.site = {data};
 
       return this.post.render(post.full_source, post).then(() => post.save());
     });

--- a/test/scripts/filters/render_post.js
+++ b/test/scripts/filters/render_post.js
@@ -46,20 +46,4 @@ describe('Render post', () => {
     page.remove();
   });
 
-  it('use data variables', async () => {
-    let page = await Page.insert({
-      source: 'foo.md',
-      path: 'foo.html',
-      _content: '<p>Hello {{site.data.foo.name}}</p>'
-    });
-
-    const id = page._id;
-    await renderPost({foo: {name: 'Hexo'}});
-
-    page = Page.findById(id);
-    page.content.trim().should.eql('<p>Hello Hexo</p>');
-
-    page.remove();
-  });
-
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

reverts #1969
fixes https://github.com/hexojs/hexo/issues/5260

Motivation for the modification: I suspect that this feature is rarely used (I noticed it for the first time today). In fact, users can access the 'site' variable through the template engine, without the need for tags within the article.

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
