### PR TITLE
chore(deps): bump hexo-front-matter from 4.0.0 to ^4.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "archy": "^1.0.0",
     "bluebird": "^3.7.2",
     "hexo-cli": "^4.3.0",
-    "hexo-front-matter": "^4.2.0",
+    "hexo-front-matter": "^4.2.1",
     "hexo-fs": "^4.1.1",
     "hexo-i18n": "^2.0.0",
     "hexo-log": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "archy": "^1.0.0",
     "bluebird": "^3.7.2",
     "hexo-cli": "^4.3.0",
-    "hexo-front-matter": "4.0.0",
+    "hexo-front-matter": "^4.2.0",
     "hexo-fs": "^4.1.1",
     "hexo-i18n": "^2.0.0",
     "hexo-log": "^4.0.1",


### PR DESCRIPTION
>The former one should be fixed in https://github.com/hexojs/hexo-front-matter/pull/67, but since `hexo-front-matter` hasn't released a new version to include this change yet, we should still stick to v4.0.0 here to prevent type error.

_Originally posted by @Pcrab in https://github.com/hexojs/hexo/issues/5202#issuecomment-1544052137_

## What does it do?

bump hexo-front-matter from 4.0.0 to ^4.2.0

## Require

dont merge this PR before:

- [x] publish hexo-front-matter@4.2.0 (hexojs/hexo-front-matter#129)
- [x] #5271



