### PR TITLE
Fix publish filename resolution

### DIFF
--- a/lib/hexo/post.ts
+++ b/lib/hexo/post.ts
@@ -1,10 +1,10 @@
 import assert from 'assert';
 import moment from 'moment';
 import Promise from 'bluebird';
-import { join, extname, basename } from 'path';
+import { join, extname, basename, posix } from 'path';
 import { magenta } from 'picocolors';
 import { load } from 'js-yaml';
-import { slugize, escapeRegExp, deepMerge} from 'hexo-util';
+import { slugize, deepMerge} from 'hexo-util';
 import { copyDir, exists, listDir, mkdirs, readFile, rmdir, unlink, writeFile } from 'hexo-fs';
 import { parse as yfmParse, split as yfmSplit, stringify as yfmStringify } from 'hexo-front-matter';
 import type Hexo from './index';
@@ -360,6 +360,44 @@ const removeExtname = (str: string) => {
   return str.substring(0, str.length - extname(str).length);
 };
 
+const normalizeSourcePath = (str: string) => str.replace(/\\/g, '/').replace(/^(?:\.\/)+/, '');
+
+const removeSourceExtname = (str: string) => {
+  return str.substring(0, str.length - posix.extname(str).length);
+};
+
+const normalizeSourceBasename = (str: string, filenameCase: number) => {
+  const extension = posix.extname(str);
+  const directory = posix.dirname(str);
+  const filename = posix.basename(str, extension);
+  const normalizedFilename = slugize(filename, { transform: filenameCase }) + extension;
+
+  return directory === '.' ? normalizedFilename : posix.join(directory, normalizedFilename);
+};
+
+const findDraftFile = (list: string[], value: string | number, filenameCase: number) => {
+  const source = normalizeSourcePath(value.toString());
+  const normalizedSource = normalizeSourceBasename(source, filenameCase);
+  const files = list.map(item => ({ item, source: normalizeSourcePath(item) }));
+  const candidates = source === normalizedSource ? [source] : [source, normalizedSource];
+
+  for (const candidate of candidates) {
+    const exactMatch = files.find(file => file.source === candidate);
+    if (exactMatch) return exactMatch.item;
+
+    const matches = files.filter(file => removeSourceExtname(file.source) === candidate);
+
+    if (matches.length === 1) return matches[0].item;
+
+    if (matches.length > 1) {
+      const filenames = matches.map(file => file.source).sort().join(', ');
+      throw new Error(`Draft "${source}" is ambiguous. Please specify the full filename: ${filenames}.`);
+    }
+  }
+
+  throw new Error(`Draft "${source}" does not exist.`);
+};
+
 const createAssetFolder = (path: string, assetFolder: boolean) => {
   if (!assetFolder) return Promise.resolve();
 
@@ -491,9 +529,7 @@ class Post {
     const ctx = this.context;
     const { config } = ctx;
     const draftDir = join(ctx.source_dir, '_drafts');
-    const slug = slugize(data.slug.toString(), { transform: config.filename_case });
-    data.slug = slug;
-    const regex = new RegExp(`^${escapeRegExp(slug)}(?:[^\\/\\\\]+)`);
+    const source = data.slug;
     let src = '';
     const result: Result = {} as any;
 
@@ -501,8 +537,9 @@ class Post {
 
     // Find the draft
     return listDir(draftDir).then(list => {
-      const item = list.find(item => regex.test(item));
-      if (!item) throw new Error(`Draft "${slug}" does not exist.`);
+      const item = findDraftFile(list, source, config.filename_case);
+      const sourcePath = normalizeSourcePath(item);
+      data.slug = slugize(posix.basename(removeSourceExtname(sourcePath)), { transform: config.filename_case });
 
       // Read the content
       src = join(draftDir, item);

--- a/lib/plugins/console/index.ts
+++ b/lib/plugins/console/index.ts
@@ -63,7 +63,7 @@ export = function(ctx: Hexo) {
     usage: '[layout] <filename>',
     arguments: [
       {name: 'layout', desc: 'Post layout. Use post, page, draft or whatever you want.'},
-      {name: 'filename', desc: 'Draft filename. "hello-world" for example.'}
+      {name: 'filename', desc: 'Draft filename relative to _drafts. The extension may be omitted when unambiguous.'}
     ]
   }, require('./publish'));
 

--- a/test/scripts/hexo/post.ts
+++ b/test/scripts/hexo/post.ts
@@ -495,6 +495,78 @@ describe('Post', () => {
     await unlink(path);
   });
 
+  // #1821
+  it('publish() - full filename in a subdirectory', async () => {
+    const draftDir = join(hexo.source_dir, '_drafts', 'nested-publish');
+    const draftPath = join(draftDir, 'Issue-1821.mkd');
+    const path = join(hexo.source_dir, '_posts', 'Issue-1821.md');
+
+    await writeFile(draftPath, [
+      '---',
+      'title: Issue 1821',
+      '---',
+      'content'
+    ].join('\n'));
+
+    const result = await post.publish({
+      slug: 'nested-publish/Issue-1821.mkd'
+    });
+
+    result.path.should.eql(path);
+    (await exists(draftPath)).should.be.false;
+
+    await unlink(path);
+    await rmdir(draftDir);
+  });
+
+  it('publish() - does not match a filename prefix', async () => {
+    const draftPath = join(hexo.source_dir, '_drafts', 'Issue-1821-prefix.md');
+    const otherDraftPath = join(hexo.source_dir, '_drafts', 'Issue-1821-prefix-extra.md');
+    const path = join(hexo.source_dir, '_posts', 'Issue-1821-prefix.md');
+    const content = '---\ntitle: Issue 1821\n---\n';
+
+    await Promise.all([
+      writeFile(draftPath, content),
+      writeFile(otherDraftPath, content)
+    ]);
+
+    await post.publish({ slug: 'Issue-1821-prefix' });
+
+    (await exists(draftPath)).should.be.false;
+    (await exists(otherDraftPath)).should.be.true;
+
+    await Promise.all([
+      unlink(otherDraftPath),
+      unlink(path)
+    ]);
+  });
+
+  it('publish() - rejects an ambiguous filename without an extension', async () => {
+    const markdownPath = join(hexo.source_dir, '_drafts', 'Issue-1821-ambiguous.md');
+    const mkdPath = join(hexo.source_dir, '_drafts', 'Issue-1821-ambiguous.mkd');
+    const content = '---\ntitle: Issue 1821\n---\n';
+    let error: Error | undefined;
+
+    await Promise.all([
+      writeFile(markdownPath, content),
+      writeFile(mkdPath, content)
+    ]);
+
+    try {
+      await post.publish({ slug: 'Issue-1821-ambiguous' });
+    } catch (err) {
+      error = err as Error;
+    }
+
+    should.exist(error);
+    error!.message.should.eql('Draft "Issue-1821-ambiguous" is ambiguous. Please specify the full filename: Issue-1821-ambiguous.md, Issue-1821-ambiguous.mkd.');
+
+    await Promise.all([
+      unlink(markdownPath),
+      unlink(mkdPath)
+    ]);
+  });
+
   it('publish() - layout', async () => {
     const path = join(hexo.source_dir, '_posts', 'Hello-World.md');
     const date = moment(now);
@@ -583,6 +655,37 @@ describe('Post', () => {
 
     await unlink(result.path);
 
+    await rmdir(newAssetDir);
+  });
+
+  // #5476
+  it('publish() - filename with spaces and asset folder', async () => {
+    const draftPath = join(hexo.source_dir, '_drafts', 'space file test.md');
+    const assetDir = join(hexo.source_dir, '_drafts', 'space file test');
+    const path = join(hexo.source_dir, '_posts', 'space-file-test.md');
+    const newAssetDir = join(hexo.source_dir, '_posts', 'space-file-test');
+    hexo.config.post_asset_folder = true;
+
+    await Promise.all([
+      writeFile(draftPath, [
+        '---',
+        'title: Space File Test',
+        '---',
+        'content'
+      ].join('\n')),
+      writeFile(join(assetDir, 'a.txt'), 'a')
+    ]);
+
+    const result = await post.publish({
+      slug: 'space file test'
+    });
+
+    result.path.should.eql(path);
+    (await exists(draftPath)).should.be.false;
+    (await exists(assetDir)).should.be.false;
+    (await listDir(newAssetDir)).should.eql(['a.txt']);
+
+    await unlink(path);
     await rmdir(newAssetDir);
   });
 


### PR DESCRIPTION
## What does it do?

This PR fixes draft filename resolution used by `hexo publish`:

- Accepts exact filenames, including extensions such as `.md` and `.mkd`.
- Accepts paths relative to `_drafts`, including nested directories.
- Allows the extension to be omitted when the filename is unambiguous.
- Prevents a filename such as `foo` from incorrectly matching `foo-bar.md` or `foobar.md`.
- Reports an explicit error with the available candidates when multiple files have the same stem.
- Handles filenames containing spaces.
- Normalizes path separators and respects the `filename_case` configuration.
- Separates source-file lookup from the slug used to create the destination post.

The destination filename continues to follow the existing `new_post_name` behavior.

This PR intentionally does not include the `unpublish` command or implementation. That work remains in #4995 so the original contribution and commit history are preserved.

Fixes #1821.
Supersedes #5476.

## Screenshots

N/A — this change only affects CLI behavior.

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.