### PR TITLE
chore: make callback on exit optional

### DIFF
--- a/lib/hexo/index.ts
+++ b/lib/hexo/index.ts
@@ -660,7 +660,7 @@ class Hexo extends EventEmitter {
       });
   }
 
-  exit(err: Error): Promise<void> {
+  exit(err?: Error): Promise<void> {
     if (err) {
       this.log.fatal(
         { err },


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

based on https://hexo.io/api/index.html#Exit method `hexo.exit()` is not always has callback function, make it optional for better typing with typescript

## Screenshots

![image](https://github.com/hexojs/hexo/assets/12471057/dc0bbce7-3ee1-4671-9b1e-e11136eb6543)

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
