### PR TITLE
fix(escapeAllSwigTags): check tag completeness

### DIFF
--- a/lib/hexo/post.ts
+++ b/lib/hexo/post.ts
@@ -67,6 +67,9 @@ class PostRenderEscape {
    * @returns string
    */
   escapeAllSwigTags(str: string) {
+    if (!/(\{\{.+?\}\})|(\{#.+?#\})|(\{%.+?%\})/.test(str)) {
+      return str;
+    }
     let state = STATE_PLAINTEXT;
     let buffer = '';
     let output = '';
@@ -85,13 +88,13 @@ class PostRenderEscape {
       if (state === STATE_PLAINTEXT) { // From plain text to swig
         if (char === '{') {
           // check if it is a complete tag {{ }}
-          if (next_char === '{' && /\{\{.+?\}\}/.test(str)) {
+          if (next_char === '{') {
             state = STATE_SWIG_VAR;
             idx++;
-          } else if (next_char === '#' && /\{#.+?#\}/.test(str)) {
+          } else if (next_char === '#') {
             state = STATE_SWIG_COMMENT;
             idx++;
-          } else if (next_char === '%' && /\{%.+?%\}/.test(str)) {
+          } else if (next_char === '%') {
             state = STATE_SWIG_TAG;
             idx++;
             swig_tag_name = '';

--- a/lib/hexo/post.ts
+++ b/lib/hexo/post.ts
@@ -84,13 +84,14 @@ class PostRenderEscape {
 
       if (state === STATE_PLAINTEXT) { // From plain text to swig
         if (char === '{') {
-          if (next_char === '{') {
+          // check if it is a complete tag {{ }}
+          if (next_char === '{' && /\{\{.+?\}\}/.test(str)) {
             state = STATE_SWIG_VAR;
             idx++;
-          } else if (next_char === '#') {
+          } else if (next_char === '#' && /\{#.+?#\}/.test(str)) {
             state = STATE_SWIG_COMMENT;
             idx++;
-          } else if (next_char === '%') {
+          } else if (next_char === '%' && /\{%.+?%\}/.test(str)) {
             state = STATE_SWIG_TAG;
             idx++;
             swig_tag_name = '';

--- a/test/scripts/hexo/post.js
+++ b/test/scripts/hexo/post.js
@@ -12,7 +12,7 @@ const escapeSwigTag = str => str.replace(/{/g, '&#123;').replace(/}/g, '&#125;')
 describe('Post', () => {
   const Hexo = require('../../../dist/hexo');
   const hexo = new Hexo(join(__dirname, 'post_test'));
-  require('../../../lib/plugins/highlight/')(hexo);
+  require('../../../dist/plugins/highlight/')(hexo);
   const { post } = hexo;
   const now = Date.now();
   let clock;
@@ -1368,5 +1368,32 @@ describe('Post', () => {
     data.content.should.include(escapeSwigTag('{% %}'));
 
     hexo.config.syntax_highlighter = 'highlight.js';
+  });
+
+  // https://github.com/hexojs/hexo/issues/5301
+  it('render() - dont escape uncomplete tags', async () => {
+    const content = 'dont drop `{% }` 11111 `{# }` 22222 `{{ }` 33333';
+
+    const data = await post.render(null, {
+      content,
+      engine: 'markdown'
+    });
+
+    data.content.should.contains('11111');
+    data.content.should.contains('22222');
+    data.content.should.contains('33333');
+    data.content.should.not.contains('&#96;'); // `
+  });
+
+  it('render() - uncomplete tags throw error', async () => {
+    const content = 'nunjucks should thorw {#  } error';
+
+    try {
+      await post.render(null, {
+        content,
+        engine: 'markdown'
+      });
+      should.fail();
+    } catch (err) {}
   });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

fix #5301
fix https://github.com/hexojs/hexo-renderer-pandoc/issues/60

Before escape tags, check if it contains a complete tag.
In others words, just escape complete tags.


## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
