### PR TITLE
chore(deps): migrate `husky` from `8.x` to `9.x`

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "pretest": "npm run clean && npm run build",
     "test": "mocha test/scripts/**/*.ts --require ts-node/register",
     "test-cov": "c8 --reporter=lcovonly npm test -- --no-parallel",
-    "prepare": "husky install"
+    "prepare": "husky"
   },
   "files": [
     "dist/",
@@ -82,8 +82,8 @@
     "eslint": "^8.48.0",
     "eslint-config-hexo": "^5.0.0",
     "hexo-renderer-marked": "^6.0.0",
-    "husky": "^8.0.1",
-    "lint-staged": "^15.2.0",
+    "husky": "^9.1.7",
+    "lint-staged": "^15.3.0",
     "mocha": "^10.0.0",
     "sinon": "^17.0.1",
     "ts-node": "^10.9.1",


### PR DESCRIPTION
## What does it do?

The current `.husky/pre-commit` is not working on windows. If we update `husky` to `9.x`, it works.

Please see [husky migration guide](https://github.com/typicode/husky/releases/tag/v9.0.1).

## Screenshots

N/A

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
