### PR TITLE
fix(test): add missing await to unlink in save_database test

### DIFF
--- a/test/scripts/filters/save_database.ts
+++ b/test/scripts/filters/save_database.ts
@@ -18,7 +18,7 @@ describe('Save database', () => {
     const exist = await exists(dbPath);
     exist.should.be.true;
 
-    unlink(dbPath);
+    await unlink(dbPath);
   });
 
   it('do nothing if hexo is not initialized', async () => {


### PR DESCRIPTION
## What does it do?

### Summary
- Fix race condition in `test/scripts/filters/save_database.ts` where `unlink(dbPath)` was not awaited
- The missing `await` caused the "do nothing if hexo is not initialized" test to intermittently fail because the database file from the previous test had not been deleted yet

### Failure log before fix

```
4. Save database
  do nothing if hexo is not initialized:
 AssertionError: expected true to be false
  - expected - actual
 -true
 +false
 at Context. (test/scripts/filters/save_database.ts:30:21)
```

### Test plan

- [x] Ran the test 5 times consecutively with no failures

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
