### PR TITLE
test(box/file): extend the mocha timeout to prevent the async file read test from failing

### DIFF
--- a/test/scripts/box/file.ts
+++ b/test/scripts/box/file.ts
@@ -38,7 +38,10 @@ describe('File', () => {
     params: {foo: 'bar'}
   });
 
-  before(async () => {
+  // NOTE: Do not use `arrow function` here.
+  //       See https://mochajs.org/#arrow-functions
+  before(async function () {
+    this.timeout(20000);
     await Promise.all([
       writeFile(file.source, body),
       hexo.init()


### PR DESCRIPTION
## What does it do?

As shown in the logs below, we occasionally face an issue where the file async read test fails due to a timeout. This PR extends the timeout for the file test to 20000ms.

```
  1) File
       "before all" hook for "read()":
     Error: Timeout of 2000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves. (/home/runner/work/hexo/hexo/test/scripts/box/file.ts)
      at createTimeoutError (/home/runner/work/hexo/hexo/node_modules/mocha/lib/errors.js:498:15)
      at Hook.Runnable._timeoutError (/home/runner/work/hexo/hexo/node_modules/mocha/lib/runnable.js:429:10)
      at done (/home/runner/work/hexo/hexo/node_modules/mocha/lib/runnable.js:306:18)
      at /home/runner/work/hexo/hexo/node_modules/mocha/lib/runnable.js:369:11
```

P.S: 

If we are allowed to change the timeout setting for the entire test, we can also specify the `--timeout` option for the mocha command.

## Screenshots

N/A

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
