### PR TITLE
fix: wrong type for StoreFunction of helper

### DIFF
--- a/lib/extend/helper.ts
+++ b/lib/extend/helper.ts
@@ -1,5 +1,5 @@
 interface StoreFunction {
-  (...args: any[]): string;
+  (...args: any[]): any;
 }
 
 interface Store {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The `require` actually leads to the imported type becoming `any`, which will cause some return value of helpers that actually return `boolean` or complex types to be incorrectly threated as `string`, yet cannot be detected by eslint, for example here:

https://github.com/hexojs/hexo/blob/492debff7c3eb697594a516ab36bed96c94a8cc1/lib/plugins/helper/index.ts#L31-L41

and here:

https://github.com/hexojs/hexo/blob/492debff7c3eb697594a516ab36bed96c94a8cc1/lib/plugins/helper/index.ts#L69-L71

And this might lead to some undefined behaviors, so I think the return type of `StoreFunction` in the helper should be changed to `any`.

## Screenshots

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
