### PR TITLE
feat(helper/toc): specify maximum number of items to output

### DIFF
--- a/lib/plugins/helper/toc.ts
+++ b/lib/plugins/helper/toc.ts
@@ -110,7 +110,7 @@ function getAndTruncateTocObj(str: string, options: {min_depth: number, max_dept
   if (data.length === 0) {
     return data;
   }
-  if (max_items < 1) {
+  if (max_items < 1 || max_items === Infinity) {
     return data;
   }
 

--- a/lib/plugins/helper/toc.ts
+++ b/lib/plugins/helper/toc.ts
@@ -114,8 +114,9 @@ function getAndTruncateTocObj(str: string, options: {min_depth: number, max_dept
     return data;
   }
 
-  const min = Math.min(...data.map(item => item.level));
-  const max = Math.max(...data.map(item => item.level));
+  const levels = data.map(item => item.level);
+  const min = Math.min(...levels);
+  const max = Math.max(...levels);
 
   for (let currentLevel = max; data.length > max_items && currentLevel > min; currentLevel--) {
     data = data.filter(item => item.level < currentLevel);

--- a/lib/plugins/helper/toc.ts
+++ b/lib/plugins/helper/toc.ts
@@ -3,6 +3,7 @@ import { tocObj, escapeHTML, encodeURL } from 'hexo-util';
 interface Options {
   min_depth?: number;
   max_depth?: number;
+  max_items?: number;
   class?: string;
   class_item?: string;
   class_link?: string;
@@ -17,6 +18,7 @@ function tocHelper(str: string, options: Options = {}) {
   options = Object.assign({
     min_depth: 1,
     max_depth: 6,
+    max_items: Infinity,
     class: 'toc',
     class_item: '',
     class_link: '',
@@ -27,7 +29,7 @@ function tocHelper(str: string, options: Options = {}) {
     list_number: true
   }, options);
 
-  const data = tocObj(str, { min_depth: options.min_depth, max_depth: options.max_depth });
+  const data = getAndTruncateTocObj(str, { min_depth: options.min_depth, max_depth: options.max_depth }, options.max_items);
 
   if (!data.length) return '';
 
@@ -100,6 +102,28 @@ function tocHelper(str: string, options: Options = {}) {
   }
 
   return result;
+}
+
+function getAndTruncateTocObj(str: string, options: {min_depth: number, max_depth: number}, max_items: number) {
+  let data = tocObj(str, { min_depth: options.min_depth, max_depth: options.max_depth });
+
+  if (data.length === 0) {
+    return data;
+  }
+  if (max_items < 1) {
+    return data;
+  }
+
+  const min = Math.min(...data.map(item => item.level));
+  const max = Math.max(...data.map(item => item.level));
+
+  for (let currentLevel = max; data.length > max_items && currentLevel > min; currentLevel--) {
+    data = data.filter(item => item.level < currentLevel);
+  }
+
+  data = data.slice(0, max_items);
+
+  return data;
 }
 
 export = tocHelper;

--- a/test/scripts/helpers/toc.ts
+++ b/test/scripts/helpers/toc.ts
@@ -552,4 +552,140 @@ describe('toc', () => {
 
     toc(html, { class: 'foo', class_child: 'bar' }).should.eql(expected);
   });
+
+  it('max_items - result contains only h1 items', () => {
+    const className = 'toc';
+    const expected = [
+      '<ol class="' + className + '">',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_1">',
+      '<span class="' + className + '-number">1.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 1</span>',
+      '</a>',
+      // '<ol class="' + className + '-child">',
+      // <!-- h2 is truncated -->
+      // '</ol>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_2">',
+      '<span class="' + className + '-number">2.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 2</span>',
+      '</a>',
+      // '<ol class="' + className + '-child">',
+      // <!-- h2 is truncated -->
+      // '</ol>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_3">',
+      '<span class="' + className + '-number">3.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title should escape &amp;, &lt;, &#39;, and &quot;</span>',
+      '</a>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_4">',
+      '<span class="' + className + '-number">4.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Chapter 1 should be printed to toc</span>',
+      '</a>',
+      '</li>',
+      '</ol>'
+    ].join('');
+
+    toc(html, { max_items: 4}).should.eql(expected); // The number of `h1` is 4
+    toc(html, { max_items: 7}).should.eql(expected); // Maximum number 7 cannot display up to `h2`
+  });
+
+  it('max_items - result contains h1 and h2 items', () => {
+    const className = 'toc';
+    const expected = [
+      '<ol class="' + className + '">',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_1">',
+      '<span class="' + className + '-number">1.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 1</span>',
+      '</a>',
+      '<ol class="' + className + '-child">',
+      '<li class="' + className + '-item ' + className + '-level-2">',
+      '<a class="' + className + '-link" href="#title_1_1">',
+      '<span class="' + className + '-number">1.1.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 1.1</span>',
+      '</a>',
+      // '<ol class="' + className + '-child">',
+      // <!-- h3 is truncated -->
+      // '</ol>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-2">',
+      '<a class="' + className + '-link" href="#title_1_2">',
+      '<span class="' + className + '-number">1.2.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 1.2</span>',
+      '</a>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-2">',
+      '<a class="' + className + '-link" href="#title_1_3">',
+      '<span class="' + className + '-number">1.3.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 1.3</span>',
+      '</a>',
+      // '<ol class="' + className + '-child">',
+      // <!-- h3 is truncated -->
+      // '</ol>',
+      '</li>',
+      '</ol>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_2">',
+      '<span class="' + className + '-number">2.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 2</span>',
+      '</a>',
+      '<ol class="' + className + '-child">',
+      '<li class="' + className + '-item ' + className + '-level-2">',
+      '<a class="' + className + '-link" href="#title_2_1">',
+      '<span class="' + className + '-number">2.1.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 2.1</span>',
+      '</a>',
+      '</li>',
+      '</ol>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_3">',
+      '<span class="' + className + '-number">3.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title should escape &amp;, &lt;, &#39;, and &quot;</span>',
+      '</a>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_4">',
+      '<span class="' + className + '-number">4.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Chapter 1 should be printed to toc</span>',
+      '</a>',
+      '</li>',
+      '</ol>'
+    ].join('');
+
+    toc(html, { max_items: 8}).should.eql(expected); // Maximum number 8 can display up to `h2`
+    toc(html, { max_items: 9}).should.eql(expected); // Maximum number 10 is required to display up to `h3`
+  });
+
+  it('max_items - result of h1 was truncated', () => {
+    const className = 'toc';
+    const expected = [
+      '<ol class="' + className + '">',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_1">',
+      '<span class="' + className + '-number">1.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 1</span>',
+      '</a>',
+      // '<ol class="' + className + '-child">',
+      // <!-- h2 is truncated -->
+      // '</ol>',
+      '</li>',
+      '<li class="' + className + '-item ' + className + '-level-1">',
+      '<a class="' + className + '-link" href="#title_2">',
+      '<span class="' + className + '-number">2.</span> ', // list_number enabled
+      '<span class="' + className + '-text">Title 2</span>',
+      '</a>',
+      '</li>',
+      // <!-- `h1` is truncated from the end -->
+      '</ol>'
+    ].join('');
+
+    toc(html, { max_items: 2}).should.eql(expected); // `h1` is truncated from the end
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Added the ability to set an upper limit on the number of items in the table of contents output by the `toc()` helper.

If no value is specified, the default is `Infinity`. This is no different from previous behavior. If we specify a number greater than or equal to 1, the elements will be truncated in the following order.

* Delete items from descendants to ancestors (from `<h6>` to `<h1>`) to fit within the specified number.
* Subheadings, which are lower-level headings on the page, will be removed in groups by level.
* The behavior differs only for the highest heading that appears on the page, which is deleted sequentially from the back.

For example, if we have a heading like this:

> \## 1
> \### 1-1
> \### 1-2
> \## 2
> \### 2-1

If `5` is specified for `max_items`, all items will be output. On the other hand, if we specify `4` or `3`,

> **\## 1**
> ~~\### 1-1~~ *truncated*
> ~~\### 1-2~~ *truncated*
> **\## 2**
> ~~\### 2-1~~ *truncated*

All `<h3>` are removed, resulting in two items being output. This is the same result as specifying `2` for `max_items`.
This is because this outline requires five elements to display up to `<h3>`.

Only the highest heading that appears on the page behaves differently. For example, if we specify `1` for `max_items`,

> **\## 1**
> ~~\### 1-1~~ *truncated*
> ~~\### 1-2~~ *truncated*
> ~~\## 2~~ *truncated*
> ~~\### 2-1~~ *truncated*

Instead of all `<h2>` being deleted at once as before, they will be deleted sequentially from the bottom. This is to avoid unintentionally not outputting anything.

In addition to the code, I welcome any feedback regarding the specifications described here. I believe this specification is the best, but if you have any other good ideas, I would definitely consider them.

## Screenshots

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
