### PR TITLE
Added URL hash support for post_link tag

### DIFF
--- a/lib/plugins/tag/post_link.ts
+++ b/lib/plugins/tag/post_link.ts
@@ -10,9 +10,17 @@ import type Hexo from '../../hexo';
  */
 export = (ctx: Hexo) => {
   return function postLinkTag(args: string[]) {
-    const slug = args.shift();
+    let slug = args.shift();
     if (!slug) {
       throw new Error(`Post not found: "${slug}" doesn't exist for {% post_link %}`);
+    }
+
+    let hash = '';
+    const parts = slug.split('#');
+
+    if (parts.length === 2) {
+      slug = parts[0];
+      hash = parts[1];
     }
 
     let escape = args[args.length - 1];
@@ -33,7 +41,8 @@ export = (ctx: Hexo) => {
     const attrTitle = escapeHTML(post.title || post.slug);
     if (escape === 'true') title = escapeHTML(title);
 
-    const link = encodeURL(new URL(post.path, ctx.config.url).pathname);
+    const url = new URL(post.path, ctx.config.url).pathname + (hash ? `#${hash}` : '');
+    const link = encodeURL(url);
 
     return `<a href="${link}" title="${attrTitle}">${title}</a>`;
   };

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -73,4 +73,8 @@ describe('post_link', () => {
   it('should throw if post not found', () => {
     should.throw(() => postLink(['bar']), Error, /Post not found: post_link bar\./);
   });
+
+  it('should keep hash', () => {
+    postLink(['foo#bar']).should.eql('<a href="/foo/#bar" title="Hello world">Hello world</a>');
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too. 
-->

## What does it do?

Supports using `post_link` tag with urls containing hashes. For example `{% post_link my-post-slug#my-hash 'My Linked Post Title' %}`.

This PR solves this issue https://github.com/hexojs/hexo/issues/5333

## Screenshots
--


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
