### PR TITLE
feat: add option to use slug as title of post

### DIFF
--- a/lib/hexo/default_config.ts
+++ b/lib/hexo/default_config.ts
@@ -58,6 +58,8 @@ export = {
     exclude_languages: [],
     strip_indent: true
   },
+  use_filename_as_post_title: false,
+
   // Category & Tag
   default_category: 'uncategorized',
   category_map: {},

--- a/lib/plugins/processor/post.ts
+++ b/lib/plugins/processor/post.ts
@@ -70,8 +70,8 @@ function processPost(ctx: Hexo, file: _File) {
   const { path } = file.params;
   const doc = Post.findOne({source: file.path});
   const { config } = ctx;
-  const { timezone: timezoneCfg } = config;
-  const updated_option = config.updated_option;
+  const { timezone: timezoneCfg, updated_option, use_filename_as_post_title } = config;
+
   let categories, tags;
 
   if (file.type === 'skip' && doc) {
@@ -107,6 +107,12 @@ function processPost(ctx: Hexo, file: _File) {
     for (let i = 0, len = keys.length; i < len; i++) {
       const key = keys[i];
       if (!preservedKeys[key]) data[key] = info[key];
+    }
+
+    // use `slug` as `title` of post when `title` is not specified.
+    // https://github.com/hexojs/hexo/issues/5372
+    if (use_filename_as_post_title && !Object.keys(data).includes('title')) {
+      data.title = info.title;
     }
 
     if (data.date) {

--- a/lib/plugins/processor/post.ts
+++ b/lib/plugins/processor/post.ts
@@ -70,7 +70,7 @@ function processPost(ctx: Hexo, file: _File) {
   const { path } = file.params;
   const doc = Post.findOne({source: file.path});
   const { config } = ctx;
-  const { timezone: timezoneCfg, updated_option, use_filename_as_post_title } = config;
+  const { timezone: timezoneCfg, updated_option, use_slug_as_post_title } = config;
 
   let categories, tags;
 
@@ -111,7 +111,7 @@ function processPost(ctx: Hexo, file: _File) {
 
     // use `slug` as `title` of post when `title` is not specified.
     // https://github.com/hexojs/hexo/issues/5372
-    if (use_filename_as_post_title && !('title' in data)) {
+    if (use_slug_as_post_title && !('title' in data)) {
       data.title = info.title;
     }
 

--- a/lib/plugins/processor/post.ts
+++ b/lib/plugins/processor/post.ts
@@ -111,7 +111,7 @@ function processPost(ctx: Hexo, file: _File) {
 
     // use `slug` as `title` of post when `title` is not specified.
     // https://github.com/hexojs/hexo/issues/5372
-    if (use_filename_as_post_title && !Object.keys(data).includes('title')) {
+    if (use_filename_as_post_title && !('title' in data)) {
       data.title = info.title;
     }
 

--- a/test/scripts/processors/post.ts
+++ b/test/scripts/processors/post.ts
@@ -808,7 +808,7 @@ describe('post', () => {
   // use `slug` as `title` of post when `title` is not specified.
   // https://github.com/hexojs/hexo/issues/5372
   it('post - without title - use filename', async () => {
-    hexo.config.use_filename_as_post_title = true;
+    hexo.config.use_slug_as_post_title = true;
 
     const body = '';
 

--- a/test/scripts/processors/post.ts
+++ b/test/scripts/processors/post.ts
@@ -805,6 +805,32 @@ describe('post', () => {
     ]);
   });
 
+  // use `slug` as `title` of post when `title` is not specified.
+  // https://github.com/hexojs/hexo/issues/5372
+  it('post - without title - use filename', async () => {
+    hexo.config.use_filename_as_post_title = true;
+
+    const body = '';
+
+    const file = newFile({
+      path: 'bar.md',
+      published: true,
+      type: 'create',
+      renderable: true
+    });
+
+    await writeFile(file.source, body);
+    await process(file);
+    const post = Post.findOne({ source: file.path });
+
+    post.title.should.eql('bar');
+
+    return Promise.all([
+      post.remove(),
+      unlink(file.source)
+    ]);
+  });
+
   it('post - category is an alias for categories', async () => {
     const body = [
       'title: "Hello world"',


### PR DESCRIPTION

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

use `slug` as `title` of post when `title` is not specified.

closed #5372

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
- [ ] add to [configuration](https://hexo.io/docs/configuration.html#Writing)
