### PR TITLE
refactor(moment): remove unused timezone setting

### DIFF
--- a/lib/models/page.ts
+++ b/lib/models/page.ts
@@ -11,14 +11,10 @@ export = (ctx: Hexo) => {
     title: {type: String, default: ''},
     date: {
       type: Moment,
-      default: moment,
-      language: ctx.config.languages,
-      timezone: ctx.config.timezone
+      default: moment
     },
     updated: {
-      type: Moment,
-      language: ctx.config.languages,
-      timezone: ctx.config.timezone
+      type: Moment
     },
     comments: {type: Boolean, default: true},
     layout: {type: String, default: 'page'},

--- a/lib/models/post.ts
+++ b/lib/models/post.ts
@@ -23,14 +23,10 @@ export = (ctx: Hexo) => {
     title: {type: String, default: ''},
     date: {
       type: Moment,
-      default: moment,
-      language: ctx.config.languages,
-      timezone: ctx.config.timezone
+      default: moment
     },
     updated: {
-      type: Moment,
-      language: ctx.config.languages,
-      timezone: ctx.config.timezone
+      type: Moment
     },
     comments: {type: Boolean, default: true},
     layout: {type: String, default: 'post'},

--- a/lib/models/types/moment.ts
+++ b/lib/models/types/moment.ts
@@ -20,11 +20,7 @@ class SchemaTypeMoment extends warehouse.SchemaType<moment.Moment> {
     value = super.cast(value, data);
     if (value == null) return value;
 
-    const { options } = this;
     value = toMoment(value);
-
-    if (options.language) value = value.locale(toMomentLocale(options.language));
-    if (options.timezone) value = value.tz(options.timezone);
 
     return value;
   }

--- a/lib/models/types/moment.ts
+++ b/lib/models/types/moment.ts
@@ -1,5 +1,5 @@
 import warehouse from 'warehouse';
-import { moment, toMomentLocale } from '../../plugins/helper/date';
+import { moment } from '../../plugins/helper/date';
 
 // It'll pollute the moment module.
 // declare module 'moment' {
@@ -20,9 +20,7 @@ class SchemaTypeMoment extends warehouse.SchemaType<moment.Moment> {
     value = super.cast(value, data);
     if (value == null) return value;
 
-    value = toMoment(value);
-
-    return value;
+    return toMoment(value);
   }
 
   validate(value, data?) {

--- a/lib/plugins/processor/asset.ts
+++ b/lib/plugins/processor/asset.ts
@@ -1,4 +1,4 @@
-import { timezone, toDate, isExcludedFile, isMatch } from './common';
+import { adjustDateForTimezone, toDate, isExcludedFile, isMatch } from './common';
 import Promise from 'bluebird';
 import { parse as yfm } from 'hexo-front-matter';
 import { extname, relative } from 'path';
@@ -34,7 +34,7 @@ function processPage(ctx: Hexo, file: _File) {
   const { path } = file;
   const doc = Page.findOne({source: path});
   const { config } = ctx;
-  const { timezone: timezoneCfg } = config;
+  const { timezone } = config;
   const updated_option = config.updated_option;
 
   if (file.type === 'skip' && doc) {
@@ -62,7 +62,7 @@ function processPage(ctx: Hexo, file: _File) {
     data.date = toDate(data.date) as any;
 
     if (data.date) {
-      if (timezoneCfg) data.date = timezone(data.date, timezoneCfg) as any;
+      if (timezone) data.date = adjustDateForTimezone(data.date, timezone) as any;
     } else {
       data.date = stats.ctime as any;
     }
@@ -70,7 +70,7 @@ function processPage(ctx: Hexo, file: _File) {
     data.updated = toDate(data.updated) as any;
 
     if (data.updated) {
-      if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg) as any;
+      if (timezone) data.updated = adjustDateForTimezone(data.updated, timezone) as any;
     } else if (updated_option === 'date') {
       data.updated = data.date;
     } else if (updated_option === 'empty') {

--- a/lib/plugins/processor/common.ts
+++ b/lib/plugins/processor/common.ts
@@ -40,7 +40,7 @@ export function toDate(date?: string | number | Date | moment.Moment): Date | un
   return date;
 }
 
-export function timezone(date: Date | moment.Moment, timezone: string) {
+export function adjustDateForTimezone(date: Date | moment.Moment, timezone: string) {
   if (moment.isMoment(date)) date = date.toDate();
 
   const offset = date.getTimezoneOffset();

--- a/lib/plugins/processor/post.ts
+++ b/lib/plugins/processor/post.ts
@@ -1,4 +1,4 @@
-import { toDate, timezone, isExcludedFile, isTmpFile, isHiddenFile, isMatch } from './common';
+import { toDate, adjustDateForTimezone, isExcludedFile, isTmpFile, isHiddenFile, isMatch } from './common';
 import Promise from 'bluebird';
 import { parse as yfm } from 'hexo-front-matter';
 import { extname, join, posix, sep } from 'path';
@@ -72,7 +72,7 @@ function processPost(ctx: Hexo, file: _File) {
   const { path } = file.params;
   const doc = Post.findOne({source: file.path});
   const { config } = ctx;
-  const { timezone: timezoneCfg, updated_option, use_slug_as_post_title } = config;
+  const { timezone, updated_option, use_slug_as_post_title } = config;
 
   let categories, tags;
 
@@ -129,7 +129,7 @@ function processPost(ctx: Hexo, file: _File) {
     }
 
     if (data.date) {
-      if (timezoneCfg) data.date = timezone(data.date, timezoneCfg) as any;
+      if (timezone) data.date = adjustDateForTimezone(data.date, timezone) as any;
     } else {
       data.date = stats.birthtime as any;
     }
@@ -137,7 +137,7 @@ function processPost(ctx: Hexo, file: _File) {
     data.updated = toDate(data.updated) as any;
 
     if (data.updated) {
-      if (timezoneCfg) data.updated = timezone(data.updated, timezoneCfg) as any;
+      if (timezone) data.updated = adjustDateForTimezone(data.updated, timezone) as any;
     } else if (updated_option === 'date') {
       data.updated = data.date;
     } else if (updated_option === 'empty') {

--- a/test/scripts/models/moment.ts
+++ b/test/scripts/models/moment.ts
@@ -18,24 +18,6 @@ describe('SchemaTypeMoment', () => {
     moment.isMoment(type.cast()).should.be.true;
   });
 
-  it('cast() - language', () => {
-    const lang = 'zh-tw';
-    const format = 'LLLL';
-    const type = new SchemaTypeMoment('test', {language: lang});
-    const now = Date.now();
-
-    type.cast(now).format(format).should.eql(moment(now).locale(lang).format(format));
-  });
-
-  it('cast() - timezone', () => {
-    const timezone = 'Etc/UTC';
-    const format = 'LLLL';
-    const type = new SchemaTypeMoment('test', {timezone});
-    const now = Date.now();
-
-    type.cast(now).format(format).should.eql(moment(now).tz(timezone).format(format));
-  });
-
   function shouldThrowError(value) {
     should.throw(
       () => type.validate(value),

--- a/test/scripts/processors/common.ts
+++ b/test/scripts/processors/common.ts
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import { isTmpFile, isHiddenFile, toDate, timezone, isMatch } from '../../../lib/plugins/processor/common';
+import { isTmpFile, isHiddenFile, toDate, adjustDateForTimezone, isMatch } from '../../../lib/plugins/processor/common';
 import chai from 'chai';
 const should = chai.should();
 
@@ -33,16 +33,16 @@ describe('common', () => {
 
   it('timezone() - date', () => {
     const d = new Date(Date.UTC(1972, 2, 29, 0, 0, 0));
-    const d_timezone_UTC = timezone(d, 'UTC').getTime();
-    (timezone(d, 'Asia/Shanghai').getTime() - d_timezone_UTC).should.eql(-8 * 3600 * 1000);
-    (timezone(d, 'Asia/Bangkok').getTime() - d_timezone_UTC).should.eql(-7 * 3600 * 1000);
-    (timezone(d, 'America/Los_Angeles').getTime() - d_timezone_UTC).should.eql(8 * 3600 * 1000);
+    const d_timezone_UTC = adjustDateForTimezone(d, 'UTC').getTime();
+    (adjustDateForTimezone(d, 'Asia/Shanghai').getTime() - d_timezone_UTC).should.eql(-8 * 3600 * 1000);
+    (adjustDateForTimezone(d, 'Asia/Bangkok').getTime() - d_timezone_UTC).should.eql(-7 * 3600 * 1000);
+    (adjustDateForTimezone(d, 'America/Los_Angeles').getTime() - d_timezone_UTC).should.eql(8 * 3600 * 1000);
   });
 
   it('timezone() - moment', () => {
     const d = moment(new Date(Date.UTC(1972, 2, 29, 0, 0, 0)));
-    const d_timezone_UTC = timezone(d, 'UTC').getTime();
-    (timezone(d, 'Europe/Moscow').getTime() - d_timezone_UTC).should.eql(-3 * 3600 * 1000);
+    const d_timezone_UTC = adjustDateForTimezone(d, 'UTC').getTime();
+    (adjustDateForTimezone(d, 'Europe/Moscow').getTime() - d_timezone_UTC).should.eql(-3 * 3600 * 1000);
   });
 
   it('isMatch() - string', () => {


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

1. According to https://github.com/hexojs/hexo/issues/3282#issuecomment-462077102, variables in `ctx.config` in `lib/models/page.ts` and `lib/models/post.ts` are Hexo default config, instead of variables from `_config.yml`.
Removing the code only affects its own unit tests, no other functionalities are affected.
I propose to remove it because it's not used and may cause confusion when developing timezone-related features.
2. Besides, I renamed `timezone` function in `common.ts` to `adjustDateForTimezone`, to make the name more precise.

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
