### PR TITLE
perf: calculate permalink field only when needed

### DIFF
--- a/lib/plugins/filter/post_permalink.ts
+++ b/lib/plugins/filter/post_permalink.ts
@@ -3,6 +3,8 @@ import { basename } from 'path';
 import type Hexo from '../../hexo';
 import type { PostSchema } from '../../types';
 
+import { defineLazyProperty } from 'foxts/define-lazy-property';
+
 let permalink: Permalink;
 
 function postPermalinkFilter(this: Hexo, data: PostSchema): string {
@@ -19,35 +21,73 @@ function postPermalinkFilter(this: Hexo, data: PostSchema): string {
     return __permalink;
   }
 
-  const hash = slug && date
-    ? createSha1Hash().update(slug + date.unix().toString()).digest('hex').slice(0, 12)
-    : null;
   const meta = {
     id: id || _id,
     title: slug,
-    name: typeof slug === 'string' ? basename(slug) : '',
-    post_title: slugize(title, {transform: 1}),
-    year: date.format('YYYY'),
-    month: date.format('MM'),
-    day: date.format('DD'),
-    hour: date.format('HH'),
-    minute: date.format('mm'),
-    second: date.format('ss'),
-    i_month: date.format('M'),
-    i_day: date.format('D'),
-    timestamp: date.format('X'),
-    hash,
-    category: config.default_category
+    name: typeof slug === 'string' ? basename(slug) : ''
   };
+
+  defineLazyProperty(
+    meta, 'hash',
+    () => {
+      return slug && date
+        ? createSha1Hash().update(slug + date.unix().toString()).digest('hex').slice(0, 12)
+        : null;
+    }
+  );
+  defineLazyProperty(
+    meta, 'post_title',
+    () => slugize(title, { transform: 1 })
+  );
+  defineLazyProperty(
+    meta, 'year',
+    () => date.format('YYYY')
+  );
+  defineLazyProperty(
+    meta, 'month',
+    () => date.format('MM')
+  );
+  defineLazyProperty(
+    meta, 'day',
+    () => date.format('DD')
+  );
+  defineLazyProperty(
+    meta, 'hour',
+    () => date.format('HH')
+  );
+  defineLazyProperty(
+    meta, 'minute',
+    () => date.format('mm')
+  );
+  defineLazyProperty(
+    meta, 'second',
+    () => date.format('ss')
+  );
+  defineLazyProperty(
+    meta, 'i_month',
+    () => date.format('M')
+  );
+  defineLazyProperty(
+    meta, 'i_day',
+    () => date.format('D')
+  );
+  defineLazyProperty(
+    meta, 'timestamp',
+    () => date.format('X')
+  );
+
+  defineLazyProperty(
+    meta, 'categories',
+    () => {
+      if (data.categories.length) {
+        return data.categories.last().slug;
+      }
+      return config.default_category;
+    }
+  );
 
   if (!permalink || permalink.rule !== config.permalink) {
     permalink = new Permalink(config.permalink, {});
-  }
-
-  const { categories } = data;
-
-  if (categories.length) {
-    meta.category = categories.last().slug;
   }
 
   const keys = Object.keys(data);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "bluebird": "^3.7.2",
     "fast-archy": "^1.0.0",
     "fast-text-table": "^1.0.1",
+    "foxts": "^4.3.1",
     "hexo-cli": "^4.3.2",
     "hexo-front-matter": "^4.2.1",
     "hexo-fs": "^5.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "moduleResolution": "node16",
     "target": "es2020",
     "sourceMap": true,
     "outDir": "dist",


### PR DESCRIPTION
## What does it do?

We don't necessarily need to calculate all potentially available fields of the permalink in advance. I myself never use `hash` or any dates in my permalink.

We should not have to deal with moment.js or sha1 overhead. We can actually calculate those expensive fields on demand.

I use `foxts` because I happen to have this exist in my util library. But I can always copy the implementation to `hexo-util` if needed.

## Screenshots



## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
