### PR TITLE
perf: reduce ObjectAssign overhead

### DIFF
--- a/lib/plugins/helper/partial.ts
+++ b/lib/plugins/helper/partial.ts
@@ -15,7 +15,7 @@ export = (ctx: Hexo) => function partial(this: LocalsType, name: string, locals?
   const currentView = this.filename.substring(viewDir.length);
   const path = join(dirname(currentView), name);
   const view = ctx.theme.getView(path) || ctx.theme.getView(name);
-  const viewLocals = { layout: false };
+  const viewLocals: Record<string, any> = {};
 
   if (!view) {
     throw new Error(`Partial ${name} does not exist. (in ${currentView})`);


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Interestingly, just modifying this single line can significantly reduce the overhead of ObjectAssign.

## Screenshots
8x hexo-many-posts + hexo-theme-reimu

before
<img width="805" height="173" alt="{5CD5CAD9-97B6-4AE7-9DC7-CBD69F5FE496}" src="https://github.com/user-attachments/assets/3211d7c3-0c49-4500-a87d-1fcbe067f264" />

after
<img width="961" height="163" alt="{DB9C014C-0B5B-4420-90B7-A790DB641960}" src="https://github.com/user-attachments/assets/d3f82cf3-1333-4a78-97fd-c16ec88249da" />


## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
