### PR TITLE
feat: add configurable image auto-copy for VSCode markdown editing

### DIFF
--- a/lib/hexo/default_config.ts
+++ b/lib/hexo/default_config.ts
@@ -84,6 +84,9 @@ export = {
   // ignore files from processing
   ignore: [] as string[],
 
+  // VS Code integration
+  use_vscode_edit_md: false,
+
   // Category & Tag
   meta_generator: true
 };

--- a/lib/plugins/generator/index.ts
+++ b/lib/plugins/generator/index.ts
@@ -6,4 +6,5 @@ export = (ctx: Hexo) => {
   generator.register('asset', require('./asset'));
   generator.register('page', require('./page'));
   generator.register('post', require('./post'));
+  generator.register('posts_image', require('./posts_image'));
 };

--- a/lib/plugins/generator/posts_image.ts
+++ b/lib/plugins/generator/posts_image.ts
@@ -1,0 +1,81 @@
+import { join } from 'path';
+import { exists, stat, listDir, createReadStream } from 'hexo-fs';
+import Promise from 'bluebird';
+import type Hexo from '../../hexo';
+import type { BaseGeneratorReturn } from '../../types';
+
+interface PostsImageGenerator extends BaseGeneratorReturn {
+    data: {
+        modified: boolean;
+        data: () => any;
+    }
+}
+
+/**
+ * Generator for copying \source\_posts\image folder to public directory
+ * Only works when use_vscode_edit_md is enabled in config
+ */
+function postsImageGenerator(this: Hexo): Promise<PostsImageGenerator[]> {
+  // Check if use_vscode_edit_md is enabled
+  if (!this.config.use_vscode_edit_md) {
+    return Promise.resolve([]);
+  }
+
+  const sourceDir = this.source_dir;
+  const postsImageDir = join(sourceDir, '_posts', 'image');
+
+  // Check if the image directory exists
+  return exists(postsImageDir).then(exist => {
+    if (!exist) {
+      return [];
+    }
+
+    return stat(postsImageDir).then(stats => {
+      if (!stats.isDirectory()) {
+        return [];
+      }
+
+      // List all files in the image directory recursively
+      return listDirRecursive(postsImageDir);
+    });
+  }).then(files => {
+    // Generate route for each file
+    return files.map(filePath => {
+      const relativePath = filePath.substring(postsImageDir.length + 1);
+      const publicPath = join('image', relativePath).replace(/\\/g, '/');
+
+      return {
+        path: publicPath,
+        data: {
+          modified: true,
+          data: () => createReadStream(filePath)
+        }
+      };
+    });
+  }).catch(err => {
+    // Log error but don't fail the build
+    this.log.debug('Posts image generator error:', err);
+    return [];
+  });
+}
+
+/**
+ * Recursively list all files in a directory
+ */
+function listDirRecursive(dir: string): Promise<string[]> {
+  return listDir(dir).then(items => {
+    return Promise.map(items, item => {
+      const fullPath = join(dir, item);
+      return stat(fullPath).then(stats => {
+        if (stats.isDirectory()) {
+          return listDirRecursive(fullPath);
+        }
+        return [fullPath];
+      });
+    });
+  }).then(results => {
+    return ([] as string[]).concat(...results);
+  });
+}
+
+export = postsImageGenerator;

--- a/test/scripts/generators/posts_image.ts
+++ b/test/scripts/generators/posts_image.ts
@@ -1,0 +1,82 @@
+import { join } from 'path';
+import { writeFile, mkdirs, rmdir } from 'hexo-fs';
+import Hexo from '../../../lib/hexo';
+import chai from 'chai';
+chai.should();
+
+const postsImageGenerator = require('../../../lib/plugins/generator/posts_image');
+
+describe('posts_image generator', () => {
+  const hexo = new Hexo(join(__dirname, 'posts_image_test'), { silent: true });
+
+  before(async () => {
+    await hexo.init();
+  });
+
+  after(async () => {
+    await rmdir(hexo.base_dir);
+  });
+
+  beforeEach(() => {
+    hexo.config.use_vscode_edit_md = false;
+  });
+
+  it('should not generate routes when use_vscode_edit_md is false', async () => {
+    hexo.config.use_vscode_edit_md = false;
+    const result = await postsImageGenerator.call(hexo);
+    result.should.be.an('array').that.is.empty;
+  });
+
+  it('should not generate routes when image directory does not exist', async () => {
+    hexo.config.use_vscode_edit_md = true;
+    const result = await postsImageGenerator.call(hexo);
+    result.should.be.an('array').that.is.empty;
+  });
+
+  it('should generate routes when use_vscode_edit_md is true and image directory exists', async () => {
+    hexo.config.use_vscode_edit_md = true;
+
+    // Create test image directory and file
+    const imageDir = join(hexo.source_dir, '_posts', 'image');
+    const testImagePath = join(imageDir, 'test.jpg');
+
+    await mkdirs(imageDir);
+    await writeFile(testImagePath, 'fake image content');
+
+    try {
+      const result = await postsImageGenerator.call(hexo);
+      result.should.be.an('array').that.is.not.empty;
+      result[0].should.have.property('path', 'image/test.jpg');
+      result[0].should.have.property('data');
+      result[0].data.should.have.property('modified', true);
+      result[0].data.should.have.property('data').that.is.a('function');
+    } finally {
+      // Cleanup
+      await rmdir(imageDir);
+    }
+  });
+
+  it('should handle nested directories', async () => {
+    hexo.config.use_vscode_edit_md = true;
+
+    // Create test nested image directory and file
+    const imageDir = join(hexo.source_dir, '_posts', 'image');
+    const nestedDir = join(imageDir, 'subfolder');
+    const testImagePath = join(nestedDir, 'nested.png');
+
+    await mkdirs(nestedDir);
+    await writeFile(testImagePath, 'fake nested image content');
+
+    try {
+      const result = await postsImageGenerator.call(hexo);
+      result.should.be.an('array').that.is.not.empty;
+
+      const nestedImage = result.find(r => r.path === 'image/subfolder/nested.png');
+      nestedImage.should.not.be.undefined;
+      nestedImage.should.have.property('data');
+    } finally {
+      // Cleanup
+      await rmdir(imageDir);
+    }
+  });
+});


### PR DESCRIPTION
Add use_vscode_edit_md config to enable automatic copying of images from source/_posts/image to public/image, preventing "Cannot GET /image/" errors when pasting images in VSCode. Disabled by default for

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?
Adds a `use_vscode_edit_md` configuration option to enable automatic copying of images from `source/_posts/image` to `public/image` when processing markdown files. This addresses the "Cannot GET /image/" errors that occur when pasting images in VSCode.

- The feature is disabled by default to maintain backward compatibility
- When enabled, it ensures images referenced in markdown posts are properly copied to the public directory
- Solves the common workflow issue where images pasted via VSCode's markdown editor are saved in the post's folder but not deployed


## Screenshots
<img width="1738" height="557" alt="image" src="https://github.com/user-attachments/assets/c116caf3-20f3-4e85-ba30-e5de51d50ba4" />
<img width="1738" height="531" alt="image" src="https://github.com/user-attachments/assets/535df131-7951-4ac3-aafa-296cd0a48312" />



## Pull request tasks

- [ x] Add test cases for the changes.
- [ x] Passed the CI test.
