### PR TITLE
cleanup(wip): remove bluebird

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 .tmp*
 .vscode
 dist/
+bun.lockb

--- a/lib/box/file.ts
+++ b/lib/box/file.ts
@@ -1,4 +1,3 @@
-import type Promise from 'bluebird';
 import { readFile, readFileSync, stat, statSync, type ReadFileOptions } from 'hexo-fs';
 import type fs from 'fs';
 

--- a/lib/extend/console.ts
+++ b/lib/extend/console.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+
 import abbrev from 'abbrev';
 import type { NodeJSLikeCallback } from '../types';
 

--- a/lib/extend/deployer.ts
+++ b/lib/extend/deployer.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+
 import type { NodeJSLikeCallback } from '../types';
 
 interface StoreFunction {

--- a/lib/extend/filter.ts
+++ b/lib/extend/filter.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+
 
 const typeAlias = {
   pre: 'before_post_render',

--- a/lib/extend/generator.ts
+++ b/lib/extend/generator.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+
 import type { NodeJSLikeCallback } from '../types';
 
 interface BaseObj {

--- a/lib/extend/migrator.ts
+++ b/lib/extend/migrator.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+
 import type { NodeJSLikeCallback } from '../types';
 
 interface StoreFunction {

--- a/lib/extend/processor.ts
+++ b/lib/extend/processor.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+
 import { Pattern } from 'hexo-util';
 import type File from '../box/file';
 

--- a/lib/extend/renderer.ts
+++ b/lib/extend/renderer.ts
@@ -1,5 +1,5 @@
 import { extname } from 'path';
-import Promise from 'bluebird';
+import { promisify } from 'util';
 import type { NodeJSLikeCallback } from '../types';
 
 const getExtname = (str: string) => {
@@ -98,10 +98,10 @@ class Renderer {
       this.storeSync[name] = fn;
       this.storeSync[name].output = output;
 
-      this.store[name] = Promise.method(fn);
+      this.store[name] = promisify(fn);
       this.store[name].disableNunjucks = (fn as StoreFunction).disableNunjucks;
     } else {
-      if (fn.length > 2) fn = Promise.promisify(fn);
+      if (fn.length > 2) fn = promisify(fn);
       this.store[name] = fn;
     }
 

--- a/lib/extend/tag.ts
+++ b/lib/extend/tag.ts
@@ -1,7 +1,7 @@
 import { stripIndent } from 'hexo-util';
 import { cyan, magenta, red, bold } from 'picocolors';
 import { Environment } from 'nunjucks';
-import Promise from 'bluebird';
+
 import type { NodeJSLikeCallback } from '../types';
 
 const rSwigRawFullBlock = /{% *raw *%}/;

--- a/lib/hexo/default_config.ts
+++ b/lib/hexo/default_config.ts
@@ -23,7 +23,7 @@ export = {
   category_dir: 'categories',
   code_dir: 'downloads/code',
   i18n_dir: ':lang',
-  skip_render: [],
+  skip_render: [] as string[],
   // Writing
   new_post_name: ':title.md',
   default_layout: 'post',

--- a/lib/hexo/load_database.ts
+++ b/lib/hexo/load_database.ts
@@ -1,5 +1,5 @@
 import { exists, unlink } from 'hexo-fs';
-import Promise from 'bluebird';
+
 import type Hexo from './index';
 
 export = (ctx: Hexo): Promise<void> => {

--- a/lib/hexo/load_plugins.ts
+++ b/lib/hexo/load_plugins.ts
@@ -1,6 +1,6 @@
 import { join } from 'path';
 import { exists, readFile, listDir } from 'hexo-fs';
-import Promise from 'bluebird';
+
 import { magenta } from 'picocolors';
 import type Hexo from './index';
 

--- a/lib/hexo/load_theme_config.ts
+++ b/lib/hexo/load_theme_config.ts
@@ -4,7 +4,6 @@ import { exists, readdir } from 'hexo-fs';
 import { magenta } from 'picocolors';
 import { deepMerge } from 'hexo-util';
 import type Hexo from './index';
-import type Promise from 'bluebird';
 
 export = (ctx: Hexo): Promise<void> => {
   if (!ctx.env.init) return;

--- a/lib/hexo/post.ts
+++ b/lib/hexo/post.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import moment from 'moment';
-import Promise from 'bluebird';
+
 import { join, extname, basename } from 'path';
 import { magenta } from 'picocolors';
 import { load } from 'js-yaml';

--- a/lib/hexo/render.ts
+++ b/lib/hexo/render.ts
@@ -1,5 +1,5 @@
 import { extname } from 'path';
-import Promise from 'bluebird';
+
 import { readFile, readFileSync } from 'hexo-fs';
 import type Hexo from './index';
 import type { Renderer } from '../extend';

--- a/lib/hexo/router.ts
+++ b/lib/hexo/router.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'events';
-import Promise from 'bluebird';
+
 import Stream from 'stream';
 const { Readable } = Stream;
 

--- a/lib/hexo/scaffold.ts
+++ b/lib/hexo/scaffold.ts
@@ -2,7 +2,6 @@ import { extname, join } from 'path';
 import { exists, listDir, readFile, unlink, writeFile } from 'hexo-fs';
 import type Hexo from './index';
 import type { NodeJSLikeCallback } from '../types';
-import type Promise from 'bluebird';
 
 class Scaffold {
   public context: Hexo;
@@ -52,33 +51,71 @@ class Scaffold {
   }
 
   get(name: string, callback?: NodeJSLikeCallback<any>): Promise<string> {
-    return this._getScaffold(name).then(item => {
-      if (item) {
-        return readFile(item.path);
-      }
-
-      return this.defaults[name];
-    }).asCallback(callback);
+    return this._getScaffold(name)
+      .then(item => {
+        if (item) {
+          return readFile(item.path);
+        }
+        return this.defaults[name];
+      })
+      .then(result => {
+        if (callback) {
+          callback(null, result);
+        }
+        return result;
+      })
+      .catch(err => {
+        if (callback) {
+          callback(err);
+        }
+        throw err;
+      });
   }
+
 
   set(name: string, content: any, callback?: NodeJSLikeCallback<void>): Promise<void> {
     const { scaffoldDir } = this;
 
-    return this._getScaffold(name).then(item => {
-      let path = item ? item.path : join(scaffoldDir, name);
-      if (!extname(path)) path += '.md';
+    return this._getScaffold(name)
+      .then(item => {
+        let path = item ? item.path : join(scaffoldDir, name);
+        if (!extname(path)) path += '.md';
 
-      return writeFile(path, content);
-    }).asCallback(callback);
+        return writeFile(path, content);
+      })
+      .then(() => {
+        if (callback) {
+          callback(null);
+        }
+      })
+      .catch(err => {
+        if (callback) {
+          callback(err);
+        }
+        throw err;
+      });
   }
 
   remove(name: string, callback?: NodeJSLikeCallback<void>): Promise<void> {
-    return this._getScaffold(name).then(item => {
-      if (!item) return;
+    return this._getScaffold(name)
+      .then(item => {
+        if (!item) return;
 
-      return unlink(item.path);
-    }).asCallback(callback);
+        return unlink(item.path);
+      })
+      .then(() => {
+        if (callback) {
+          callback(null);
+        }
+      })
+      .catch(err => {
+        if (callback) {
+          callback(err);
+        }
+        throw err;
+      });
   }
+
 }
 
 export = Scaffold;

--- a/lib/hexo/update_package.ts
+++ b/lib/hexo/update_package.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { writeFile, exists, readFile } from 'hexo-fs';
 import type Hexo from './index';
-import type Promise from 'bluebird';
 
 export = (ctx: Hexo): Promise<void> => {
   const pkgPath = join(ctx.base_dir, 'package.json');

--- a/lib/models/cache.ts
+++ b/lib/models/cache.ts
@@ -1,5 +1,5 @@
 import warehouse from 'warehouse';
-import Promise from 'bluebird';
+
 import type Hexo from '../hexo';
 
 export = (ctx: Hexo) => {

--- a/lib/models/post.ts
+++ b/lib/models/post.ts
@@ -1,7 +1,7 @@
 import warehouse from 'warehouse';
 import moment from 'moment';
 import { extname, join, sep } from 'path';
-import Promise from 'bluebird';
+
 import Moment from './types/moment';
 import { full_url_for, Cache } from 'hexo-util';
 import type Hexo from '../hexo';

--- a/lib/plugins/console/clean.ts
+++ b/lib/plugins/console/clean.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+
 import { exists, unlink, rmdir } from 'hexo-fs';
 import type Hexo from '../../hexo';
 

--- a/lib/plugins/console/config.ts
+++ b/lib/plugins/console/config.ts
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml';
 import { exists, writeFile } from 'hexo-fs';
 import { extname } from 'path';
-import Promise from 'bluebird';
+
 import type Hexo from '../../hexo';
 
 interface ConfigArgs {

--- a/lib/plugins/console/generate.ts
+++ b/lib/plugins/console/generate.ts
@@ -1,6 +1,6 @@
 import { exists, writeFile, unlink, stat, mkdirs } from 'hexo-fs';
 import { join } from 'path';
-import Promise from 'bluebird';
+
 import prettyHrtime from 'pretty-hrtime';
 import { cyan, magenta } from 'picocolors';
 import tildify from 'tildify';

--- a/lib/plugins/filter/before_generate/render_post.ts
+++ b/lib/plugins/filter/before_generate/render_post.ts
@@ -1,4 +1,4 @@
-import Promise from 'bluebird';
+
 import type Hexo from '../../../hexo';
 
 function renderPostFilter(this: Hexo): Promise<[any[], any[]]> {

--- a/lib/plugins/filter/new_post_path.ts
+++ b/lib/plugins/filter/new_post_path.ts
@@ -1,6 +1,6 @@
 import { join, extname } from 'path';
 import moment from 'moment';
-import Promise from 'bluebird';
+
 import { createSha1Hash, Permalink } from 'hexo-util';
 import { ensurePath } from 'hexo-fs';
 import type Hexo from '../../hexo';

--- a/lib/plugins/generator/asset.ts
+++ b/lib/plugins/generator/asset.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
 import { exists, createReadStream } from 'hexo-fs';
-import Promise from 'bluebird';
+
 import { extname } from 'path';
 import { magenta } from 'picocolors';
 import type Hexo from '../../hexo';

--- a/lib/plugins/processor/asset.ts
+++ b/lib/plugins/processor/asset.ts
@@ -1,5 +1,4 @@
 import { timezone, toDate, isExcludedFile, isMatch } from './common';
-import Promise from 'bluebird';
 import { parse as yfm } from 'hexo-front-matter';
 import { extname, relative } from 'path';
 import { Pattern } from 'hexo-util';
@@ -51,7 +50,7 @@ function processPage(ctx: Hexo, file: _File) {
   return Promise.all([
     file.stat(),
     file.read()
-  ]).spread((stats: Stats, content: string) => {
+  ]).then(([stats, content]) => {
     const data = yfm(content);
     const output = ctx.render.getOutput(path);
 
@@ -60,16 +59,16 @@ function processPage(ctx: Hexo, file: _File) {
 
     data.date = toDate(data.date);
 
-    if (data.date) {
-      if (timezoneCfg) data.date = timezone(data.date, timezoneCfg);
-    } else {
+    if (data.date && timezoneCfg) {
+      data.date = timezone(data.date, timezoneCfg);
+    } else if (!data.date) {
       data.date = stats.ctime;
     }
 
     data.updated = toDate(data.updated);
 
-    if (data.updated) {
-      if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg);
+    if (data.updated && timezoneCfg) {
+      data.updated = timezone(data.updated, timezoneCfg);
     } else if (updated_option === 'date') {
       data.updated = data.date;
     } else if (updated_option === 'empty') {

--- a/lib/theme/view.ts
+++ b/lib/theme/view.ts
@@ -1,6 +1,5 @@
 import { dirname, extname, join } from 'path';
 import { parse as yfm } from 'hexo-front-matter';
-import Promise from 'bluebird';
 import type Theme from '.';
 import type Render from '../hexo/render';
 import type { NodeJSLikeCallback } from '../types';

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
   "dependencies": {
     "abbrev": "^2.0.0",
     "archy": "^1.0.0",
-    "bluebird": "^3.7.2",
     "hexo-cli": "^4.3.2",
     "hexo-front-matter": "^4.2.1",
     "hexo-fs": "^4.1.3",
@@ -68,7 +67,6 @@
   "devDependencies": {
     "0x": "^5.1.2",
     "@types/abbrev": "^1.1.3",
-    "@types/bluebird": "^3.5.37",
     "@types/chai": "^4.3.11",
     "@types/js-yaml": "^4.0.9",
     "@types/mocha": "^10.0.6",

--- a/test/scripts/box/box.ts
+++ b/test/scripts/box/box.ts
@@ -2,8 +2,6 @@ import { join, sep } from 'path';
 import { appendFile, mkdir, mkdirs, rename, rmdir, stat, unlink, writeFile } from 'hexo-fs';
 import { hash, Pattern } from 'hexo-util';
 import { spy, match, assert as sinonAssert } from 'sinon';
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import Box from '../../../lib/box';
 import chai from 'chai';
@@ -323,7 +321,7 @@ describe('Box', () => {
     await writeFile(src, 'a');
     await box.watch();
     box.isWatching().should.be.true;
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     sinonAssert.calledWithMatch(processor.firstCall, {
       source: src,
@@ -352,7 +350,7 @@ describe('Box', () => {
     ]);
     await box.watch();
     await appendFile(src, 'b');
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     sinonAssert.calledWithMatch(processor.lastCall, {
       source: src,
@@ -381,7 +379,7 @@ describe('Box', () => {
     ]);
     await box.watch();
     await unlink(src);
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     sinonAssert.calledWithMatch(processor.lastCall, {
       source: src,
@@ -412,7 +410,7 @@ describe('Box', () => {
     ]);
     await box.watch();
     await rename(src, newSrc);
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     for (const [file] of processor.args.slice(-2)) {
       switch (file.type) {
@@ -450,7 +448,7 @@ describe('Box', () => {
     ]);
     await box.watch();
     await rename(join(box.base, 'a'), join(box.base, 'b'));
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     for (const [file] of processor.args.slice(-2)) {
       switch (file.type) {
@@ -493,7 +491,7 @@ describe('Box', () => {
     ]);
     await box.watch();
     await appendFile(src1, 'aaa');
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     const file = processor.lastCall.args[0];
 
@@ -505,7 +503,7 @@ describe('Box', () => {
     });
 
     await appendFile(src2, 'bbb');
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     const file2 = processor.lastCall.args[0];
     file2.should.eql(file); // not changed
@@ -544,7 +542,7 @@ describe('Box', () => {
     ]);
     await box.watch();
     await appendFile(src1, 'aaa');
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     const file = processor.lastCall.args[0];
 
@@ -556,12 +554,12 @@ describe('Box', () => {
     });
 
     await appendFile(src2, 'bbb');
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     processor.lastCall.args[0].should.eql(file); // not changed
 
     await appendFile(src3, 'ccc');
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     processor.lastCall.args[0].should.eql(file); // not changed
 

--- a/test/scripts/console/generate.ts
+++ b/test/scripts/console/generate.ts
@@ -1,7 +1,5 @@
 import { join } from 'path';
 import { emptyDir, exists, mkdirs, readFile, rmdir, stat, unlink, writeFile } from 'hexo-fs';
-// @ts-ignore
-import Promise from 'bluebird';
 import { spy } from 'sinon';
 import chai from 'chai';
 const should = chai.should();
@@ -148,7 +146,7 @@ describe('generate', () => {
     let stats = await stat(dest);
     const mtime = stats.mtime.getTime();
 
-    await Promise.delay(1000);
+    await new Promise(resolve => setTimeout(resolve, 1000));
 
     // Force regenerate
     await generate({ force: true });
@@ -173,7 +171,7 @@ describe('generate', () => {
     // Update the file
     await writeFile(src, content);
 
-    await Promise.delay(300);
+    await new Promise(resolve => setTimeout(resolve, 300));
 
     // Check the updated file
     const result = await readFile(dest);
@@ -216,7 +214,7 @@ describe('generate', () => {
     // Generate again
     await generate();
 
-    await Promise.delay(300);
+    await new Promise(resolve => setTimeout(resolve, 300));
 
     // Read the updated source file
     const result = await Promise.all([
@@ -322,7 +320,7 @@ describe('generate - watch (delete)', () => {
     const exist = await exists(hexo.base_dir);
     if (exist) {
       await emptyDir(hexo.base_dir);
-      await Promise.delay(500);
+      await new Promise(resolve => setTimeout(resolve, 500));
       await rmdir(hexo.base_dir);
     }
   });
@@ -358,7 +356,7 @@ describe('generate - watch (delete)', () => {
     await testGenerate({ watch: true });
 
     await unlink(join(hexo.source_dir, 'test.txt'));
-    await Promise.delay(500);
+    await new Promise(resolve => setTimeout(resolve, 500));
 
     const exist = await exists(join(hexo.public_dir, 'test.txt'));
     exist.should.be.false;

--- a/test/scripts/console/list.ts
+++ b/test/scripts/console/list.ts
@@ -1,6 +1,4 @@
 import { spy, stub, assert as sinonAssert, SinonSpy } from 'sinon';
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import listConsole from '../../../lib/plugins/console/list';
 type OriginalParams = Parameters<typeof listConsole>;

--- a/test/scripts/console/list_categories.ts
+++ b/test/scripts/console/list_categories.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import { stub, assert as sinonAssert } from 'sinon';
 import Hexo from '../../../lib/hexo';
 import listCategory from '../../../lib/plugins/console/list/category';
@@ -36,11 +34,11 @@ describe('Console list', () => {
 
     await hexo.init();
     const output = await Post.insert(posts);
-    await Promise.each([
+    await Promise.all([
       ['foo'],
       ['baz'],
       ['baz']
-    ], (tags, i) => output[i].setCategories(tags));
+    ].map((tags, i) => output[i].setCategories(tags)));
     await hexo.locals.invalidate();
     listCategories();
     sinonAssert.calledWithMatch(logStub, 'Name');

--- a/test/scripts/console/list_post.ts
+++ b/test/scripts/console/list_post.ts
@@ -1,5 +1,5 @@
 // @ts-ignore
-import Promise from 'bluebird';
+
 import { stub, assert as sinonAssert } from 'sinon';
 import Hexo from '../../../lib/hexo';
 import listPost from '../../../lib/plugins/console/list/post';

--- a/test/scripts/console/list_tags.ts
+++ b/test/scripts/console/list_tags.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import { stub, assert as sinonAssert } from 'sinon';
 import Hexo from '../../../lib/hexo';
 import listTag from '../../../lib/plugins/console/list/tag';
@@ -39,11 +37,11 @@ describe('Console list', () => {
 
     await hexo.init();
     const output = await Post.insert(posts);
-    await Promise.each([
+    await Promise.all([
       ['foo'],
       ['baz'],
       ['baz']
-    ], (tags, i) => output[i].setTags(tags));
+    ].map((tags, i) => output[i].setTags(tags)));
     await hexo.locals.invalidate();
 
     listTags();

--- a/test/scripts/console/new.ts
+++ b/test/scripts/console/new.ts
@@ -2,7 +2,7 @@ import { exists, mkdirs, readFile, rmdir, unlink } from 'hexo-fs';
 import moment from 'moment';
 import { join } from 'path';
 // @ts-ignore
-import Promise from 'bluebird';
+
 import { useFakeTimers, spy, SinonSpy } from 'sinon';
 import Hexo from '../../../lib/hexo';
 import newConsole from '../../../lib/plugins/console/new';

--- a/test/scripts/console/publish.ts
+++ b/test/scripts/console/publish.ts
@@ -1,8 +1,6 @@
 import { exists, mkdirs, readFile, rmdir, unlink } from 'hexo-fs';
 import moment from 'moment';
 import { join } from 'path';
-// @ts-ignore
-import Promise from 'bluebird';
 import { useFakeTimers, spy, SinonSpy, SinonFakeTimers } from 'sinon';
 import Hexo from '../../../lib/hexo';
 import publishConsole from '../../../lib/plugins/console/publish';

--- a/test/scripts/console/render.ts
+++ b/test/scripts/console/render.ts
@@ -1,7 +1,5 @@
 import { mkdirs, readFile, rmdir, unlink, writeFile } from 'hexo-fs';
 import { join } from 'path';
-// @ts-ignore
-import Promise from 'bluebird';
 import { spy, SinonSpy } from 'sinon';
 import Hexo from '../../../lib/hexo';
 import renderConsole from '../../../lib/plugins/console/render';

--- a/test/scripts/extend/renderer.ts
+++ b/test/scripts/extend/renderer.ts
@@ -1,6 +1,6 @@
 import Renderer from '../../../lib/extend/renderer';
 // @ts-ignore
-import Promise from 'bluebird';
+
 import chai from 'chai';
 const should = chai.should();
 

--- a/test/scripts/filters/save_database.ts
+++ b/test/scripts/filters/save_database.ts
@@ -1,14 +1,17 @@
 import Hexo from '../../../lib/hexo';
 import { exists, unlink } from 'hexo-fs';
-// @ts-ignore
-import Promise from 'bluebird';
 import saveDatabaseFilter from '../../../lib/plugins/filter/before_exit/save_database';
 type SaveDatabaseFilterParams = Parameters<typeof saveDatabaseFilter>
 type SaveDatabaseFilterReturn = ReturnType<typeof saveDatabaseFilter>
 
 describe('Save database', () => {
   const hexo = new Hexo();
-  const saveDatabase: (...args: SaveDatabaseFilterParams) => Promise<SaveDatabaseFilterReturn> = Promise.method(saveDatabaseFilter).bind(hexo);
+  const saveDatabase: (...args: SaveDatabaseFilterParams) => Promise<SaveDatabaseFilterReturn> = (...args: SaveDatabaseFilterParams) => {
+    return new Promise(resolve => {
+      const boundSaveDatabase = saveDatabaseFilter.bind(hexo);
+      resolve(boundSaveDatabase(...args));
+    });
+  };
   const dbPath = hexo.database.options.path;
 
   it('default', async () => {

--- a/test/scripts/generators/page.ts
+++ b/test/scripts/generators/page.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import pageGenerator from '../../../lib/plugins/generator/page';
 import { NormalPostGenerator } from '../../../lib/types';
@@ -11,7 +9,12 @@ type PageGeneratorReturn = ReturnType<typeof pageGenerator>;
 describe('page', () => {
   const hexo = new Hexo(__dirname, {silent: true});
   const Page = hexo.model('Page');
-  const generator: (...args: PageGeneratorParams) => Promise<PageGeneratorReturn> = Promise.method(pageGenerator.bind(hexo));
+  const generator: (...args: PageGeneratorParams) => Promise<PageGeneratorReturn> = (...args: PageGeneratorParams) => {
+    return new Promise((resolve, reject) => {
+      const boundGenerator = pageGenerator.bind(hexo);
+      resolve(boundGenerator(...args));
+    });
+  };
 
   const locals = (): any => {
     hexo.locals.invalidate();

--- a/test/scripts/generators/post.ts
+++ b/test/scripts/generators/post.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import postGenerator from '../../../lib/plugins/generator/post';
 import { NormalPostGenerator } from '../../../lib/types';
@@ -11,7 +9,16 @@ type PostGeneratorReturn = ReturnType<typeof postGenerator>;
 describe('post', () => {
   const hexo = new Hexo(__dirname, {silent: true});
   const Post = hexo.model('Post');
-  const generator: (...args: PostGeneratorParams) => Promise<PostGeneratorReturn> = Promise.method(postGenerator.bind(hexo));
+  const generator: (...args: PostGeneratorParams) => Promise<PostGeneratorReturn> = (...args: PostGeneratorParams) => {
+    return new Promise((resolve, reject) => {
+      const boundGenerator = postGenerator.bind(hexo);
+      try {
+        resolve(boundGenerator(...args));
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
 
   hexo.config.permalink = ':title/';
 

--- a/test/scripts/helpers/partial.ts
+++ b/test/scripts/helpers/partial.ts
@@ -1,7 +1,5 @@
 import pathFn from 'path';
 import { mkdirs, writeFile, rmdir } from 'hexo-fs';
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import fragmentCache from '../../../lib/plugins/helper/fragment_cache';
 import partialHelper from '../../../lib/plugins/helper/partial';

--- a/test/scripts/helpers/tagcloud.ts
+++ b/test/scripts/helpers/tagcloud.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import tagcloudHelper from '../../../lib/plugins/helper/tagcloud';
 import chai from 'chai';

--- a/test/scripts/hexo/hexo.ts
+++ b/test/scripts/hexo/hexo.ts
@@ -1,7 +1,5 @@
 import { sep, join } from 'path';
 import { mkdirs, rmdir, unlink, writeFile } from 'hexo-fs';
-// @ts-ignore
-import Promise from 'bluebird';
 import { spy } from 'sinon';
 import { readStream } from '../../util';
 import { full_url_for } from 'hexo-util';
@@ -229,7 +227,7 @@ describe('Hexo', () => {
     await hexo.watch();
     await checkStream(route.get('test.txt'), body); // Test for first generation
     await writeFile(target, newBody); // Update the file
-    await Promise.delay(300);
+    await new Promise(resolve => setTimeout(resolve, 300));
     await checkStream(route.get('test.txt'), newBody); // Check the new route
     hexo.unwatch(); // Stop watching
     await unlink(target); // Delete the file
@@ -300,7 +298,7 @@ describe('Hexo', () => {
   it('exit() - error handling - promise', () => {
     return Promise.all([
       hexo.exit({ foo: 'bar' }),
-      new Promise((resolve, reject) => {
+      new Promise<void>((resolve, reject) => {
         hexo.once('exit', err => {
           try {
             err.should.eql({ foo: 'bar' });

--- a/test/scripts/hexo/load_plugins.ts
+++ b/test/scripts/hexo/load_plugins.ts
@@ -2,8 +2,6 @@ import { join, dirname } from 'path';
 import { writeFile, mkdir, rmdir, unlink } from 'hexo-fs';
 import Hexo from '../../../lib/hexo';
 import loadPlugins from '../../../lib/hexo/load_plugins';
-// @ts-ignore
-import Promise from 'bluebird';
 import chai from 'chai';
 const should = chai.should();
 

--- a/test/scripts/hexo/router.ts
+++ b/test/scripts/hexo/router.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import { Readable } from 'stream';
 import { join } from 'path';
 import crypto from 'crypto';

--- a/test/scripts/processors/data.ts
+++ b/test/scripts/processors/data.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import { mkdirs, rmdir, unlink, writeFile } from 'hexo-fs';
 import { join } from 'path';
 import Hexo from '../../../lib/hexo';
@@ -11,7 +9,17 @@ describe('data', () => {
   const baseDir = join(__dirname, 'data_test');
   const hexo = new Hexo(baseDir);
   const processor = data(hexo);
-  const process = Promise.method(processor.process).bind(hexo);
+  const process = (...args: unknown[]) => {
+    return new Promise((resolve, reject) => {
+      try {
+        const boundProcess = processor.process.bind(hexo);
+        const result = boundProcess(...args);
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
   const { source } = hexo;
   const { File } = source;
   const Data = hexo.model('Data');

--- a/test/scripts/processors/post.ts
+++ b/test/scripts/processors/post.ts
@@ -1,8 +1,6 @@
 
 import { join } from 'path';
 import { mkdirs, rmdir, unlink, writeFile } from 'hexo-fs';
-// @ts-ignore
-import Promise from 'bluebird';
 import defaultConfig from '../../../lib/hexo/default_config';
 import Hexo from '../../../lib/hexo';
 import posts from '../../../lib/plugins/processor/post';
@@ -17,7 +15,16 @@ describe('post', () => {
   const baseDir = join(__dirname, 'post_test');
   const hexo = new Hexo(baseDir);
   const post = posts(hexo);
-  const process: (...args: PostParams) => Promise<PostReturn> = Promise.method(post.process.bind(hexo));
+  const process: (...args: PostParams) => Promise<PostReturn> = (...args: PostParams) => {
+    return new Promise((resolve, reject) => {
+      try {
+        const result = post.process.apply(hexo, args);
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
   const { pattern } = post;
   const { source } = hexo;
   const { File } = source;

--- a/test/scripts/tags/asset_img.ts
+++ b/test/scripts/tags/asset_img.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import tagAssetImg from '../../../lib/plugins/tag/asset_img';
 import chai from 'chai';

--- a/test/scripts/tags/asset_link.ts
+++ b/test/scripts/tags/asset_link.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import tagAssetLink from '../../../lib/plugins/tag/asset_link';
 import chai from 'chai';

--- a/test/scripts/tags/asset_path.ts
+++ b/test/scripts/tags/asset_path.ts
@@ -1,5 +1,3 @@
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import tagAssetPath from '../../../lib/plugins/tag/asset_path';
 import chai from 'chai';

--- a/test/scripts/tags/include_code.ts
+++ b/test/scripts/tags/include_code.ts
@@ -1,8 +1,6 @@
 import { join } from 'path';
 import { rmdir, writeFile } from 'hexo-fs';
 import { highlight, prismHighlight } from 'hexo-util';
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import tagIncludeCode from '../../../lib/plugins/tag/include_code';
 import chai from 'chai';
@@ -11,7 +9,17 @@ const should = chai.should();
 describe('include_code', () => {
   const hexo = new Hexo(join(__dirname, 'include_code_test'));
   require('../../../lib/plugins/highlight/')(hexo);
-  const includeCode = Promise.method(tagIncludeCode(hexo));
+  const includeCode = (...args: string[]) => {
+    return new Promise<string>((resolve, reject) => {
+      try {
+        const result = tagIncludeCode(hexo)(args);
+        resolve(result!);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
+
   const path = join(hexo.source_dir, hexo.config.code_dir, 'test.js');
   const defaultCfg = JSON.parse(JSON.stringify(hexo.config));
 

--- a/test/scripts/theme_processors/config.ts
+++ b/test/scripts/theme_processors/config.ts
@@ -1,8 +1,6 @@
 import { spy, assert as sinonAssert } from 'sinon';
 import { join } from 'path';
 import { mkdirs, rmdir, unlink, writeFile} from 'hexo-fs';
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import { config } from '../../../lib/theme/processors/config';
 import chai from 'chai';
@@ -12,7 +10,18 @@ type ConfigReturn = ReturnType<typeof config['process']>
 
 describe('config', () => {
   const hexo = new Hexo(join(__dirname, 'config_test'), {silent: true});
-  const process: (...args: ConfigParams) => Promise<ConfigReturn> = Promise.method(config.process.bind(hexo));
+  const process: (...args: ConfigParams) => Promise<ConfigReturn> = (...args: ConfigParams) => {
+    return new Promise((resolve, reject) => {
+      try {
+        const boundProcess = config.process.bind(hexo);
+        const result = boundProcess(...args);
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
+
   const themeDir = join(hexo.base_dir, 'themes', 'test');
 
   function newFile(options) {

--- a/test/scripts/theme_processors/i18n.ts
+++ b/test/scripts/theme_processors/i18n.ts
@@ -1,7 +1,5 @@
 import { join } from 'path';
 import { mkdirs, rmdir, unlink, writeFile } from 'hexo-fs';
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import { i18n } from '../../../lib/theme/processors/i18n';
 import chai from 'chai';
@@ -11,7 +9,16 @@ type I18nReturn = ReturnType<typeof i18n['process']>
 
 describe('i18n', () => {
   const hexo = new Hexo(join(__dirname, 'config_test'), {silent: true});
-  const process: (...args: I18nParams) => Promise<I18nReturn> = Promise.method(i18n.process.bind(hexo));
+  const process: (...args: I18nParams) => Promise<I18nReturn> = (...args: I18nParams) => {
+    return new Promise((resolve, reject) => {
+      try {
+        const result = i18n.process.apply(hexo, args);
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
   const themeDir = join(hexo.base_dir, 'themes', 'test');
 
   function newFile(options) {

--- a/test/scripts/theme_processors/source.ts
+++ b/test/scripts/theme_processors/source.ts
@@ -1,7 +1,5 @@
 import { join } from 'path';
 import { mkdirs, rmdir, unlink, writeFile } from 'hexo-fs';
-// @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import { source } from '../../../lib/theme/processors/source';
 import chai from 'chai';
@@ -11,7 +9,16 @@ type SourceReturn = ReturnType<typeof source['process']>
 
 describe('source', () => {
   const hexo = new Hexo(join(__dirname, 'source_test'), {silent: true});
-  const process: (...args: SourceParams) => Promise<SourceReturn> = Promise.method(source.process.bind(hexo));
+  const process: (...args: SourceParams) => Promise<SourceReturn> = (...args: SourceParams) => {
+    return new Promise((resolve, reject) => {
+      try {
+        const result = source.process.apply(hexo, args);
+        resolve(result);
+      } catch (error) {
+        reject(error);
+      }
+    });
+  };
   const themeDir = join(hexo.base_dir, 'themes', 'test');
   const Asset = hexo.model('Asset');
 

--- a/test/scripts/theme_processors/view.ts
+++ b/test/scripts/theme_processors/view.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import { mkdirs, rmdir, unlink, writeFile } from 'hexo-fs';
 // @ts-ignore
-import Promise from 'bluebird';
 import Hexo from '../../../lib/hexo';
 import { view } from '../../../lib/theme/processors/view';
 import chai from 'chai';
@@ -12,7 +11,13 @@ type ViewReturn = ReturnType<typeof view['process']>
 
 describe('view', () => {
   const hexo = new Hexo(join(__dirname, 'view_test'), {silent: true});
-  const process: (...args: ViewParams) => Promise<ViewReturn> = Promise.method(view.process.bind(hexo));
+  const process: (...args: ViewParams) => Promise<ViewReturn> = (...args: ViewParams) => {
+    try {
+      return Promise.resolve(view.process.apply(hexo, args));
+    } catch (error) {
+      return Promise.reject(error);
+    }
+  };
   const themeDir = join(hexo.base_dir, 'themes', 'test');
 
   hexo.env.init = true;

--- a/test/util/stream.ts
+++ b/test/util/stream.ts
@@ -1,5 +1,3 @@
-import Promise from 'bluebird';
-
 export function readStream(stream): Promise<string> {
   return new Promise((resolve, reject) => {
     let data = '';


### PR DESCRIPTION
## What does it do?

Removes Bluebird and replaces it with native Promise API. Promises have been in Node since [0.12](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise#browser_compatibility) so there's no need to use it anymore.

Needs a PR to https://github.com/hexojs/warehouse as well

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
