### PR TITLE
perf(postGenerator): delete unnecessary `toArray`

### DIFF
--- a/lib/plugins/generator/post.ts
+++ b/lib/plugins/generator/post.ts
@@ -2,7 +2,7 @@ import type { PostGenerator, PostSchema, SiteLocals } from '../../types';
 import type Document from 'warehouse/dist/document';
 
 function postGenerator(locals: SiteLocals): PostGenerator[] {
-  const posts = locals.posts.sort('-date').toArray();
+  const posts = locals.posts.sort('-date');
   const { length } = posts;
 
   return posts.map((post: Document<PostSchema>, i: number) => {


### PR DESCRIPTION
## What does it do?

`locals.posts` is iterable, there is no need to use [toArray](https://github.com/hexojs/warehouse/blob/b550c426b238a1aa24aa48a92c5c4606b8befb2a/src/model.ts#L440-L448) again here. `toArray` scans the data once, so this change is expected to slightly improve processing speed and reduce memory usage.

## Screenshots

N/A

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
