### PR TITLE
feat(load_config): enforce stricter extension checks

### DIFF
--- a/lib/hexo/load_config.ts
+++ b/lib/hexo/load_config.ts
@@ -1,4 +1,4 @@
-import { sep, resolve, join, parse } from 'path';
+import { sep, resolve, join, parse, basename, extname } from 'path';
 import tildify from 'tildify';
 import Theme from '../theme';
 import Source from './source';
@@ -63,13 +63,12 @@ export = async (ctx: Hexo): Promise<void> => {
   }
   ctx.theme_script_dir = join(ctx.theme_dir, 'scripts') + sep;
   ctx.theme = new Theme(ctx, { ignored });
-
 };
 
 async function findConfigPath(path: string): Promise<string> {
   const { dir, name } = parse(path);
 
   const files = await readdir(dir);
-  const item = files.find(item => item.startsWith(name));
+  const item = files.find(item => basename(item, extname(item)) === name);
   if (item != null) return join(dir, item);
 }

--- a/lib/hexo/load_theme_config.ts
+++ b/lib/hexo/load_theme_config.ts
@@ -1,4 +1,4 @@
-import { join, parse } from 'path';
+import { join, parse, basename, extname } from 'path';
 import tildify from 'tildify';
 import { exists, readdir } from 'hexo-fs';
 import { magenta } from 'picocolors';
@@ -36,7 +36,7 @@ function findConfigPath(path: string): Promise<string> {
   const { dir, name } = parse(path);
 
   return readdir(dir).then(files => {
-    const item = files.find(item => item.startsWith(name));
+    const item = files.find(item => basename(item, extname(item)) === name);
     if (item != null) return join(dir, item);
   });
 }

--- a/test/scripts/hexo/load_config.ts
+++ b/test/scripts/hexo/load_config.ts
@@ -14,6 +14,7 @@ describe('Load config', () => {
   after(() => rmdir(hexo.base_dir));
 
   beforeEach(() => {
+    hexo.config_path = join(hexo.base_dir, '_config.yml');
     hexo.config = JSON.parse(JSON.stringify(defaultConfig));
   });
 
@@ -41,6 +42,7 @@ describe('Load config', () => {
       await writeFile(configPath, '{"baz": 3}');
       await loadConfig(hexo);
       hexo.config.baz.should.eql(3);
+      hexo.config_path.should.eql(configPath);
     } finally {
       await unlink(configPath);
     }
@@ -53,6 +55,7 @@ describe('Load config', () => {
       await writeFile(configPath, 'foo: 1');
       await loadConfig(hexo);
       hexo.config.should.eql(defaultConfig);
+      hexo.config_path.should.not.eql(configPath);
     } finally {
       await unlink(configPath);
     }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

I've noticed that Hexo supports searching for configuration files with different suffixes, such as `_config.txt` and `_config.json`. However, this check is very loose, meaning that `_config.backup` or `_config.yml.bak` are also considered valid configuration files. This feature can cause confusion and even security issues for users. Therefore, I refactor this feature in the pull request.

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
