### PR TITLE
fix(types): cast from `number` to `string` explicitly

### DIFF
--- a/lib/hexo/multi_config_path.ts
+++ b/lib/hexo/multi_config_path.ts
@@ -62,7 +62,7 @@ export = (ctx: Hexo) => function multiConfigPath(base: string, configPaths: stri
     return defaultPath;
   }
 
-  log.i('Config based on', count, 'files');
+  log.i('Config based on', count.toString(), 'files');
 
   const multiconfigRoot = outputDir || base;
   const outputPath = join(multiconfigRoot, '_multiconfig.yml');

--- a/lib/plugins/console/generate.ts
+++ b/lib/plugins/console/generate.ts
@@ -169,7 +169,7 @@ class Generater {
       const interval = prettyHrtime(process.hrtime(this.start));
       const count = result.filter(Boolean).length;
 
-      log.info('%d files generated in %s', count, cyan(interval));
+      log.info('%d files generated in %s', count.toString(), cyan(interval));
     });
   }
   execWatch(): Promise<void> {


### PR DESCRIPTION

## What does it do?

fix `TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.` error. I ignore them with `@ts-ignore` when I published `v7.0.0`.

```
$ npm run build

> hexo@7.0.0 build
> tsc -b

lib/hexo/multi_config_path.ts:65:28 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

65   log.i('Config based on', count, 'files');
                              ~~~~~

lib/plugins/console/generate.ts:172:44 - error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.

172       log.info('%d files generated in %s', count, cyan(interval));
                                               ~~~~~
Found 2 errors.
```

## Screenshots

N/A

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
