### PR TITLE
perf: faster text-table

### DIFF
--- a/lib/plugins/console/list/category.ts
+++ b/lib/plugins/console/list/category.ts
@@ -1,5 +1,5 @@
 import { underline } from 'picocolors';
-import table from 'text-table';
+import table from 'fast-text-table';
 import { stringLength } from './common';
 import type Hexo from '../../../hexo';
 import type { CategorySchema } from '../../../types';

--- a/lib/plugins/console/list/page.ts
+++ b/lib/plugins/console/list/page.ts
@@ -1,5 +1,5 @@
 import { magenta, underline, gray } from 'picocolors';
-import table from 'text-table';
+import table from 'fast-text-table';
 import { stringLength } from './common';
 import type Hexo from '../../../hexo';
 import type { PageSchema } from '../../../types';

--- a/lib/plugins/console/list/post.ts
+++ b/lib/plugins/console/list/post.ts
@@ -1,5 +1,5 @@
 import { gray, magenta, underline } from 'picocolors';
-import table from 'text-table';
+import table from 'fast-text-table';
 import { stringLength } from './common';
 import type Hexo from '../../../hexo';
 import type { PostSchema } from '../../../types';

--- a/lib/plugins/console/list/tag.ts
+++ b/lib/plugins/console/list/tag.ts
@@ -1,5 +1,5 @@
 import { magenta, underline } from 'picocolors';
-import table from 'text-table';
+import table from 'fast-text-table';
 import { stringLength } from './common';
 import type Hexo from '../../../hexo';
 import type { TagSchema } from '../../../types';

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "abbrev": "^3.0.0",
     "archy": "^1.0.0",
     "bluebird": "^3.7.2",
+    "fast-text-table": "^1.0.1",
     "hexo-cli": "^4.3.2",
     "hexo-front-matter": "^4.2.1",
     "hexo-fs": "^5.0.0",
@@ -58,7 +59,6 @@
     "picocolors": "^1.1.1",
     "pretty-hrtime": "^1.0.3",
     "strip-ansi": "^6.0.0",
-    "text-table": "^0.2.0",
     "tildify": "^2.0.0",
     "titlecase": "^1.1.3",
     "warehouse": "^6.0.0"
@@ -74,7 +74,6 @@
     "@types/node": "^20.17.6",
     "@types/nunjucks": "^3.2.2",
     "@types/sinon": "^17.0.3",
-    "@types/text-table": "^0.2.4",
     "0x": "^5.1.2",
     "c8": "^9.0.0",
     "chai": "^4.3.6",


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

replace text-table with [fast-text-table](https://github.com/D-Sketon/fast-text-table) I created, which is smaller and faster.

benchmark
```
clk: ~4.18 GHz
cpu: 13th Gen Intel(R) Core(TM) i5-13400F
runtime: node 24.1.0 (x64-win32)

benchmark                   avg (min … max) p75 / p99    (min … top 1%)
------------------------------------------- -------------------------------
• table - small dataset
------------------------------------------- -------------------------------
fast-text-table                4.99 µs/iter   4.87 µs  █▂
                        (4.67 µs … 5.95 µs)   5.92 µs ▅██▇▂▂▁▁▁▁▁▁▁▁▁▁▃▃▄▃▂
                  gc(  2.41 ms …   4.42 ms)  13.29 kb ( 13.25 kb… 13.37 kb)

text-table                    20.23 µs/iter  20.24 µs        ██
                      (19.48 µs … 21.52 µs)  21.01 µs █▁▁█▁█▁████▁▁▁█▁▁▁▁▁█
                  gc(  2.47 ms …   4.59 ms)   3.13 kb (  3.08 kb…  3.17 kb)

summary
  fast-text-table
   4.05x faster than text-table

• table - middle dataset
------------------------------------------- -------------------------------
fast-text-table              263.47 µs/iter 276.20 µs    ▇▆ █▂
                    (194.60 µs … 465.30 µs) 436.00 µs ▂▂███▆██▃▄▃▂▂▃▂▁▁▁▁▁▁
                  gc(  2.29 ms …   5.08 ms) 543.81 kb (210.00 kb…801.07 kb)

text-table                     7.05 ms/iter   7.16 ms    █ ▄ ▆▃       ▄
                        (6.82 ms … 7.39 ms)   7.33 ms ▄▆▇███▆██▇█▇▇▆▆▆█▂▅▅▂
                  gc(  2.27 ms …   2.99 ms)   1.89 mb (  1.89 mb…  1.89 mb)

summary
  fast-text-table
   26.76x faster than text-table

• table - large dataset
------------------------------------------- -------------------------------
fast-text-table               10.39 ms/iter  10.51 ms  ▂   ▅█ ▂▂
                      (10.01 ms … 11.01 ms)  10.93 ms ▂█▇▃▄██▇██▆▆▃▂▇▁▆▂▃▃▃
                  gc(  2.32 ms …   3.02 ms)  34.06 mb ( 34.03 mb… 34.14 mb)

text-table                      5.43 s/iter    5.45 s     █
                          (5.38 s … 5.53 s)    5.47 s █▁▁██▁█▁▁█▁█▁▁█▁▁█▁██
                  gc(  2.64 ms …   3.78 ms)  75.76 mb ( 75.76 mb… 75.76 mb)

summary
  fast-text-table
   523.01x faster than text-table
```

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
