### PR TITLE
ci(benchmark): add PR permissions for comment

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -3,12 +3,12 @@ name: Benchmark
 on:
   push:
     paths:
-      - 'lib/**'
+      - "lib/**"
   pull_request:
     branches:
       - master
     paths-ignore:
-      - 'test/scripts/**'
+      - "test/scripts/**"
 
 jobs:
   benchmark:
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: ['14', '16', '18']
+        node-version: ["14", "16", "18"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -30,10 +30,12 @@ jobs:
         run: node test/benchmark.js --benchmark
   profiling:
     runs-on: ${{ matrix.os }}
+    permissions:
+      pull-requests: write # for marocchino/sticky-pull-request-comment to create or update PR comment
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: ['14', '16', '18']
+        node-version: ["14", "16", "18"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


## What does it do?

fix #5332

### refs:

- [marocchino/sticky-pull-request-comment#basic](https://github.com/marocchino/sticky-pull-request-comment/blob/main/README.md#basic)

- https://github.com/hexojs/hexo/blob/268882b19a9a8510ce7df7d8a978ba2dd130d7be/.github/workflows/commenter.yml#L11

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
