### PR TITLE
fix: after enabling "post_asset_folder: true", only one format of posts can be rendered

### DIFF
--- a/lib/hexo/default_config.ts
+++ b/lib/hexo/default_config.ts
@@ -36,6 +36,7 @@ export = {
   filename_case: 0,
   render_drafts: false,
   post_asset_folder: false,
+  post_extensions: [],
   relative_link: false,
   future: true,
   syntax_highlighter: 'highlight.js',

--- a/lib/plugins/processor/post.ts
+++ b/lib/plugins/processor/post.ts
@@ -50,7 +50,11 @@ export = (ctx: Hexo) => {
 
       // if post_asset_folder is set, restrict renderable files to default file extension
       if (result.renderable && ctx.config.post_asset_folder) {
-        result.renderable = (extname(ctx.config.new_post_name) === extname(path));
+        if (!Array.isArray(ctx.config.post_extensions) || ctx.config.post_extensions.length === 0) {
+          result.renderable = (extname(ctx.config.new_post_name) === extname(path));
+        } else {
+          result.renderable = ctx.config.post_extensions.includes(extname(path).slice(1));
+        }
       }
 
       return result;

--- a/test/scripts/processors/post.ts
+++ b/test/scripts/processors/post.ts
@@ -1359,4 +1359,42 @@ describe('post', () => {
       PostAsset.removeById(id)
     ]);
   });
+
+  it('post - post_extensions', async () => {
+    function fooRenderer() {
+      return '';
+    }
+
+    hexo.extend.renderer.register('md', 'html', fooRenderer, true);
+    hexo.extend.renderer.register('adoc', 'html', fooRenderer, true);
+    hexo.extend.renderer.register('ejs', 'html', fooRenderer, true);
+
+    hexo.config.post_asset_folder = true;
+    hexo.config.new_post_name = ':title.md';
+
+    hexo.config.post_extensions = null;
+    pattern.match('_posts/foo.md').should.have.property('renderable', true);
+    pattern.match('_posts/foo.adoc').should.have.property('renderable', false);
+    pattern.match('_posts/foo.ejs').should.have.property('renderable', false);
+
+    hexo.config.post_extensions = [];
+    pattern.match('_posts/foo.md').should.have.property('renderable', true);
+    pattern.match('_posts/foo.adoc').should.have.property('renderable', false);
+    pattern.match('_posts/foo.ejs').should.have.property('renderable', false);
+
+    hexo.config.post_extensions = ['adoc'];
+    pattern.match('_posts/foo.md').should.have.property('renderable', false);
+    pattern.match('_posts/foo.adoc').should.have.property('renderable', true);
+    pattern.match('_posts/foo.ejs').should.have.property('renderable', false);
+
+    hexo.config.post_extensions = ['md', 'adoc'];
+    pattern.match('_posts/foo.md').should.have.property('renderable', true);
+    pattern.match('_posts/foo.adoc').should.have.property('renderable', true);
+    pattern.match('_posts/foo.ejs').should.have.property('renderable', false);
+
+    hexo.config.post_extensions = ['md', 'adoc', 'ejs'];
+    pattern.match('_posts/foo.md').should.have.property('renderable', true);
+    pattern.match('_posts/foo.adoc').should.have.property('renderable', true);
+    pattern.match('_posts/foo.ejs').should.have.property('renderable', true);
+  });
 });


### PR DESCRIPTION

## What does it do?

I added a configuration option `post_extensions` to address the issue where only posts with the same extension as `new_post_name` are rendered when `post_asset_folder: true`. 

To resolve this, simply add the file extensions into this configuration to enable rendering, which is useful for handling posts in multiple different file formats.

When post_extensions is not filled in or is empty, the rendering method remains the same as before to ensure compatibility.

fix #5523



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
