### PR TITLE
Restore legacy permalink behavior using `:filepath` pattern

### DIFF
--- a/lib/plugins/filter/post_permalink.ts
+++ b/lib/plugins/filter/post_permalink.ts
@@ -19,14 +19,29 @@ function postPermalinkFilter(this: Hexo, data: PostSchema): string {
     return __permalink;
   }
 
-  const hash = slug && date
-    ? createSha1Hash().update(slug + date.unix().toString()).digest('hex').slice(0, 12)
-    : null;
+  const hash
+    = slug && date
+      ? createSha1Hash()
+        .update(slug + date.unix().toString())
+        .digest('hex')
+        .slice(0, 12)
+      : null;
+
+  const relativeSourcePath = data.full_source
+    // Remove base directory
+    .replace(this.base_dir, '')
+    // Normalize path to handle both / and \ (cross-platform)
+    .replace(/\\/g, '/')
+    // Remove leading "source/" or "source/_posts/" if present
+    .replace(/^source\/(_posts\/)?/, '')
+    // Remove any extension
+    .replace(/\.[^/.]+$/, '');
+
   const meta = {
     id: id || _id,
     title: slug,
     name: typeof slug === 'string' ? basename(slug) : '',
-    post_title: slugize(title, {transform: 1}),
+    post_title: slugize(title, { transform: 1 }),
     year: date.format('YYYY'),
     month: date.format('MM'),
     day: date.format('DD'),
@@ -37,7 +52,8 @@ function postPermalinkFilter(this: Hexo, data: PostSchema): string {
     i_day: date.format('D'),
     timestamp: date.format('X'),
     hash,
-    category: config.default_category
+    category: config.default_category,
+    filepath: relativeSourcePath
   };
 
   if (!permalink || permalink.rule !== config.permalink) {

--- a/test/scripts/filters/filepath_permalink.ts
+++ b/test/scripts/filters/filepath_permalink.ts
@@ -1,0 +1,115 @@
+import { should } from 'chai';
+import Hexo from 'hexo';
+import moment from 'moment';
+import path from 'path';
+import postPermalinkFilter from '../../../lib/plugins/filter/post_permalink';
+
+// Usage: `mocha test/scripts/filters/filepath_permalink.ts --require ts-node/register`
+should(); // <-- This line is essential to enable `.should` assertions
+
+type PostPermalinkFilterParams = Parameters<typeof postPermalinkFilter>;
+type PostPermalinkFilterReturn = ReturnType<typeof postPermalinkFilter>;
+
+describe('Hexo Filter (TypeScript)', () => {
+  // Initialize hexo
+  const hexo = new Hexo(path.join(__dirname, '../../fixtures'), { silent: true });
+  // Initialize permalink parser
+  const postPermalink: (...args: PostPermalinkFilterParams) => PostPermalinkFilterReturn
+    = postPermalinkFilter.bind(hexo);
+  // Initialize post model
+  const Post = hexo.model('Post');
+
+  before(async () => {
+    // Load configurations
+    await hexo.init();
+  });
+
+  it(':filepath.html', async () => {
+    hexo.config.permalink = ':filepath.html';
+
+    const posts = await Post.insert([
+      {
+        source: 'foo.md',
+        slug: 'foo',
+        date: moment('2014-01-02')
+      },
+      {
+        source: '2025/01/my-foo.md',
+        slug: '2025/01/my-foo',
+        date: moment('2014-01-04')
+      }
+    ]);
+    postPermalink(posts[0]).should.eql('foo.html');
+    postPermalink(posts[1]).should.eql('2025/01/my-foo.html');
+  });
+
+  it('filepath - inside folder', async () => {
+    hexo.config.permalink = ':year/:month/:day/:filepath/';
+
+    const post = await Post.insert({
+      source: 'sub/2025-05-06-my-new-post.md',
+      slug: '2025-05-06-my-new-post',
+      title: 'My New Post',
+      date: moment('2025-05-06')
+    });
+    postPermalink(post).should.eql('2025/05/06/sub/2025-05-06-my-new-post/');
+    Post.removeById(post._id);
+  });
+
+  it('filepath - within spaces', async () => {
+    hexo.config.permalink = ':year/:month/:filepath.html';
+
+    const post = await Post.insert({
+      source: 'space folder/my new post with space.md',
+      slug: 'space folder/my new post with space',
+      title: 'My New Post With Space',
+      date: moment('2025-10-07')
+    });
+    postPermalink(post).should.eql('2025/10/space folder/my new post with space.html');
+    Post.removeById(post._id);
+  });
+
+  it('filepath - with language', async () => {
+    hexo.config.permalink = 'posts/:lang/:filepath/';
+    hexo.config.permalink_defaults = { lang: 'en' };
+
+    const posts = await Post.insert([
+      {
+        source: 'my-new-post.md',
+        slug: 'my-new-post',
+        title: 'My New Post1'
+      },
+      {
+        source: 'my-new-fr-post.md',
+        slug: 'my-new-fr-post',
+        title: 'My New Post2',
+        lang: 'fr'
+      }
+    ]);
+    postPermalink(posts[0]).should.eql('posts/en/my-new-post/');
+    postPermalink(posts[1]).should.eql('posts/fr/my-new-fr-post/');
+  });
+
+  it('permalink - should override everything', async () => {
+    hexo.config.permalink = ':year/:month/:day/:filepath/';
+
+    const posts = await Post.insert([{
+      source: 'my-new-post.md',
+      slug: 'hexo/permalink-test-filepath',
+      __permalink: 'hexo/permalink-test-filepath',
+      title: 'Permalink Test',
+      date: moment('2014-01-02')
+    }, {
+      source: 'another-new-post.md',
+      slug: '/hexo-hexo/permalink-test-2',
+      __permalink: '/hexo-hexo/permalink-test-2',
+      title: 'Permalink Test',
+      date: moment('2014-01-02')
+    }]);
+
+    postPermalink(posts[0]).should.eql('/hexo/permalink-test-filepath');
+    postPermalink(posts[1]).should.eql('/hexo-hexo/permalink-test-2');
+
+    await Promise.all(posts.map(post => Post.removeById(post._id)));
+  });
+});


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

This PR introduces or adjusts the `:filepath` permalink pattern to replicate the previous behavior of `:title`, which was based on the post's file name and path under `source/_posts/`.

#### ✅ What this PR does:

-   Restores old permalink behavior via `:filepath`
-   Enables backward compatibility for existing blogs without requiring manual changes to thousands of posts
-   Preserves legacy URLs and helps prevent SEO regressions or broken external links

#### 🧪 How to test:

1.  Add the following to your `_config.yml`:
    ```yml
    permalink: :filepath/
    ```
2. Make sure your posts inside `source/_posts/` generate the expected permalinks matching the file name.

#### 📌 Related Issue / Discussion:

-   [Original issue and discussion](https://github.com/orgs/hexojs/discussions/5630)

-   [Issue describing permalink regression](https://github.com/hexojs/hexo/issues/5658)

#### 🙏 Note:

This change helps long-time users maintain their blog structure and avoid unnecessary mass edits due to the breaking permalink change. Especially for blogger/wordpress users who have migrated to Hexo.

### 🔍 Test Results:

-   **Dev repo (Hexo fork):**\
    <https://github.com/dimaslanjaka/hexo/tree/603a01549d895b60994e7b455574c5c915b4e35c>

-   **Test unit repo:**\
    <https://github.com/dimaslanjaka/hexo-theme-unit-test/tree/monorepo>

-   **Test result output (gh-pages):**\
    <https://github.com/dimaslanjaka/hexo-theme-unit-test/tree/gh-pages>

-   **Live site preview:**\
    <https://www.webmanajemen.com/hexo-theme-unit-test/>

All posts render with the expected permalink structure using the `:filepath` pattern.

Issue resolved: https://github.com/hexojs/hexo/issues/5658

## Screenshots

![image](https://github.com/user-attachments/assets/e8619603-1c39-4f30-bd8e-8c2e0634df0b)
![image](https://github.com/user-attachments/assets/39e54658-d1d5-4615-a074-671e59376777)


## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
