### PR TITLE
fix: post_link behaviour when using subdir

### DIFF
--- a/lib/plugins/tag/post_link.ts
+++ b/lib/plugins/tag/post_link.ts
@@ -40,7 +40,7 @@ export = (ctx: Hexo) => {
     // Let attribute be the true post title so it appears in tooltip.
     const attrTitle = escapeHTML(post.title || post.slug);
     if (escape === 'true') title = escapeHTML(title);
-   
+
     // guarantee the base url ends with a slash. (case of using a subdirectory in the url of the site)
     let baseUrl = ctx.config.url;
     if (!baseUrl.endsWith('/')) {

--- a/lib/plugins/tag/post_link.ts
+++ b/lib/plugins/tag/post_link.ts
@@ -41,7 +41,7 @@ export = (ctx: Hexo) => {
     const attrTitle = escapeHTML(post.title || post.slug);
     if (escape === 'true') title = escapeHTML(title);
     
-    // guarantee the base url ends with a slash (case of using a subdirectory in the url of the site)
+    // guarantee the base url ends with a slash. (case of using a subdirectory in the url of the site)
     let baseUrl = ctx.config.url;
     if (!baseUrl.endsWith('/')) {
       baseUrl += '/';

--- a/lib/plugins/tag/post_link.ts
+++ b/lib/plugins/tag/post_link.ts
@@ -40,7 +40,7 @@ export = (ctx: Hexo) => {
     // Let attribute be the true post title so it appears in tooltip.
     const attrTitle = escapeHTML(post.title || post.slug);
     if (escape === 'true') title = escapeHTML(title);
-    
+   
     // guarantee the base url ends with a slash. (case of using a subdirectory in the url of the site)
     let baseUrl = ctx.config.url;
     if (!baseUrl.endsWith('/')) {

--- a/lib/plugins/tag/post_link.ts
+++ b/lib/plugins/tag/post_link.ts
@@ -40,8 +40,14 @@ export = (ctx: Hexo) => {
     // Let attribute be the true post title so it appears in tooltip.
     const attrTitle = escapeHTML(post.title || post.slug);
     if (escape === 'true') title = escapeHTML(title);
+    
+    // guarantee the base url ends with a slash (case of using a subdirectory in the url of the site)
+    let baseUrl = ctx.config.url;
+    if (!baseUrl.endsWith('/')) {
+      baseUrl += '/';
+    }
 
-    const url = new URL(post.path, ctx.config.url).pathname + (hash ? `#${hash}` : '');
+    const url = new URL(post.path, baseUrl).pathname + (hash ? `#${hash}` : '');
     const link = encodeURL(url);
 
     return `<a href="${link}" title="${attrTitle}">${title}</a>`;

--- a/test/scripts/tags/post_link.js
+++ b/test/scripts/tags/post_link.js
@@ -77,4 +77,9 @@ describe('post_link', () => {
   it('should keep hash', () => {
     postLink(['foo#bar']).should.eql('<a href="/foo/#bar" title="Hello world">Hello world</a>');
   });
+
+  it('should keep subdir', () => {
+    hexo.config.url = 'http://example.com/subdir';
+    postLink(['foo']).should.eql('<a href="/subdir/foo/" title="Hello world">Hello world</a>');
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

When subdir is used, the generated URL ignores it, creating an incorrect link. If the value of config.url does not end with '/', this was added to create a correct link.

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
