### PR TITLE
ci: fix flamegraph preview publishing

### DIFF
--- a/.github/workflows/benchmark-post.yml
+++ b/.github/workflows/benchmark-post.yml
@@ -1,0 +1,67 @@
+name: Benchmark - Post Process
+
+on:
+  workflow_run:
+    workflows: ["Benchmark"]
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  profiling-preview:
+    if:
+      ${{ github.event_name == 'workflow_run' && github.event.workflow_run.event
+      == 'pull_request' && github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-slim
+    environment:
+      name: "profiling-preview"
+      url: ${{ steps.get_info.outputs.url }}
+      deployment: false
+    permissions:
+      contents: read
+      pull-requests: write # for marocchino/sticky-pull-request-comment to create or update PR comment
+    env:
+      comment_result: "tmp-comment-flamegraph.md"
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ toJSON( github.event.workflow_run.id ) }}
+          pattern: "comment-*"
+          merge-multiple: true
+
+      - name: Get PR info
+        id: get_info
+        run: |
+          pr_number=$(cat tmp-comment-pr_number)
+
+          echo "pr_number=$pr_number" | tee -a "$GITHUB_OUTPUT"
+          echo "url=https://$pr_number-pr-hexo.surge.sh/" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Publish flamegraph to ${{ steps.get_info.outputs.url }}
+        uses: dswistowski/surge-sh-action@v1
+        with:
+          domain: ${{ steps.get_info.outputs.url }}
+          project: ./flamegraph/
+          login: ${{ secrets.SURGE_LOGIN }}
+          token: ${{ secrets.SURGE_TOKEN }}
+
+      - name: Print full URLs
+        if: ${{ steps.get_info.outputs.pr_number!='' }}
+        run: |
+          echo "## Flamegraph" > ${{ env.comment_result }}
+          echo "" >> ${{ env.comment_result }}
+          cat tmp-comment-flamegraph-*.md >> ${{ env.comment_result }}
+
+          cat "${{ env.comment_result }}" | tee -a "$GITHUB_STEP_SUMMARY"
+
+      - name: Comment PR - flamegraph
+        if: ${{ steps.get_info.outputs.pr_number!='' }}
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ steps.get_info.outputs.pr_number }}
+          header: Flamegraph
+          path: ${{ env.comment_result }}

--- a/.github/workflows/benchmark-post.yml
+++ b/.github/workflows/benchmark-post.yml
@@ -20,6 +20,7 @@ jobs:
       url: ${{ steps.get_info.outputs.url }}
       deployment: false
     permissions:
+      actions: read # download artifacts from the triggering workflow run
       contents: read
       pull-requests: write # for marocchino/sticky-pull-request-comment to create or update PR comment
     env:
@@ -29,16 +30,50 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ toJSON( github.event.workflow_run.id ) }}
-          pattern: "comment-*"
+          pattern: "flamegraph-*"
+          path: ./flamegraph/
           merge-multiple: true
 
       - name: Get PR info
         id: get_info
-        run: |
-          pr_number=$(cat tmp-comment-pr_number)
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const run = context.payload.workflow_run;
+            let pullRequests = run.pull_requests || [];
 
-          echo "pr_number=$pr_number" | tee -a "$GITHUB_OUTPUT"
-          echo "url=https://$pr_number-pr-hexo.surge.sh/" | tee -a "$GITHUB_OUTPUT"
+            if (pullRequests.length !== 1) {
+              if (!run.head_repository || !run.head_branch) {
+                throw new Error(`Missing head repository metadata for workflow run ${run.id}`);
+              }
+
+              const response = await github.rest.pulls.list({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                state: 'all',
+                head: `${run.head_repository.owner.login}:${run.head_branch}`,
+                base: context.payload.repository.default_branch
+              });
+
+              pullRequests = response.data.filter(pullRequest => (
+                pullRequest.head.sha === run.head_sha
+                && pullRequest.base.repo.full_name === `${context.repo.owner}/${context.repo.repo}`
+                && pullRequest.base.ref === context.payload.repository.default_branch
+              ));
+            }
+
+            if (pullRequests.length !== 1) {
+              throw new Error(`Expected one pull request for workflow run ${run.id}, found ${pullRequests.length}`);
+            }
+
+            const prNumber = pullRequests[0].number;
+            if (!Number.isSafeInteger(prNumber) || prNumber < 1) {
+              throw new Error(`Invalid pull request number for workflow run ${run.id}`);
+            }
+
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('url', `https://${prNumber}-pr-hexo.surge.sh/`);
 
       - name: Publish flamegraph to ${{ steps.get_info.outputs.url }}
         uses: dswistowski/surge-sh-action@v1
@@ -49,16 +84,18 @@ jobs:
           token: ${{ secrets.SURGE_TOKEN }}
 
       - name: Print full URLs
-        if: ${{ steps.get_info.outputs.pr_number!='' }}
+        env:
+          preview_url: ${{ steps.get_info.outputs.url }}
         run: |
-          echo "## Flamegraph" > ${{ env.comment_result }}
-          echo "" >> ${{ env.comment_result }}
-          cat tmp-comment-flamegraph-*.md >> ${{ env.comment_result }}
-
-          cat "${{ env.comment_result }}" | tee -a "$GITHUB_STEP_SUMMARY"
+          {
+            echo "## Flamegraph"
+            echo ""
+            for node_version in 20 22 24; do
+              echo "${preview_url}${node_version}/flamegraph.html"
+            done
+          } | tee "${{ env.comment_result }}" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Comment PR - flamegraph
-        if: ${{ steps.get_info.outputs.pr_number!='' }}
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -42,7 +42,7 @@ jobs:
         node-version: ["20", "22", "24"]
       fail-fast: false
     env:
-      comment_file: ".tmp-comment-flamegraph-node${{ matrix.node-version }}.md"
+      comment_file: "tmp-comment-flamegraph-node${{ matrix.node-version }}.md"
     steps:
       - uses: actions/checkout@v6
       - name: Use Node.js ${{ matrix.node-version }}
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{github.event_name == 'pull_request' }}
     env:
-      pr_number_file: .tmp-comment-pr_number
+      pr_number_file: tmp-comment-pr_number
     steps:
       - name: save PR number to file
         run: |

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -53,25 +53,64 @@ jobs:
         run: npm install --silent
       - name: Running profiling
         run: node test/benchmark.js --profiling
-      - name: Publish flamegraph to https://${{ github.sha }}-${{ matrix.node-version }}-hexo.surge.sh/flamegraph.html
-        uses: dswistowski/surge-sh-action@v1
-        with:
-          domain: ${{ github.sha }}-${{ matrix.node-version }}-hexo.surge.sh
-          project: ./.tmp-hexo-theme-unit-test/0x/
-          login: ${{ secrets.SURGE_LOGIN }}
-          token: ${{ secrets.SURGE_TOKEN }}
 
-      - name: save comment to file
+      - name: mv flamegraph
+        run: |
+          mkdir -p ./flamegraph/
+          mv ./.tmp-hexo-theme-unit-test/0x/ ./flamegraph/${{ matrix.node-version }}/
+
+      - name: save URL to file
+        if: ${{github.event_name != 'pull_request' }}
+        run: |
+          echo "https://${{ github.sha }}-hexo.surge.sh/${{ matrix.node-version }}/flamegraph.html" > ${{env.comment_file}}
+
+      - name: save URL to file
         if: ${{github.event_name == 'pull_request' }}
         run: |
-          echo "https://${{ github.sha }}-${{ matrix.node-version }}-hexo.surge.sh/flamegraph.html" > ${{env.comment_file}}
+          echo "https://${{ github.event.number }}-pr-hexo.surge.sh/${{ matrix.node-version }}/flamegraph.html" > ${{env.comment_file}}
 
       - uses: actions/upload-artifact@v7
-        if: ${{github.event_name == 'pull_request' }}
         with:
           retention-days: 1
           name: comment-node${{ matrix.node-version }}
-          path: ${{env.comment_file}}
+          path: |
+            ${{env.comment_file}}
+            ./flamegraph/${{ matrix.node-version }}/
+
+  profiling-preview:
+    needs: profiling
+    if: ${{ github.event_name != 'pull_request' }}
+    runs-on: ubuntu-slim
+    environment:
+      name: 'profiling-preview'
+      url: ${{ env.url }}
+      deployment: false
+    permissions:
+      contents: read
+    env:
+      url: https://${{ github.sha }}-hexo.surge.sh/
+      comment_result: "tmp-comment-flamegraph.md"
+    steps:
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: "comment-*"
+          merge-multiple: true
+
+      - name: Publish flamegraph to ${{ env.url }}
+        uses: dswistowski/surge-sh-action@v1
+        with:
+          domain: ${{ env.url }}
+          project: ./flamegraph/
+          login: ${{ secrets.SURGE_LOGIN }}
+          token: ${{ secrets.SURGE_TOKEN }}
+
+      - name: Print full URLs
+        run: |
+          echo "## Flamegraph" > ${{ env.comment_result }}
+          echo "" >> ${{ env.comment_result }}
+          cat tmp-comment-flamegraph-*.md >> ${{ env.comment_result }}
+
+          cat "${{ env.comment_result }}" | tee -a "$GITHUB_STEP_SUMMARY"
 
   number:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -41,8 +41,6 @@ jobs:
         os: [ubuntu-latest]
         node-version: ["20", "22", "24"]
       fail-fast: false
-    env:
-      comment_file: "tmp-comment-flamegraph-node${{ matrix.node-version }}.md"
     steps:
       - uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
@@ -59,23 +57,11 @@ jobs:
           mkdir -p ./flamegraph/
           mv ./.tmp-hexo-theme-unit-test/0x/ ./flamegraph/${{ matrix.node-version }}/
 
-      - name: save URL to file
-        if: ${{github.event_name != 'pull_request' }}
-        run: |
-          echo "https://${{ github.sha }}-hexo.surge.sh/${{ matrix.node-version }}/flamegraph.html" > ${{env.comment_file}}
-
-      - name: save URL to file
-        if: ${{github.event_name == 'pull_request' }}
-        run: |
-          echo "https://${{ github.event.number }}-pr-hexo.surge.sh/${{ matrix.node-version }}/flamegraph.html" > ${{env.comment_file}}
-
       - uses: actions/upload-artifact@v7
         with:
           retention-days: 1
-          name: comment-node${{ matrix.node-version }}
-          path: |
-            ${{env.comment_file}}
-            ./flamegraph/${{ matrix.node-version }}/
+          name: flamegraph-node${{ matrix.node-version }}
+          path: ./flamegraph/
 
   profiling-preview:
     needs: profiling
@@ -89,11 +75,11 @@ jobs:
       contents: read
     env:
       url: https://${{ github.sha }}-hexo.surge.sh/
-      comment_result: "tmp-comment-flamegraph.md"
     steps:
       - uses: actions/download-artifact@v8
         with:
-          pattern: "comment-*"
+          pattern: "flamegraph-*"
+          path: ./flamegraph/
           merge-multiple: true
 
       - name: Publish flamegraph to ${{ env.url }}
@@ -106,23 +92,10 @@ jobs:
 
       - name: Print full URLs
         run: |
-          echo "## Flamegraph" > ${{ env.comment_result }}
-          echo "" >> ${{ env.comment_result }}
-          cat tmp-comment-flamegraph-*.md >> ${{ env.comment_result }}
-
-          cat "${{ env.comment_result }}" | tee -a "$GITHUB_STEP_SUMMARY"
-
-  number:
-    runs-on: ubuntu-latest
-    if: ${{github.event_name == 'pull_request' }}
-    env:
-      pr_number_file: tmp-comment-pr_number
-    steps:
-      - name: save PR number to file
-        run: |
-          echo -n "${{ github.event.number }}" > ${{env.pr_number_file}}
-      - uses: actions/upload-artifact@v7
-        with:
-          retention-days: 1
-          name: comment-pr_number
-          path: ${{env.pr_number_file}}
+          {
+            echo "## Flamegraph"
+            echo ""
+            for node_version in 20 22 24; do
+              echo "${{ env.url }}${node_version}/flamegraph.html"
+            done
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/commenter.yml
+++ b/.github/workflows/commenter.yml
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{github.event_name == 'workflow_run' && github.event.workflow_run.conclusion=='success'}}
     env:
-      comment_result: ".tmp-comment-flamegraph.md"
+      comment_result: "tmp-comment-flamegraph.md"
     steps:
       - name: download artifact
         uses: actions/download-artifact@v8
@@ -53,14 +53,14 @@ jobs:
 
       - name: get PR number
         run: |
-          echo "pr_number=$(cat .tmp-comment-pr_number)" >> "$GITHUB_ENV"
+          echo "pr_number=$(cat tmp-comment-pr_number)" >> "$GITHUB_ENV"
 
       - name: combime comment
         if: ${{env.pr_number!=''}}
         run: |
           echo "## Flamegraph" > ${{env.comment_result}}
           echo "" >> ${{env.comment_result}}
-          cat .tmp-comment-flamegraph-*.md >> ${{env.comment_result}}
+          cat tmp-comment-flamegraph-*.md >> ${{env.comment_result}}
 
       - name: Comment PR - flamegraph
         if: ${{env.pr_number!=''}}

--- a/.github/workflows/commenter.yml
+++ b/.github/workflows/commenter.yml
@@ -3,11 +3,6 @@ name: Commenter
 on:
   pull_request_target:
 
-  workflow_run:
-    workflows: ["Benchmark"]
-    types:
-      - completed
-
 permissions:
   contents: read
 
@@ -32,41 +27,3 @@ jobs:
             npm install
             npm test
             ```
-
-  comment-flamegraph:
-    name: Flamegraph
-    permissions:
-      pull-requests: write # for marocchino/sticky-pull-request-comment to create or update PR comment
-      actions: read # get artifact
-    runs-on: ubuntu-latest
-    if: ${{github.event_name == 'workflow_run' && github.event.workflow_run.conclusion=='success'}}
-    env:
-      comment_result: "tmp-comment-flamegraph.md"
-    steps:
-      - name: download artifact
-        uses: actions/download-artifact@v8
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          run-id: ${{toJSON(github.event.workflow_run.id)}}
-          pattern: "comment-*"
-          merge-multiple: true
-
-      - name: get PR number
-        run: |
-          echo "pr_number=$(cat tmp-comment-pr_number)" >> "$GITHUB_ENV"
-
-      - name: combime comment
-        if: ${{env.pr_number!=''}}
-        run: |
-          echo "## Flamegraph" > ${{env.comment_result}}
-          echo "" >> ${{env.comment_result}}
-          cat tmp-comment-flamegraph-*.md >> ${{env.comment_result}}
-
-      - name: Comment PR - flamegraph
-        if: ${{env.pr_number!=''}}
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          number: ${{env.pr_number}}
-          header: Flamegraph
-          path: ${{env.comment_result}}


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

since github action security policy strengthen, secrets could not be accessed in workflow 'on.pull_request'. 

- refact workflow publishing flamegraph to surge
  - publish PR's flamegraph to surge via trigger 'on.workflow_run'.
  - redesign projects' file structure and domain to reduce the usage of surge's projects.
    Previously one `sha` occupy 3 projects. Now one `sha` occupy 1 project (in main branch) or one PR occupy 1 project (in PR)
  - use `environment` to strengthen secrets' security.

Issue resolved: #5394 

## Screenshots



## Pull request tasks

- [ ] ~Add test cases for the changes.~
- [x] Passed the CI test.
- [ ] rebase #5772
