### PR TITLE
refactor: backslashes on Windows

### DIFF
--- a/lib/plugins/processor/asset.ts
+++ b/lib/plugins/processor/asset.ts
@@ -109,7 +109,7 @@ function processPage(ctx: Hexo, file: _File) {
 }
 
 function processAsset(ctx: Hexo, file: _File) {
-  const id = relative(ctx.base_dir, file.source).replace(/\\/g, '/');
+  const id = relative(ctx.base_dir, file.source);
   const Asset = ctx.model('Asset');
   const doc = Asset.findById(id);
 

--- a/lib/plugins/processor/post.ts
+++ b/lib/plugins/processor/post.ts
@@ -233,7 +233,7 @@ function scanAssetDir(ctx: Hexo, post) {
     if (err && err.code === 'ENOENT') return [];
     throw err;
   }).filter(item => !isExcludedFile(item, ctx.config)).map(item => {
-    const id = join(assetDir, item).substring(baseDirLength).replace(/\\/g, '/');
+    const id = join(assetDir, item).substring(baseDirLength);
     const renderablePath = id.substring(sourceDirLength + 1);
     const asset = PostAsset.findById(id);
 
@@ -267,7 +267,7 @@ function shouldSkipAsset(ctx: Hexo, post, asset) {
 function processAsset(ctx: Hexo, file: _File) {
   const PostAsset = ctx.model('PostAsset');
   const Post = ctx.model('Post');
-  const id = file.source.substring(ctx.base_dir.length).replace(/\\/g, '/');
+  const id = file.source.substring(ctx.base_dir.length);
   const doc = PostAsset.findById(id);
 
   if (file.type === 'delete') {

--- a/lib/theme/processors/source.ts
+++ b/lib/theme/processors/source.ts
@@ -4,7 +4,7 @@ import type { _File } from '../../box';
 
 function process(file: _File) {
   const Asset = this.model('Asset');
-  const id = file.source.substring(this.base_dir.length).replace(/\\/g, '/');
+  const id = file.source.substring(this.base_dir.length);
   const { path } = file.params;
   const doc = Asset.findById(id);
 

--- a/test/scripts/box/box.ts
+++ b/test/scripts/box/box.ts
@@ -120,7 +120,7 @@ describe('Box', () => {
     const box = newBox('test');
     const name = 'a.txt';
     const path = join(box.base, name);
-    const cacheId = 'test/' + name;
+    const cacheId = join('test/', name);
 
     const processor = spy();
     box.addProcessor(processor);
@@ -144,7 +144,7 @@ describe('Box', () => {
     const box = newBox('test');
     const name = 'a.txt';
     const path = join(box.base, name);
-    const cacheId = 'test/' + name;
+    const cacheId = join('test/', name);
 
     const processor = spy();
     box.addProcessor(processor);
@@ -167,7 +167,7 @@ describe('Box', () => {
     const box = newBox('test');
     const name = 'a.txt';
     const path = join(box.base, name);
-    const cacheId = 'test/' + name;
+    const cacheId = join('test/', name);
 
     const processor = spy();
     box.addProcessor(processor);
@@ -190,7 +190,7 @@ describe('Box', () => {
     const box = newBox('test');
     const name = 'a.txt';
     const path = join(box.base, name);
-    const cacheId = 'test/' + name;
+    const cacheId = join('test/', name);
 
     const processor = spy();
     box.addProcessor(processor);
@@ -211,7 +211,8 @@ describe('Box', () => {
 
   it('process() - delete', async () => {
     const box = newBox('test');
-    const cacheId = 'test/a.txt';
+    // join will replace backslashes on Windows
+    const cacheId = join('test/', 'a.txt');
 
     const processor = spy();
     box.addProcessor(processor);

--- a/test/scripts/processors/asset.ts
+++ b/test/scripts/processors/asset.ts
@@ -80,7 +80,7 @@ describe('asset', () => {
 
     await writeFile(file.source, 'foo');
     await process(file);
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
     const asset = Asset.findById(id);
 
     asset._id.should.eql(id);
@@ -103,7 +103,7 @@ describe('asset', () => {
 
     await writeFile(file.source, 'foo');
     await process(file);
-    const id = '../source/foo.jpg'; // The id should a relative path,because the 'lib/models/assets.js' use asset path by joining base path with "_id" directly.
+    const id = join('../source/', 'foo.jpg'); // The id should a relative path, because the 'lib/models/assets.js' use asset path by joining base path with "_id" directly.
     const asset = Asset.findById(id);
     asset._id.should.eql(id);
     asset.path.should.eql(file.path);
@@ -122,7 +122,7 @@ describe('asset', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     await Promise.all([
       writeFile(file.source, 'test'),
@@ -153,7 +153,7 @@ describe('asset', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     await Promise.all([
       writeFile(file.source, 'test'),
@@ -179,7 +179,7 @@ describe('asset', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     await Asset.insert({
       _id: id,
@@ -197,7 +197,7 @@ describe('asset', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
     await process(file);
 
     should.not.exist(Asset.findById(id));

--- a/test/scripts/processors/post.ts
+++ b/test/scripts/processors/post.ts
@@ -118,7 +118,7 @@ describe('post', () => {
     });
 
     await process(file);
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
     should.not.exist(PostAsset.findById(id));
   });
 
@@ -141,7 +141,7 @@ describe('post', () => {
     const postId = doc._id;
     await process(file);
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
     const asset = PostAsset.findById(id);
 
     asset._id.should.eql(id);
@@ -165,7 +165,7 @@ describe('post', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     const post = await Post.insert({
       source: '_posts/foo.html',
@@ -200,7 +200,7 @@ describe('post', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     const post = await Post.insert({
       source: '_posts/foo.html',
@@ -235,7 +235,7 @@ describe('post', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     const post = await Post.insert({
       source: '_posts/foo.html',
@@ -265,7 +265,7 @@ describe('post', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     const post = await Post.insert({
       source: '_posts/foo.html',
@@ -290,7 +290,7 @@ describe('post', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     await writeFile(file.source, 'test');
     await process(file);
@@ -309,7 +309,7 @@ describe('post', () => {
       renderable: false
     });
 
-    const id = 'source/' + file.path;
+    const id = join('source/', file.path);
 
     await Promise.all([
       writeFile(file.source, 'test'),
@@ -966,7 +966,7 @@ describe('post', () => {
       '_fizz.jpg',
       '_buzz.jpg'
     ].map(filename => {
-      const id = `source/_posts/foo/${filename}`;
+      const id = join('source/_posts/foo/', filename);
       const path = join(hexo.base_dir, id);
       const contents = filename.replace(/\.\w+$/, '');
       return {
@@ -1022,7 +1022,8 @@ describe('post', () => {
       renderable: true
     });
 
-    const assetId = 'source/_posts/foo/bar.jpg';
+    // join will replace backslashes on Windows
+    const assetId = join('source/_posts/foo/', 'bar.jpg');
     const assetPath = join(hexo.base_dir, assetId);
 
     await Promise.all([
@@ -1068,7 +1069,8 @@ describe('post', () => {
       renderable: true
     });
 
-    const assetId = 'source/_posts/foo/bar.jpg';
+    // join will replace backslashes on Windows
+    const assetId = join('source/_posts/foo/', 'bar.jpg');
     const assetPath = join(hexo.base_dir, assetId);
 
     await Promise.all([
@@ -1106,7 +1108,8 @@ describe('post', () => {
       renderable: true
     });
 
-    const assetId = 'source/_posts/foo/bar.jpg';
+    // join will replace backslashes on Windows
+    const assetId = join('source/_posts/foo/', 'bar.jpg');
     const assetPath = join(hexo.base_dir, assetId);
 
     await Promise.all([
@@ -1283,7 +1286,7 @@ describe('post', () => {
       writeFile(assetFile.source, 'test')
     ]);
     await process(file);
-    const id = 'source/' + assetFile.path;
+    const id = join('source/', assetFile.path);
     const post = Post.findOne({ source: file.path });
     PostAsset.findById(id).renderable.should.be.true;
 
@@ -1319,7 +1322,7 @@ describe('post', () => {
       writeFile(assetFile.source, 'test')
     ]);
     await process(file);
-    const id = 'source/' + assetFile.path;
+    const id = join('source/', assetFile.path);
     const post = Post.findOne({ source: file.path });
     PostAsset.findById(id).renderable.should.be.false;
 

--- a/test/scripts/theme_processors/source.ts
+++ b/test/scripts/theme_processors/source.ts
@@ -56,7 +56,7 @@ describe('source', () => {
       type: 'create'
     });
 
-    const id = 'themes/test/' + file.path;
+    const id = join('themes/test/', file.path);
 
     await writeFile(file.source, 'test');
     await process(file);
@@ -77,7 +77,7 @@ describe('source', () => {
       type: 'update'
     });
 
-    const id = 'themes/test/' + file.path;
+    const id = join('themes/test/', file.path);
 
     await Promise.all([
       writeFile(file.source, 'test'),
@@ -104,7 +104,7 @@ describe('source', () => {
       type: 'skip'
     });
 
-    const id = 'themes/test/' + file.path;
+    const id = join('themes/test/', file.path);
 
     await Promise.all([
       writeFile(file.source, 'test'),
@@ -130,7 +130,7 @@ describe('source', () => {
       type: 'delete'
     });
 
-    const id = 'themes/test/' + file.path;
+    const id = join('themes/test/', file.path);
 
     await Asset.insert({
       _id: id,
@@ -146,7 +146,7 @@ describe('source', () => {
       type: 'delete'
     });
 
-    const id = 'themes/test/' + file.path;
+    const id = join('themes/test/', file.path);
 
     await process(file);
     should.not.exist(Asset.findById(id));


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

I have noticed that currently on Windows, paths in Hexo are converted frequently. For example, when adding files to the `ctx.model('Cache')` database, the path separators `\` are replaced with `/`, and later when Assets use these paths, the `join` function is called, which on Windows, will replace `/` back with `\`. This pull request aims to standardize the separator in the cache's `_id` to match the current operating system's support and to avoid using hardcoded separators (using `path.sep` instead). It will not change existing functionalities but is intended to improve the uniformity and maintainability of the code.

~~WIP: pending https://github.com/hexojs/hexo/pull/5385~~

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
