### PR TITLE
ci: enable trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish Package
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #6.0.1
+
+      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f #6.1.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Verify tag version
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "Error: Tag version (v$TAG_VERSION) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+          echo "Version matched: $PKG_VERSION"
+
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm publish


### PR DESCRIPTION
## What does it do?

This PR enables OIDC (OpenID Connect) publishing to npm using Trusted Publishing. I have already configured the OIDC publishing settings on the npm package side. Please see below image:

## Screenshots

<img width="1293" height="706" alt="hexo-trusted" src="https://github.com/user-attachments/assets/67ce4ce7-7480-4f77-9528-5f50611c1da4" />

## Pull request tasks

- [ ] Add test cases for the changes.
- [ ] Passed the CI test.
