### PR TITLE
perf(generate): avoid concatenating a single buffer

### DIFF
--- a/lib/plugins/console/generate.ts
+++ b/lib/plugins/console/generate.ts
@@ -102,12 +102,14 @@ class Generator {
         return;
       }
 
+      const data = buffers.length > 1 ? Buffer.concat(buffers) : buffers[0] || Buffer.alloc(0);
+
       // Save new hash to cache
       return Cache.save({
         _id: cacheId,
         hash
       }).then(() => // Write cache data to public folder
-        writeFile(dest, Buffer.concat(buffers))).then(() => {
+        writeFile(dest, data)).then(() => {
         log.info('Generated: %s', magenta(path));
         return true;
       });

--- a/test/scripts/console/generate.ts
+++ b/test/scripts/console/generate.ts
@@ -1,4 +1,5 @@
 import { join } from 'path';
+import { Readable } from 'stream';
 import { emptyDir, exists, mkdirs, readFile, rmdir, stat, unlink, writeFile } from 'hexo-fs';
 import BluebirdPromise from 'bluebird';
 import { spy, useFakeTimers } from 'sinon';
@@ -302,6 +303,37 @@ describe('generate', () => {
       ]
     );
     return generate({ bail: true });
+  });
+
+  it('should only concatenate multiple chunks before writing', async () => {
+    hexo.extend.generator.register('resource', () => [
+      {
+        path: 'single-chunk',
+        data: Buffer.from('single')
+      },
+      {
+        path: 'multiple-chunks',
+        data: () => Readable.from([Buffer.from('multiple'), Buffer.from('-chunks')])
+      }
+    ]);
+
+    const concatSpy = spy(Buffer, 'concat');
+
+    try {
+      await generate({ bail: true });
+      concatSpy.calledOnce.should.be.true;
+      concatSpy.firstCall.args[0].should.have.lengthOf(2);
+    } finally {
+      concatSpy.restore();
+    }
+
+    const [singleChunk, multipleChunks] = await BluebirdPromise.all([
+      readFile(join(hexo.public_dir, 'single-chunk')),
+      readFile(join(hexo.public_dir, 'multiple-chunks'))
+    ]);
+
+    singleChunk.should.eql('single');
+    multipleChunks.should.eql('multiple-chunks');
   });
 
   it('should generate all files even when concurrency is set', async () => {


### PR DESCRIPTION
## What does it do?

`Generator.writeFile()` previously called `Buffer.concat(buffers)` even when a route emitted only one chunk. Most rendered pages use a single chunk, so this allocated another output-sized buffer and copied the entire page before writing it.

This PR:

- passes a single chunk directly to `writeFile()`;
- uses an empty buffer when no chunks are emitted;
- preserves `Buffer.concat()` for multi-chunk streams;
- adds test coverage for both single-chunk and multi-chunk routes.

This is a targeted performance improvement related to #5705. It avoids the redundant concatenation and memory copy, but does not remove the UTF-8 conversion performed by `Buffer.from()` in the router.

In a synthetic local benchmark on Node.js v26.6.0, including SHA1 calculation and writing to `/dev/null`, a 64 MiB single-chunk page improved from:

| Content | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| ASCII HTML | 45.70 ms | 38.78 ms | 15.1% |
| Mixed UTF-8 HTML | 131.81 ms | 124.76 ms | 5.3% |

It also avoids one output-sized buffer allocation for single-chunk routes.

Local validation:

- `npm run build`
- ESLint on the changed files
- Generate tests: 15 passing

## Screenshots

N/A

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.