### PR TITLE
fix(regression): remove overly strict invalid tag format check in Swig parser

### DIFF
--- a/lib/hexo/post.ts
+++ b/lib/hexo/post.ts
@@ -147,14 +147,8 @@ class PostRenderEscape {
               swig_string_quote = '';
             }
           }
-          // {% } or {% %
-          if (((char !== '%' && next_char === '}') || (char === '%' && next_char !== '}')) && swig_string_quote === '') {
-            // From swig back to plain text
-            swig_tag_name = '';
-            state = STATE_PLAINTEXT;
-            output.append(`{%${buffer}${char}`);
-            buffer = '';
-          } else if (char === '%' && next_char === '}' && swig_string_quote === '') { // From swig back to plain text
+          // Check for valid tag ending %}
+          if (char === '%' && next_char === '}' && swig_string_quote === '') { // From swig back to plain text
             idx++;
             if (swig_tag_name !== '' && str.includes(`end${swig_tag_name}`)) {
               state = STATE_SWIG_FULL_TAG;


### PR DESCRIPTION

<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

The previous condition `((char !== '%' && next_char === '}') || (char === '%' && next_char !== '}'))` (https://github.com/hexojs/hexo/pull/5618) was too restrictive and incorrectly identified valid tags containing '%' characters (like `{% include 11% 22 %}`) as invalid format.

This change removes the problematic validation and relies on proper tag ending detection (`%}`) and the existing backtracking mechanism for handling truly malformed tags.

## Screenshots



## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
