### PR TITLE
chore: use `prepublishOnly` instead of `prepublish` and run `npm install` in `prepublishOnly` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "hexo": "./bin/hexo"
   },
   "scripts": {
-    "prepublish ": "npm run clean && npm run build",
+    "prepublishOnly": "npm install && npm run clean && npm run build",
     "build": "tsc -b",
     "clean": "tsc -b --clean",
     "eslint": "eslint lib test",


### PR DESCRIPTION
## What does it do?

`prepublish` has been [deprecated](https://docs.npmjs.com/cli/v9/using-npm/scripts#life-cycle-scripts).

## Screenshots

N/A

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.

-----

Thanks :)