### PR TITLE
fix: update ESLint test configuration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 const config = require('eslint-config-hexo/ts');
-const testConfig = require('eslint-config-hexo/test');
+const testConfig = require('eslint-config-hexo/ts-test');
 
 module.exports = [
   // Configurations applied globally
@@ -7,10 +7,9 @@ module.exports = [
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 0,
-      '@typescript-eslint/no-var-requires': 0,
       '@typescript-eslint/no-require-imports': 0,
-      'n/no-missing-require': 0,
       'n/no-missing-import': 0,
+      'n/no-missing-require': 0,
       '@typescript-eslint/no-unused-vars': [
         'error', {
           'argsIgnorePattern': '^_'
@@ -19,15 +18,15 @@ module.exports = [
     }
   },
   // Configurations applied only to test files
-  {
-    files: [
-      'test/**/*.ts'
-    ],
-    languageOptions: {
-      ...testConfig.languageOptions
-    },
+  ...testConfig.map(config => ({
+    ...config,
+    files: ['test/**/*.ts'],
     rules: {
-      ...testConfig.rules,
+      ...config.rules,
+      '@typescript-eslint/no-explicit-any': 0,
+      '@typescript-eslint/no-require-imports': 0,
+      'n/no-missing-require': 0,
+      'n/no-missing-import': 0,
       '@typescript-eslint/ban-ts-comment': 0,
       '@typescript-eslint/no-unused-expressions': 0,
       '@typescript-eslint/no-unused-vars': [
@@ -38,5 +37,5 @@ module.exports = [
         }
       ]
     }
-  }
+  }))
 ];

--- a/lib/box/file.ts
+++ b/lib/box/file.ts
@@ -22,7 +22,6 @@ class File {
   /**
    * File type. The value can be create, update, skip, delete.
    */
-  // eslint-disable-next-line no-use-before-define
   public type: typeof File.TYPE_CREATE | typeof File.TYPE_UPDATE | typeof File.TYPE_SKIP | typeof File.TYPE_DELETE;
   static TYPE_CREATE: 'create';
   static TYPE_UPDATE: 'update';

--- a/lib/hexo/index.ts
+++ b/lib/hexo/index.ts
@@ -51,7 +51,6 @@ const routeCache = new WeakMap();
 
 const castArray = (obj: any) => { return Array.isArray(obj) ? obj : [obj]; };
 
-// eslint-disable-next-line no-use-before-define
 const mergeCtxThemeConfig = (ctx: Hexo) => {
   // Merge hexo.config.theme_config into hexo.theme.config before post rendering & generating
   // config.theme_config has "_config.[theme].yml" merged in load_theme_config.js
@@ -60,7 +59,6 @@ const mergeCtxThemeConfig = (ctx: Hexo) => {
   }
 };
 
-// eslint-disable-next-line no-use-before-define
 const createLoadThemeRoute = function(generatorResult: BaseGeneratorReturn, locals: LocalsType, ctx: Hexo) {
   const { log, theme } = ctx;
   const { path, cache: useCache } = locals;


### PR DESCRIPTION
`testConfig` is an array, so `testConfig.rules` and `testConfig.languageOptions` will be undefined.
We may need to modify the ESLint configurations in other repositories as well.