### PR TITLE
Unit tests for displayPath function

### DIFF
--- a/lib/hexo/load_plugins.ts
+++ b/lib/hexo/load_plugins.ts
@@ -4,7 +4,7 @@ import Promise from 'bluebird';
 import { magenta } from 'picocolors';
 import type Hexo from './index';
 
-export = (ctx: Hexo): Promise<void[][]> => {
+export default function loadPlugins(ctx: Hexo): Promise<void[][]> {
   if (!ctx.env.init || ctx.env.safe) return;
 
   return loadModules(ctx).then(() => loadScripts(ctx));
@@ -77,6 +77,7 @@ function loadScripts(ctx: Hexo): Promise<void[][]> {
   }));
 }
 
-function displayPath(path: string, baseDirLength: number): string {
+//EXPORTING displayPath FUNCTION FOR TESTING
+export function displayPath(path: string, baseDirLength: number): string {
   return magenta(path.substring(baseDirLength));
 }

--- a/test/scripts/hexo/displayPath.ts
+++ b/test/scripts/hexo/displayPath.ts
@@ -1,0 +1,37 @@
+//NEW UNIT TEST FOR displayPath FUNCTION
+import { magenta } from 'picocolors';
+import chai from 'chai';
+import loadPlugins, { displayPath } from '../../../lib/hexo/load_plugins';
+
+const should = chai.should();
+
+describe('load_plugins', () => {
+  describe('displayPath', () => {
+    it('should return relative path with magenta formatting', () => {
+      const fullPath = '/home/user/project/scripts/test.js';
+      const baseDirLength = '/home/user/project/'.length;
+      const expected = magenta('scripts/test.js');
+
+      const result = displayPath(fullPath, baseDirLength);
+      result.should.equal(expected);
+    });
+
+    it('should handle Windows paths', () => {
+      const fullPath = 'C:\\project\\scripts\\test.js';
+      const baseDirLength = 'C:\\project\\'.length;
+      const expected = magenta('scripts\\test.js');
+
+      const result = displayPath(fullPath, baseDirLength);
+      result.should.equal(expected);
+    });
+
+    it('should handle paths at base directory level', () => {
+      const fullPath = '/project/config.js';
+      const baseDirLength = '/project/'.length;
+      const expected = magenta('config.js');
+
+      const result = displayPath(fullPath, baseDirLength);
+      result.should.equal(expected);
+    });
+  });
+});


### PR DESCRIPTION
## 📚 Class Assignment: Adding Unit Tests
**Assignment Context:** This pull request fulfills a university requirement to add unit tests to an open-source project.

## Description
Added unit tests for the `displayPath` utility function from `.\lib\hexo\load_plugins.ts`. The tests cover Unix and Windows paths, and base directory edge cases.

## Changes
- new file with the actual unit test at `.\test\scripts\hexo\displayPath.ts`
- changed the `displayPath` function to be exported
- modified module export in `load_plugins.ts`: 
<img width="1518" height="392" alt="image" src="https://github.com/user-attachments/assets/a6836249-2373-436b-b9d7-f1776c6fba80" />

## !! Known Issues !!
- the module export modification breaks existing imports and causes some tests to fail.

## Running tests
- Unit test: `npm test -- --grep "displayPath"` -> PASS
- all tests: `npm test` -> FAIL (some)


-----------------------------------------------------------
**Note for maintainers**: This is a learning exercise, and the changes proposed are currently deemed unsuitable for merging. Any constructive feedback and guidance on the proper approach is highly appreciated and welcomed.