### PR TITLE
WIP: Allow `publish` handle files with filenames separated by spaces

### DIFF
--- a/lib/hexo/post.ts
+++ b/lib/hexo/post.ts
@@ -348,8 +348,7 @@ class Post {
     const { config } = ctx;
     const draftDir = join(ctx.source_dir, '_drafts');
     const slug = slugize(data.slug.toString(), { transform: config.filename_case });
-    data.slug = slug;
-    const regex = new RegExp(`^${escapeRegExp(slug)}(?:[^\\/\\\\]+)`);
+    const regex = new RegExp(`^${escapeRegExp(data.slug.toString())}(?:[^\\/\\\\]+)`);
     let src = '';
     const result: Result = {};
 

--- a/lib/plugins/processor/post.ts
+++ b/lib/plugins/processor/post.ts
@@ -1,13 +1,14 @@
 import { toDate, timezone, isExcludedFile, isTmpFile, isHiddenFile, isMatch } from './common';
 import Promise from 'bluebird';
 import { parse as yfm } from 'hexo-front-matter';
-import { extname, join } from 'path';
+import { extname, join, posix, sep } from 'path';
 import { stat, listDir } from 'hexo-fs';
 import { slugize, Pattern, Permalink } from 'hexo-util';
 import { magenta } from 'picocolors';
 import type { _File } from '../../box';
 import type Hexo from '../../hexo';
 import type { Stats } from 'fs';
+import { PostSchema } from '../../types';
 
 const postDir = '_posts/';
 const draftDir = '_drafts/';
@@ -268,19 +269,16 @@ function processAsset(ctx: Hexo, file: _File) {
   const PostAsset = ctx.model('PostAsset');
   const Post = ctx.model('Post');
   const id = file.source.substring(ctx.base_dir.length);
-  const doc = PostAsset.findById(id);
+  const postAsset = PostAsset.findById(id);
 
-  if (file.type === 'delete') {
-    if (doc) {
-      return doc.remove();
+  if (file.type === 'delete' || Post.length === 0) {
+    if (postAsset) {
+      return postAsset.remove();
     }
-
     return;
   }
 
-  // TODO: Better post searching
-  const post = Post.toArray().find(post => file.source.startsWith(post.asset_dir));
-  if (post != null && (post.published || ctx._showDrafts())) {
+  const savePostAsset = (post: PostSchema) => {
     return PostAsset.save({
       _id: id,
       slug: file.source.substring(post.asset_dir.length),
@@ -288,9 +286,24 @@ function processAsset(ctx: Hexo, file: _File) {
       modified: file.type !== 'skip',
       renderable: file.params.renderable
     });
+  };
+
+  if (postAsset) {
+    // `postAsset.post` is `Post.id`.
+    const post = Post.findById(postAsset.post);
+    if (post != null && (post.published || ctx._showDrafts())) {
+      return savePostAsset(post);
+    }
   }
 
-  if (doc) {
-    return doc.remove();
+  const assetDir = id.slice(0, id.lastIndexOf(sep));
+  const post = Post.findOne(p => p.asset_dir.endsWith(posix.join(assetDir, '/')));
+  if (post != null && (post.published || ctx._showDrafts())) {
+    return savePostAsset(post);
+  }
+
+  // NOTE: Probably, unreachable.
+  if (postAsset) {
+    return postAsset.remove();
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "eslint": "eslint lib test",
     "pretest": "npm run clean && npm run build",
     "test": "mocha test/scripts/**/*.ts --require ts-node/register",
+    "yapinTest": "mocha --file test/scripts/hexo/post.ts --grep \"yapinxxx test\" --require ts-node/register --timeout 10000",
     "test-cov": "c8 --reporter=lcovonly npm test -- --no-parallel",
     "prepare": "husky install"
   },
@@ -66,7 +67,6 @@
     "warehouse": "^5.0.1"
   },
   "devDependencies": {
-    "0x": "^5.1.2",
     "@types/abbrev": "^1.1.3",
     "@types/bluebird": "^3.5.37",
     "@types/chai": "^4.3.11",
@@ -77,6 +77,7 @@
     "@types/rewire": "^2.5.30",
     "@types/sinon": "^17.0.3",
     "@types/text-table": "^0.2.4",
+    "0x": "^5.1.2",
     "c8": "^9.0.0",
     "chai": "^4.3.6",
     "cheerio": "0.22.0",
@@ -84,9 +85,9 @@
     "eslint": "^8.48.0",
     "eslint-config-hexo": "^5.0.0",
     "hexo-renderer-marked": "^6.0.0",
-    "husky": "^8.0.1",
+    "husky": "^8.0.3",
     "lint-staged": "^15.2.0",
-    "mocha": "^10.0.0",
+    "mocha": "^10.4.0",
     "rewire": "^7.0.0",
     "sinon": "^17.0.1",
     "ts-node": "^10.9.1",

--- a/test/scripts/hexo/post.ts
+++ b/test/scripts/hexo/post.ts
@@ -650,6 +650,86 @@ describe('Post', () => {
     await unlink(data.path);
   });
 
+  // #5476 - yapinxxx
+  // it('publish() - filenames separated by spaces', async () => {
+  it('yapinxxx test', async () => {
+
+    const assetDir = join(hexo.source_dir, '_drafts');
+    const assetSpaceDir = join(assetDir, 'space file');
+    const assetSpace1Dir = join(assetDir, 'space file test1');
+    const assetSpace2Dir = join(assetDir, 'space file test2');
+    const assetSpace3Dir = join(assetDir, 'space file test 3');
+    const assetSpace4Dir = join(assetDir, 'space file test 4');
+
+
+    console.log(assetSpace1Dir, '####space 1 dir');
+    console.log(assetSpace3Dir, '####space 3 dir');
+    console.log(assetSpace4Dir, '####space 4 dir');
+
+    const newAssetDir = join(hexo.source_dir, '_posts');
+    const date = moment(now);
+    hexo.config.post_asset_folder = true;
+
+    const write_content = 'This is Hello World with Space';
+    const template = [
+      '---',
+      'title: Hello World',
+      'date: ' + date.format('YYYY-MM-DD HH:mm:ss'),
+      'tags:',
+      '---'
+    ].join('\n') + '\n';
+
+    const content = [template, write_content].join('\n');
+
+    // Put some files into the asset folder
+    await Promise.all([
+      writeFile(join(assetDir, 'space file.txt'), write_content),
+      writeFile(join(assetDir, 'space file test 0.txt'), write_content),
+      writeFile(join(assetDir, 'space file test 1.txt'), write_content),
+      writeFile(join(assetDir, 'space file test2.txt'), write_content),
+      writeFile(join(assetDir, 'space file test 3.txt'), write_content),
+
+      writeFile(join(assetSpaceDir, 'space file.txt'), write_content),
+
+      writeFile(join(assetSpace1Dir, 'space file10.txt'), write_content),
+      writeFile(join(assetSpace1Dir, 'space file test11.txt'), write_content),
+      writeFile(join(assetSpace1Dir, 'space file test12.txt'), write_content),
+      writeFile(join(assetSpace1Dir, 'space file test 13.txt'), write_content),
+
+
+      writeFile(join(assetSpace2Dir, 'space file20.txt'), write_content),
+
+      writeFile(join(assetSpace3Dir, 'space file30.txt'), write_content),
+      writeFile(join(assetSpace3Dir, 'space file test31.txt'), write_content),
+      writeFile(join(assetSpace3Dir, 'space file test32.txt'), write_content),
+      writeFile(join(assetSpace3Dir, 'space file test 33.txt'), write_content),
+
+      writeFile(join(assetSpace4Dir, 'space file.txt'), write_content),
+      writeFile(join(assetSpace4Dir, 'space file test41.txt'), write_content),
+      writeFile(join(assetSpace4Dir, 'space file test42.txt'), write_content),
+      writeFile(join(assetSpace4Dir, 'space file test 43.txt'), write_content)
+    ]);
+
+    const result = await post.publish({
+      slug: 'space file test',
+      title: 'Hello World'
+    });
+
+    listDir(assetDir).then(list => {
+      console.log(list, 'show all files asset ####');
+    });
+
+    listDir(newAssetDir).then(list => {
+      console.log(list, 'show all files new asset ####');
+    });
+
+    // result.path.should.eql(join(newAssetDir, 'space-file-test.md'));
+    // result.content.should.eql(content);
+
+    await unlink(result.path);
+  });
+
+
   it('render()', async () => {
     // TODO: validate data
     const beforeHook = spy();


### PR DESCRIPTION
Allow the publish command to handle files with filenames separated by spaces in the _draft folder.

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The update enables filenames to include spaces in the `_draft` folder. 
However, the source code modifies the original filename(`data.slug`) and then incorrectly compares it with the filenames in the `_draft` folder, leading to erroneous results.

