### PR TITLE
feat: bind hexo context to helper function callback

### DIFF
--- a/lib/extend/helper.ts
+++ b/lib/extend/helper.ts
@@ -37,7 +37,7 @@ interface HexoContext extends Hexo {
 }
 
 interface StoreFunction {
-  (this: HexoContext, ...args: any[]): string;
+  (this: HexoContext, ...args: any[]): any;
 }
 
 interface Store {

--- a/lib/extend/helper.ts
+++ b/lib/extend/helper.ts
@@ -1,11 +1,18 @@
+import Hexo from '../hexo';
+import { PageSchema } from '../types';
+
+interface HexoContext extends Hexo {
+  // https://github.com/dimaslanjaka/hexo-renderers/blob/147340f6d03a8d3103e9589ddf86778ed7f9019b/src/helper/related-posts.ts#L106-L113
+  page?: PageSchema;
+}
+
 interface StoreFunction {
-  (...args: any[]): string;
+  (this: HexoContext, ...args: any[]): string;
 }
 
 interface Store {
-  [key: string]: StoreFunction
+  [key: string]: StoreFunction;
 }
-
 
 class Helper {
   public store: Store;

--- a/lib/extend/helper.ts
+++ b/lib/extend/helper.ts
@@ -1,9 +1,39 @@
 import Hexo from '../hexo';
 import { PageSchema } from '../types';
+import * as hutil from 'hexo-util';
 
 interface HexoContext extends Hexo {
+  // get current page information
   // https://github.com/dimaslanjaka/hexo-renderers/blob/147340f6d03a8d3103e9589ddf86778ed7f9019b/src/helper/related-posts.ts#L106-L113
   page?: PageSchema;
+
+  // hexo-util shims
+  url_for: typeof hutil.url_for;
+  full_url_for: typeof hutil.full_url_for;
+  relative_url: typeof hutil.relative_url;
+  slugize: typeof hutil.slugize;
+  escapeDiacritic: typeof hutil.escapeDiacritic;
+  escapeHTML: typeof hutil.escapeHTML;
+  unescapeHTML: typeof hutil.unescapeHTML;
+  encodeURL: typeof hutil.encodeURL;
+  decodeURL: typeof hutil.decodeURL;
+  escapeRegExp: typeof hutil.escapeRegExp;
+  stripHTML: typeof hutil.stripHTML;
+  stripIndent: typeof hutil.stripIndent;
+  hash: typeof hutil.hash;
+  createSha1Hash: typeof hutil.createSha1Hash;
+  highlight: typeof hutil.highlight;
+  prismHighlight: typeof hutil.prismHighlight;
+  tocObj: typeof hutil.tocObj;
+  wordWrap: typeof hutil.wordWrap;
+  prettyUrls: typeof hutil.prettyUrls;
+  isExternalLink: typeof hutil.isExternalLink;
+  gravatar: typeof hutil.gravatar;
+  htmlTag: typeof hutil.htmlTag;
+  truncate: typeof hutil.truncate;
+  spawn: typeof hutil.spawn;
+  camelCaseKeys: typeof hutil.camelCaseKeys;
+  deepMerge: typeof hutil.deepMerge;
 }
 
 interface StoreFunction {

--- a/lib/extend/processor.ts
+++ b/lib/extend/processor.ts
@@ -3,15 +3,15 @@ import { Pattern } from 'hexo-util';
 import type File from '../box/file';
 
 interface StoreFunction {
-  (file: File): any
+  (file: File | string): any;
 }
 
 type Store = {
-    pattern: Pattern;
-    process: StoreFunction
-  }[];
+  pattern: Pattern;
+  process: StoreFunction;
+}[];
 
-type patternType = Exclude<ConstructorParameters<typeof Pattern>[0], ((str: string) => string)>;
+type patternType = Exclude<ConstructorParameters<typeof Pattern>[0], (str: string) => string>;
 class Processor {
   public store: Store;
 

--- a/lib/plugins/filter/template_locals/i18n.ts
+++ b/lib/plugins/filter/template_locals/i18n.ts
@@ -13,9 +13,9 @@ function i18nLocalsFilter(this: Hexo, locals: LocalsType): void {
 
   if (!lang) {
     const pattern = new Pattern(`${i18nDir}/*path`);
-    const data = pattern.match(locals.path);
+    const data = pattern.match(locals.path) as Record<string, any>;
 
-    if (data && data.lang && i18nLanguages.includes(data.lang)) {
+    if (data && typeof data.lang === 'string' && i18nLanguages.includes(data.lang)) {
       lang = data.lang;
       page.canonical_path = data.path;
     } else {

--- a/lib/plugins/filter/template_locals/i18n.ts
+++ b/lib/plugins/filter/template_locals/i18n.ts
@@ -13,9 +13,9 @@ function i18nLocalsFilter(this: Hexo, locals: LocalsType): void {
 
   if (!lang) {
     const pattern = new Pattern(`${i18nDir}/*path`);
-    const data = pattern.match(locals.path) as Record<string, any>;
+    const data = pattern.match(locals.path) as any;
 
-    if (data && typeof data.lang === 'string' && i18nLanguages.includes(data.lang)) {
+    if (data && 'lang' in data && i18nLanguages.includes(data.lang)) {
       lang = data.lang;
       page.canonical_path = data.path;
     } else {

--- a/lib/plugins/filter/template_locals/i18n.ts
+++ b/lib/plugins/filter/template_locals/i18n.ts
@@ -13,7 +13,7 @@ function i18nLocalsFilter(this: Hexo, locals: LocalsType): void {
 
   if (!lang) {
     const pattern = new Pattern(`${i18nDir}/*path`);
-    const data = pattern.match(locals.path) as any;
+    const data = pattern.match(locals.path);
 
     if (data && 'lang' in data && i18nLanguages.includes(data.lang)) {
       lang = data.lang;


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

- Apply hexo context for `this` callback, useful for plugin written with typescript. [Sample](https://github.com/dimaslanjaka/hexo-renderers/blob/147340f6d03a8d3103e9589ddf86778ed7f9019b/src/helper/related-posts.ts#L106-L113)
- Fix some missmatch type (fail compile fixed)

## Screenshots

![image](https://github.com/user-attachments/assets/d40e542e-8340-4bb7-93bf-79da4d418613)
![image](https://github.com/user-attachments/assets/c97cfa1d-a25c-4b1b-aaaa-80472703fa71)

based on https://hexo.io/api/helper#How-do-I-use-another-registered-helper-in-my-custom-helper
![image](https://github.com/user-attachments/assets/d5b821db-7d5d-410b-ae01-c936917c5271)


## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
