### PR TITLE
ci: pin actions to commit SHAs

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -24,9 +24,9 @@ jobs:
         node-version: ["20", "22", "24"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
@@ -44,9 +44,9 @@ jobs:
     env:
       comment_file: ".tmp-comment-flamegraph-node${{ matrix.node-version }}.md"
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
@@ -54,7 +54,7 @@ jobs:
       - name: Running profiling
         run: node test/benchmark.js --profiling
       - name: Publish flamegraph to https://${{ github.sha }}-${{ matrix.node-version }}-hexo.surge.sh/flamegraph.html
-        uses: dswistowski/surge-sh-action@v1
+        uses: dswistowski/surge-sh-action@2ef23bb28f7240e4922a44df1807022af43782bf #1.1.0
         with:
           domain: ${{ github.sha }}-${{ matrix.node-version }}-hexo.surge.sh
           project: ./.tmp-hexo-theme-unit-test/0x/
@@ -66,7 +66,7 @@ jobs:
         run: |
           echo "https://${{ github.sha }}-${{ matrix.node-version }}-hexo.surge.sh/flamegraph.html" > ${{env.comment_file}}
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #7.0.1
         if: ${{github.event_name == 'pull_request' }}
         with:
           retention-days: 1
@@ -82,7 +82,7 @@ jobs:
       - name: save PR number to file
         run: |
           echo -n "${{ github.event.number }}" > ${{env.pr_number_file}}
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a #7.0.1
         with:
           retention-days: 1
           name: comment-pr_number

--- a/.github/workflows/commenter.yml
+++ b/.github/workflows/commenter.yml
@@ -20,7 +20,7 @@ jobs:
     if: ${{github.event_name == 'pull_request_target'}}
     steps:
       - name: Comment PR - How to test
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 #3.0.4
         with:
           header: How to test
           message: |
@@ -44,7 +44,7 @@ jobs:
       comment_result: ".tmp-comment-flamegraph.md"
     steps:
       - name: download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c #8.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           run-id: ${{toJSON(github.event.workflow_run.id)}}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Comment PR - flamegraph
         if: ${{env.pr_number!=''}}
-        uses: marocchino/sticky-pull-request-comment@v3
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0 #3.0.4
         with:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
           number: ${{env.pr_number}}

--- a/.github/workflows/dependencies-review.yml
+++ b/.github/workflows/dependencies-review.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout Repository'
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #6.0.1
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
       - name: 'Dependencies Review'
         uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 #4.9.0
         with:

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,9 +21,9 @@ jobs:
   linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
       - name: Use Node.js 22
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #6.4.0
         with:
           node-version: "22"
       - name: Install Dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 #6.0.1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
 
-      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f #6.1.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #6.4.0
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/tester.yml
+++ b/.github/workflows/tester.yml
@@ -30,9 +30,9 @@ jobs:
         node-version: ["20", "22", "24"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -51,9 +51,9 @@ jobs:
         os: [ubuntu-latest]
         node-version: ["22"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install Dependencies
@@ -63,6 +63,6 @@ jobs:
         env:
           CI: true
       - name: Coveralls
-        uses: coverallsapp/github-action@master
+        uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b #2.3.6
         with:
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
## What does it do?

Pin all GitHub Actions in workflows to commit SHAs (with version comments) for supply-chain safety.

Initially I planned to pin only third-party actions. However, mixing pinned and unpinned references across the same workflow files would be confusing.                                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                                                                                                           
  To keep things consistent and reviewable, I decided to pin every uses: reference, including the official actions ones. Dependabot will automatically open update PRs for the pinned SHAs, so the ongoing maintenance cost stays low once this is set up. 

## Screenshots

N/A

## Pull request tasks

- [ ] ~~Add test cases for the changes.~~
- [x] Passed the CI test.
