### PR TITLE
fix: reprocess future posts after publish date

### DIFF
--- a/lib/plugins/processor/post.ts
+++ b/lib/plugins/processor/post.ts
@@ -188,7 +188,7 @@ function processPost(ctx: Hexo, file: _File) {
     doc.setCategories(categories),
     doc.setTags(tags),
     scanAssetDir(ctx, doc)
-  ]));
+  ]).then(() => markFuturePostDirty(ctx, file, doc)));
 }
 
 function parseFilename(config: string, path: string) {
@@ -271,6 +271,19 @@ function shouldSkipAsset(ctx: Hexo, post: PostSchema, asset: Document<PostAssetS
   }
 
   return asset !== undefined; // skip already existing assets
+}
+
+function markFuturePostDirty(ctx: Hexo, file: _File, post: PostSchema) {
+  if (ctx.config.future || post.published === false || !post.date || post.date.valueOf() <= Date.now()) return;
+
+  const id = file.source.substring(ctx.base_dir.length).replace(/\\/g, '/');
+  const cache = ctx.model('Cache').findById(id);
+  if (!cache) return;
+
+  cache.hash = '';
+  cache.modified = 0;
+
+  return cache.save();
 }
 
 function processAsset(ctx: Hexo, file: _File) {

--- a/test/scripts/console/generate.ts
+++ b/test/scripts/console/generate.ts
@@ -348,7 +348,7 @@ describe('generate - future posts', () => {
         writeFile(join(hexo.source_dir, '_posts', 'scheduled.html'), [
           '---',
           'title: scheduled',
-          'date: 2099-01-01T00:01:00.000Z',
+          'date: 2098-12-31T18:31:00.000Z',
           'categories:',
           '  - web',
           'tags:',

--- a/test/scripts/console/generate.ts
+++ b/test/scripts/console/generate.ts
@@ -1,7 +1,7 @@
 import { join } from 'path';
 import { emptyDir, exists, mkdirs, readFile, rmdir, stat, unlink, writeFile } from 'hexo-fs';
 import BluebirdPromise from 'bluebird';
-import { spy } from 'sinon';
+import { spy, useFakeTimers } from 'sinon';
 import chai from 'chai';
 const should = chai.should();
 import Hexo from '../../../lib/hexo';
@@ -307,6 +307,84 @@ describe('generate', () => {
   it('should generate all files even when concurrency is set', async () => {
     await generate({ concurrency: '1' });
     return generate({ concurrency: '2' });
+  });
+
+});
+
+describe('generate - future posts', () => {
+  let hexo: Hexo, generate: (...args: OriginalParams) => OriginalReturn;
+
+  beforeEach(async function() {
+    this.timeout(30000);
+    hexo = new Hexo(join(__dirname, 'generate_future_test'), {silent: true});
+    generate = generateConsole.bind(hexo);
+
+    await mkdirs(hexo.base_dir);
+    await emptyDir(hexo.base_dir);
+    await hexo.init();
+  });
+
+  afterEach(async () => {
+    const exist = await exists(hexo.base_dir);
+    if (exist) {
+      await emptyDir(hexo.base_dir);
+      await rmdir(hexo.base_dir);
+    }
+  });
+
+  it('reprocesses future posts after publish date passes', async () => {
+    const clock = useFakeTimers({
+      now: new Date('2098-12-31T18:30:00.000Z'),
+      toFake: ['Date']
+    });
+    const baseDir = join(__dirname, 'generate_future_test');
+
+    try {
+      hexo.config.future = false;
+      hexo.config.new_post_name = ':title.html';
+
+      await BluebirdPromise.all([
+        writeFile(join(hexo.theme_dir, 'layout', 'post.html'), '<%- page.content %>'),
+        writeFile(join(hexo.source_dir, '_posts', 'scheduled.html'), [
+          '---',
+          'title: scheduled',
+          'date: 2099-01-01T00:01:00.000Z',
+          'categories:',
+          '  - web',
+          'tags:',
+          '  - css',
+          '---',
+          'body'
+        ].join('\n'))
+      ]);
+
+      await generate();
+      hexo.locals.invalidate();
+      hexo.locals.toObject().posts.toArray().should.have.lengthOf(0);
+      await hexo.database.save();
+
+      clock.setSystemTime(new Date('2098-12-31T18:32:00.000Z'));
+      hexo = new Hexo(baseDir, {silent: true});
+      generate = generateConsole.bind(hexo);
+      await hexo.init();
+      hexo.config.future = false;
+      hexo.config.new_post_name = ':title.html';
+
+      await generate();
+      hexo.locals.invalidate();
+      const locals = hexo.locals.toObject();
+      const posts = locals.posts.toArray();
+      const tags = locals.tags.toArray();
+      const categories = locals.categories.toArray();
+
+      posts.should.have.lengthOf(1);
+      tags.should.have.lengthOf(1);
+      tags.map(tag => tag.name).should.eql(['css']);
+      categories.should.have.lengthOf(1);
+      categories.map(category => category.name).should.eql(['web']);
+    } finally {
+      clock.restore();
+    }
   });
 });
 


### PR DESCRIPTION
## What does it do?

Fixes #5642.

When `future: false` hides a future-dated post, Hexo strips its tag/category relations while processing. The source cache was still saved as clean, so once the post date passed, a later `hexo generate` could skip the unchanged source file and leave tag/category pages missing until the post changed or the site was cleaned.

This keeps published future-dated posts dirty in the source cache while `future: false`, so the next generate after their publish date reprocesses the post and restores its relations.

## Screenshots

N/A

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.

Local verification:

- `TS_NODE_CACHE=false npm_config_cache=/tmp/hexo-5671-npm-cache npx mocha test/scripts/console/generate.ts --require ts-node/register --grep "reprocesses future posts" --timeout 60000`
- `TS_NODE_CACHE=false npm_config_cache=/tmp/hexo-5671-npm-cache npx mocha test/scripts/processors/post.ts --require ts-node/register --timeout 60000`
- `npm_config_cache=/tmp/hexo-5671-npm-cache npm run build`
- `npm_config_cache=/tmp/hexo-5671-npm-cache npx eslint lib/plugins/processor/post.ts test/scripts/console/generate.ts`
- `npm_config_cache=/tmp/hexo-5671-npm-cache npm run eslint`
- `git diff --check`
