### PR TITLE
chore: use object format for repository field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,10 @@
     "bin/"
   ],
   "types": "./dist/hexo/index.d.ts",
-  "repository": "hexojs/hexo",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hexojs/hexo.git"
+  },
   "homepage": "https://hexo.io/",
   "funding": {
     "type": "opencollective",


### PR DESCRIPTION
## What does it do?

Update a `package.json` repository field to object format. While it's unclear when this format became available, npm documentation has used it since at least [v6](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository).


## Screenshots

N/A

## Pull request tasks

- [ ] Add test cases for the changes.
- [x] Passed the CI test.
