### PR TITLE
chore: drop Node.js 16

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: ["14", "16", "18"]
+        node-version: ["18", "20", "22"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: ["14", "16", "18"]
+        node-version: ["18", "20", "22"]
       fail-fast: false
     env:
       comment_file: ".tmp-comment-flamegraph-node${{ matrix.node-version }}.md"

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 14.x
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: "14.x"
+          node-version: "22"
       - name: Install Dependencies
         run: npm install
       - name: Lint

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ["14.x", "16.x", "18.x"]
+        node-version: ["18", "20", "22"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node-version: ["14.x"]
+        node-version: ["22"]
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js ${{ matrix.node-version }}

--- a/package.json
+++ b/package.json
@@ -91,6 +91,6 @@
     "typescript": "^5.3.2"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   }
 }


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Versions of Node.js prior than 16 are already in End-Of-Life status. We should upgrade the supported Node.js versions in `package.json`. The required Node.js versions for other Hexo plugins also need to be upgraded accordingly.

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
