### PR TITLE
feat(prism): support line_number: 'inline' for per-block line number …

### DIFF
--- a/lib/plugins/filter/before_post_render/backtick_code_block.ts
+++ b/lib/plugins/filter/before_post_render/backtick_code_block.ts
@@ -158,6 +158,9 @@ export = (ctx: Hexo): (data: RenderData) => void => {
       // setup firstLineNumber;
       if (_args.includes('=')) {
         options.firstLineNumber = _args.split('=')[1] || 1;
+        if ((ctx.config.prismjs as any)?.line_number === 'inline') {
+          options.line_number = true;
+        }
       }
       content = ctx.extend.highlight.exec(ctx.config.syntax_highlighter, {
         context: ctx,

--- a/lib/plugins/highlight/prism.ts
+++ b/lib/plugins/highlight/prism.ts
@@ -7,13 +7,14 @@ let prismHighlight: typeof import('hexo-util').prismHighlight;
 module.exports = function(this: Hexo, code: string, options: HighlightOptions) {
   const prismjsCfg = this.config.prismjs || {} as any;
   const line_threshold = options.line_threshold || prismjsCfg.line_threshold || 0;
-  const shouldUseLineNumbers = typeof options.line_number === 'undefined' ? prismjsCfg.line_number : options.line_number;
+  const globalLineNumber = prismjsCfg.line_number === 'inline' ? false : prismjsCfg.line_number;
+  const shouldUseLineNumbers = typeof options.line_number === 'undefined' ? globalLineNumber : options.line_number;
   const surpassesLineThreshold = options.lines_length > line_threshold;
   const lineNumber = shouldUseLineNumbers && surpassesLineThreshold;
 
   const prismjsOptions = {
     caption: options.caption,
-    firstLine: options.firstLine as number,
+    firstLine: (options.firstLine ?? options.firstLineNumber) as number,
     isPreprocess: prismjsCfg.preprocess,
     lang: options.lang,
     lineNumber,

--- a/test/scripts/filters/backtick_code_block.ts
+++ b/test/scripts/filters/backtick_code_block.ts
@@ -1092,5 +1092,53 @@ describe('Backtick code block', () => {
       codeBlock(data);
       data.content.should.eql('<hexoPostRenderCodeBlock>' + expected + '</hexoPostRenderCodeBlock>');
     });
+
+    describe('line_number: \'inline\'', () => {
+      beforeEach(() => {
+        hexo.config.prismjs.line_number = 'inline' as any;
+      });
+
+      it('no = → no line numbers', () => {
+        const data = {
+          content: ['```js', code, '```'].join('\n')
+        };
+
+        codeBlock(data);
+
+        data.content.should.eql(
+          '<hexoPostRenderCodeBlock>'
+          + prism(code, { lang: 'js', lineNumber: false })
+          + '</hexoPostRenderCodeBlock>'
+        );
+      });
+
+      it('= → line numbers from 1', () => {
+        const data = {
+          content: ['```js=', code, '```'].join('\n')
+        };
+
+        codeBlock(data);
+
+        data.content.should.eql(
+          '<hexoPostRenderCodeBlock>'
+          + prism(code, { lang: 'js', lineNumber: true, firstLine: 1 })
+          + '</hexoPostRenderCodeBlock>'
+        );
+      });
+
+      it('=5 → line numbers from 5', () => {
+        const data = {
+          content: ['```js=5', code, '```'].join('\n')
+        };
+
+        codeBlock(data);
+
+        data.content.should.eql(
+          '<hexoPostRenderCodeBlock>'
+          + prism(code, { lang: 'js', lineNumber: true, firstLine: 5 })
+          + '</hexoPostRenderCodeBlock>'
+        );
+      });
+    });
   });
 });


### PR DESCRIPTION
功能： 支援 line_number: 'inline' 模式，透過 ```lang= 語法按 block 控制行號顯示

修改檔案：
- lib/plugins/highlight/prism.ts：line_number === 'inline' 時全域 fallback 改為 false，並支援 firstLineNumber 對應 firstLine
- lib/plugins/filter/before_post_render/backtick_code_block.ts：偵測 = 語法且 inline mode 時設 options.line_number = true
- test/scripts/filters/backtick_code_block.ts：新增三個測試 case

行為：

|  語法   |        結果         |
|---------|---------------------|
| ```js   | 不顯示行號          |
| ```js=  | 顯示行號，從第 1 行 |
| ```js=5 | 顯示行號，從第 5 行 |

