### PR TITLE
fix: Swig tag breaks Markdown processing on the same line

### DIFF
--- a/lib/hexo/post.ts
+++ b/lib/hexo/post.ts
@@ -16,6 +16,7 @@ const rHexoPostRenderEscape = /<hexoPostRenderCodeBlock>([\s\S]+?)<\/hexoPostRen
 const rSwigTag = /(\{\{.+?\}\})|(\{#.+?#\})|(\{%.+?%\})/s;
 
 const rSwigPlaceHolder = /(?:<|&lt;)!--swig\uFFFC(\d+)--(?:>|&gt;)/g;
+const rInlineSwigPlaceHolder = /(?:\uFFFC|&#(?:xFFFC|xfffc|65532);)swig(\d+)(?:\uFFFC|&#(?:xFFFC|xfffc|65532);)/g;
 const rCodeBlockPlaceHolder = /(?:<|&lt;)!--code\uFFFC(\d+)--(?:>|&gt;)/g;
 const rCommentHolder = /(?:<|&lt;)!--comment\uFFFC(\d+)--(?:>|&gt;)/g;
 
@@ -42,8 +43,9 @@ class PostRenderEscape {
     this.stored = [];
   }
 
-  static escapeContent(cache: string[], flag: string, str: string) {
-    return `<!--${flag}\uFFFC${cache.push(str) - 1}-->`;
+  static escapeContent(cache: string[], flag: string, str: string, inline = false) {
+    const idx = cache.push(str) - 1;
+    return inline ? `\uFFFC${flag}${idx}\uFFFC` : `<!--${flag}\uFFFC${idx}-->`;
   }
 
   static restoreContent(cache: string[]) {
@@ -56,8 +58,9 @@ class PostRenderEscape {
   }
 
   restoreAllSwigTags(str: string) {
-    const restored = str.replace(rSwigPlaceHolder, PostRenderEscape.restoreContent(this.stored));
-    return restored;
+    str = str.replace(rSwigPlaceHolder, PostRenderEscape.restoreContent(this.stored));
+    str = str.replace(rInlineSwigPlaceHolder, PostRenderEscape.restoreContent(this.stored));
+    return str;
   }
 
   restoreCodeBlocks(str: string) {
@@ -112,6 +115,16 @@ class PostRenderEscape {
     const pushAndReset = (value: string) => {
       output += value;
       plain_text_start = -1;
+    };
+
+    // Inline placeholder avoids triggering CommonMark HTML block (type 2),
+    // which would prevent Markdown processing on the rest of the line.
+    const hasTrailingContentOnLine = (startIdx: number): boolean => {
+      for (let j = startIdx; j < length; j++) {
+        if (str[j] === '\n' || str[j] === '\r') return false;
+        if (isNonWhiteSpaceChar(str[j])) return true;
+      }
+      return false;
     };
 
     while (idx < length) {
@@ -224,7 +237,8 @@ class PostRenderEscape {
               swig_tag_name = '';
               state = STATE_PLAINTEXT;
               // since we have already move idx to next char of '}', so here is idx -1
-              pushAndReset(PostRenderEscape.escapeContent(this.stored, 'swig', `{%${str.slice(buffer_start, idx - 1)}%}`));
+              const swigTagStr = `{%${str.slice(buffer_start, idx - 1)}%}`;
+              pushAndReset(PostRenderEscape.escapeContent(this.stored, 'swig', swigTagStr, hasTrailingContentOnLine(idx + 1)));
             }
 
           } else {
@@ -257,9 +271,10 @@ class PostRenderEscape {
             state = STATE_PLAINTEXT;
             pushAndReset(`{{${str.slice(buffer_start, idx)}${char}`);
           } else if (char === '}' && next_char === '}' && swig_string_quote === '') {
-            pushAndReset(PostRenderEscape.escapeContent(this.stored, 'swig', `{{${str.slice(buffer_start, idx)}}}`));
+            const swigVarStr = `{{${str.slice(buffer_start, idx)}}}`;
             idx++;
             state = STATE_PLAINTEXT;
+            pushAndReset(PostRenderEscape.escapeContent(this.stored, 'swig', swigVarStr, hasTrailingContentOnLine(idx + 1)));
           }
         } else if (state === STATE_SWIG_COMMENT) { // From swig back to plain text
           if (char === '#' && next_char === '}') {

--- a/lib/hexo/post.ts
+++ b/lib/hexo/post.ts
@@ -303,7 +303,8 @@ class PostRenderEscape {
 
             if (swig_full_tag_found && swig_full_tag_end_buffer.includes(`end${swig_tag_name}`)) {
               state = STATE_PLAINTEXT;
-              pushAndReset(PostRenderEscape.escapeContent(this.stored, 'swig', `{%${str.slice(swig_full_tag_start_start, swig_full_tag_start_end)}%}${str.slice(buffer_start, idx)}{%${swig_full_tag_end_buffer}%}`));
+              const swigFullTagStr = `{%${str.slice(swig_full_tag_start_start, swig_full_tag_start_end)}%}${str.slice(buffer_start, idx)}{%${swig_full_tag_end_buffer}%}`;
+              pushAndReset(PostRenderEscape.escapeContent(this.stored, 'swig', swigFullTagStr, hasTrailingContentOnLine(_idx + 1)));
               idx = _idx;
               swig_full_tag_end_buffer = '';
             }

--- a/test/scripts/hexo/post.ts
+++ b/test/scripts/hexo/post.ts
@@ -2423,4 +2423,137 @@ describe('Post', () => {
       data.content.trim().should.include('<code>c</code>');
     });
   });
+
+  describe('inline swig placeholder', () => {
+    it('render() - markdown link on same line as swig tag at beginning of line', async () => {
+      hexo.extend.tag.register('inlineTestTag', () => '<span>test</span>');
+
+      const content = '{% inlineTestTag %} text with [link](https://example.com) more';
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('>link</a>');
+      data.content.trim().should.include('example.com');
+      data.content.trim().should.include('<span>test</span>');
+
+      hexo.extend.tag.unregister('inlineTestTag');
+    });
+
+    it('render() - swig tag alone on line should not be wrapped in <p>', async () => {
+      hexo.extend.tag.register('blockTestTag', () => '<div>block content</div>');
+
+      const content = '{% blockTestTag %}\n\nparagraph text';
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('<div>block content</div>');
+      data.content.trim().should.include('<p>paragraph text</p>');
+      data.content.should.not.include('<p><div>');
+
+      hexo.extend.tag.unregister('blockTestTag');
+    });
+
+    it('render() - multiple swig tags on same line with markdown', async () => {
+      hexo.extend.tag.register('multiTestTag', args => `<span>${args[0]}</span>`);
+
+      const content = '{% multiTestTag a %} [link](https://example.com) {% multiTestTag b %}';
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('>link</a>');
+      data.content.trim().should.include('example.com');
+      data.content.trim().should.include('<span>a</span>');
+      data.content.trim().should.include('<span>b</span>');
+
+      hexo.extend.tag.unregister('multiTestTag');
+    });
+
+    it('render() - full block tag should still work as block', async () => {
+      const content = [
+        '{% blockquote %}',
+        'quote text',
+        '{% endblockquote %}',
+        '',
+        'paragraph text'
+      ].join('\n');
+
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('<blockquote>');
+      data.content.trim().should.include('<p>paragraph text</p>');
+    });
+
+    it('render() - variable tag with trailing markdown link should use inline format', async () => {
+      const content = '{{ "var-output" }} text [link](https://example.com) after';
+
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('>link</a>');
+      data.content.trim().should.include('example.com');
+      data.content.trim().should.include('var-output');
+    });
+
+    it('render() - variable tag alone on line should use block format', async () => {
+      const content = '{{ "block-var" }}\n\nparagraph text';
+
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('block-var');
+      data.content.trim().should.include('<p>paragraph text</p>');
+      data.content.should.not.include('<p>block-var</p>');
+    });
+
+    it('render() - swig tag with trailing whitespace only should use block format', async () => {
+      hexo.extend.tag.register('wsTestTag', () => '<div>ws content</div>');
+
+      const content = '{% wsTestTag %}   \n\nparagraph text';
+
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('<div>ws content</div>');
+      data.content.trim().should.include('<p>paragraph text</p>');
+      data.content.should.not.include('<p><div>');
+
+      hexo.extend.tag.unregister('wsTestTag');
+    });
+
+    it('render() - block format on first line does not prevent inline format on next line', async () => {
+      hexo.extend.tag.register('blockLineTag', () => '<div>block</div>');
+      hexo.extend.tag.register('inlineLineTag', () => '<span>inline</span>');
+
+      const content = '{% blockLineTag %}\n{% inlineLineTag %} [link](https://example.com)';
+
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('<div>block</div>');
+      data.content.trim().should.include('<span>inline</span>');
+      data.content.trim().should.include('>link</a>');
+      data.content.should.not.include('<p><div>');
+
+      hexo.extend.tag.unregister('blockLineTag');
+      hexo.extend.tag.unregister('inlineLineTag');
+    });
+
+  });
 });

--- a/test/scripts/hexo/post.ts
+++ b/test/scripts/hexo/post.ts
@@ -2492,6 +2492,17 @@ describe('Post', () => {
       data.content.trim().should.include('<p>paragraph text</p>');
     });
 
+    it('render() - markdown link on same line as block tag closing', async () => {
+      const content = '{% blockquote %}quote{% endblockquote %} [link](https://example.com)';
+      const data = await post.render('', {
+        content,
+        engine: 'markdown'
+      });
+
+      data.content.trim().should.include('<blockquote>');
+      data.content.trim().should.include('>link</a>');
+    });
+
     it('render() - variable tag with trailing markdown link should use inline format', async () => {
       const content = '{{ "var-output" }} text [link](https://example.com) after';
 


### PR DESCRIPTION
> **Note:** This PR recreates #5752. I accidentally closed that PR — a force-push during a rebase auto-closed it — and GitHub no longer allows it to be reopened (*"the repository may be missing relevant data"*), so I'm recreating it here with the same changes. Original review thread: #5752. cc @VibhorGautam — thanks again for the suggestion, which is now included as a fix below.

## What does it do?

### Problem

When a Swig/Nunjucks tag appears at the beginning of a line, Markdown syntax on the rest of that line is not processed.

**Input:**
~~~markdown
{% post_link my-post 'My Post' %} and [link](https://example.com)
~~~

**Expected:** `link` becomes a clickable link.
**Actual:** `[link](https://example.com)` is rendered as plain text.

### Cause

Hexo replaces Swig tags with HTML comment placeholders (`<!--swig￼N-->`) before Markdown rendering. When this placeholder starts a line, it triggers an [HTML block (type 2)](https://spec.commonmark.org/0.31.2/#html-blocks) per the CommonMark spec — the entire line is treated as raw HTML and no Markdown processing occurs (see [Example 177](https://spec.commonmark.org/0.31.2/#example-177)).

### Fix

A single placeholder format cannot satisfy both requirements:

- **Block-level tags** (e.g. `{% blockquote %}`) need the HTML comment placeholder to trigger HTML block parsing, which prevents the Markdown renderer from wrapping the output in `<p>` tags.
- **Inline tags with trailing content** (e.g. `{% post_link %} [link](url)`) must *not* trigger HTML block parsing, or the rest of the line loses Markdown processing.

This PR adds an inline placeholder format (`￼swigN￼`) that uses U+FFFC (Object Replacement Character) as delimiters instead of HTML comments. U+FFFC is already used in the existing block placeholder format and is safe for this purpose — it has no special meaning in HTML or Markdown, does not appear in normal text, and survives Markdown rendering unchanged.

The state machine in `escapeAllSwigTags` looks ahead after each closing `%}` / `}}`: if non-whitespace content follows on the same line, the inline format is used; otherwise the existing block format (`<!--swig￼N-->`) is used.

### Additional fix: trailing Markdown after a block tag's *closing*

Following @VibhorGautam's review suggestion on #5752, I added a regression test for a full block tag whose **closing** is followed by Markdown on the same line:

~~~markdown
{% blockquote %}quote{% endblockquote %} [link](https://example.com)
~~~

The test surfaced a real bug: the same-line Markdown was **not** processed, because the full-block-tag branch in `escapeAllSwigTags` was the only escape path that didn't pass the inline-placeholder flag — the same root cause as above, on the closing side. Fixed by applying the same `hasTrailingContentOnLine` look-ahead there. All `post.ts` tests pass (121 passing / 1 pending).

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
