### PR TITLE
perf(nunjucks): reuse compiled view templates

### DIFF
--- a/lib/plugins/renderer/nunjucks.ts
+++ b/lib/plugins/renderer/nunjucks.ts
@@ -76,6 +76,13 @@ njkRenderer.compile = (data: StoreFunctionData): (locals: any) => string => {
   const { env, template } = njkCompile(data);
 
   return locals => {
+    // The top-level template is compiled directly and is not stored in the loader cache,
+    // so invalidating the cache here does not recompile it. This intentionally reloads
+    // extends/include/import dependencies before every render to preserve `hexo server`
+    // hot updates because the renderer has no signal indicating that a dependency changed.
+    // The trade-off is that unchanged dependencies are also recompiled on every render.
+    // If a reliable theme-template change signal becomes available, invalidate the cache
+    // in response to that signal instead of removing this call outright.
     env.invalidateCache();
     return template.render(locals);
   };

--- a/lib/plugins/renderer/nunjucks.ts
+++ b/lib/plugins/renderer/nunjucks.ts
@@ -3,6 +3,15 @@ import { readFileSync } from 'hexo-fs';
 import { dirname } from 'path';
 import type { StoreFunctionData } from '../../extend/renderer';
 
+interface CacheableEnvironment extends Environment {
+  invalidateCache(): void;
+}
+
+interface CompiledTemplate {
+  env: CacheableEnvironment;
+  template: nunjucks.Template;
+}
+
 function toArray(value) {
   if (Array.isArray(value)) {
     // Return if given value is an Array
@@ -42,27 +51,34 @@ const nunjucksAddFilter = (env: Environment): void => {
   env.addFilter('safedump', safeJsonStringify);
 };
 
-function njkCompile(data: StoreFunctionData): nunjucks.Template {
-  let env: Environment;
+function njkCompile(data: StoreFunctionData): CompiledTemplate {
+  let env: CacheableEnvironment;
   if (data.path) {
-    env = nunjucks.configure(dirname(data.path), nunjucksCfg);
+    env = nunjucks.configure(dirname(data.path), nunjucksCfg) as CacheableEnvironment;
   } else {
-    env = nunjucks.configure(nunjucksCfg);
+    env = nunjucks.configure(nunjucksCfg) as CacheableEnvironment;
   }
   nunjucksAddFilter(env);
 
   const text = 'text' in data ? data.text : readFileSync(data.path);
 
-  return nunjucks.compile(text, env, data.path);
+  return {
+    env,
+    template: nunjucks.compile(text, env, data.path)
+  };
 }
 
 function njkRenderer(data: StoreFunctionData, locals?: any): string {
-  return njkCompile(data).render(locals);
+  return njkCompile(data).template.render(locals);
 }
 
 njkRenderer.compile = (data: StoreFunctionData): (locals: any) => string => {
-  // Need a closure to keep the compiled template.
-  return locals => njkCompile(data).render(locals);
+  const { env, template } = njkCompile(data);
+
+  return locals => {
+    env.invalidateCache();
+    return template.render(locals);
+  };
 };
 
 export = njkRenderer;

--- a/test/scripts/renderers/nunjucks.ts
+++ b/test/scripts/renderers/nunjucks.ts
@@ -1,6 +1,10 @@
 import r from '../../../lib/plugins/renderer/nunjucks';
+import nunjucks from 'nunjucks';
 import { dirname, join } from 'path';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import chai from 'chai';
+import { spy } from 'sinon';
 const _should = chai.should();
 
 
@@ -46,6 +50,71 @@ describe('nunjucks', () => {
       name: 'world'
     }).should.eql('Hello world!\n');
   });
+
+  it('compile template only once', () => {
+    const compile = spy(nunjucks, 'compile');
+
+    try {
+      const render = r.compile({
+        text: 'Hello {{ name }}!'
+      });
+
+      render({ name: 'world' }).should.eql('Hello world!');
+      render({ name: 'Hexo' }).should.eql('Hello Hexo!');
+      compile.calledOnce.should.be.true;
+    } finally {
+      compile.restore();
+    }
+  });
+
+  const dependencyCases = [
+    {
+      name: 'include',
+      source: '{%- include \'dependency.njk\' -%}',
+      firstDependency: 'one',
+      secondDependency: 'two',
+      firstResult: 'one',
+      secondResult: 'two'
+    },
+    {
+      name: 'extends',
+      source: '{% extends \'dependency.njk\' %}{% block body %}body{% endblock %}',
+      firstDependency: 'one:{% block body %}{% endblock %}',
+      secondDependency: 'two:{% block body %}{% endblock %}',
+      firstResult: 'one:body',
+      secondResult: 'two:body'
+    },
+    {
+      name: 'import',
+      source: '{%- import \'dependency.njk\' as dependency -%}{{ dependency.value() }}',
+      firstDependency: '{% macro value() %}one{% endmacro %}',
+      secondDependency: '{% macro value() %}two{% endmacro %}',
+      firstResult: 'one',
+      secondResult: 'two'
+    }
+  ];
+
+  for (const dependencyCase of dependencyCases) {
+    it(`invalidate ${dependencyCase.name} cache before rendering`, () => {
+      const fixtureDir = mkdtempSync(join(tmpdir(), 'hexo-nunjucks-'));
+      const templatePath = join(fixtureDir, 'template.njk');
+      const dependencyPath = join(fixtureDir, 'dependency.njk');
+
+      try {
+        writeFileSync(dependencyPath, dependencyCase.firstDependency);
+        const render = r.compile({
+          path: templatePath,
+          text: dependencyCase.source
+        });
+
+        render({}).should.eql(dependencyCase.firstResult);
+        writeFileSync(dependencyPath, dependencyCase.secondDependency);
+        render({}).should.eql(dependencyCase.secondResult);
+      } finally {
+        rmSync(fixtureDir, { recursive: true });
+      }
+    });
+  }
 
   describe('nunjucks filters', () => {
     const forLoop = [


### PR DESCRIPTION
## What does it do?

Reuses the compiled top-level Nunjucks template for each Hexo View instead of creating a new Nunjucks environment and recompiling the same source on every render.

### Background

The current behavior dates back to #4356, which introduced the dedicated Nunjucks renderer in 2020.

Although the `compile()` hook returns a closure with a comment saying that the closure keeps the compiled template, `njkCompile(data)` is invoked inside that closure. Consequently, every render creates another Nunjucks environment and recompiles the current View.

Simply moving the compilation outside the closure would make `{% extends %}`, `{% include %}`, and `{% import %}` dependencies stale during `hexo server`, because Nunjucks caches loader-resolved templates.

This PR therefore:

- Compiles and retains the current View once.
- Calls `Environment#invalidateCache()` before every render.
- Reloads templates referenced through `extends`, `include`, and `import`.
- Keeps the top-level compiled View because it is not stored in the loader cache.
- Preserves `hexo server` hot-reload behavior.

This optimization was identified while profiling #5705. It does not remove the `Buffer.from()` encoding cost reported by that issue; it addresses a larger Nunjucks rendering hot path found during the same profiling work.

### Performance

Measured with an isolated snapshot of a real-world Hexo blog. Baseline and patched runs used the same site state and were executed in alternating order.

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Warm `hexo generate` median | 4.84 s | 3.60 s | -25.6% |
| First generation | 7.16 s | 6.21 s | -13.2% |
| Top-level compile calls | 2,873 | 79 | -97.3% |
| Nunjucks environments created | 2,875 | 81 | -97.2% |
| Total template compilations | 5,763 | 2,918 | -49.4% |
| Template compilation time | 1,517 ms | 647 ms | -57.3% |
| Loader dependency reads | 2,890 | 2,890 | unchanged |

The unchanged dependency-read count is intentional: loader-resolved dependencies are still reloaded on each render to preserve server-side hot updates.

### Tests

Added coverage to verify that:

- The current View is compiled only once.
- Updated `include` templates are reloaded.
- Updated `extends` templates are reloaded.
- Updated `import` templates are reloaded.

A real `hexo server` integration check was also performed by changing an included theme partial and confirming that the updated content appeared in the next HTTP response.

Validation completed:

- Nunjucks renderer tests: 23 passing
- TypeScript build: passed
- ESLint: passed

Related to #5705.

## Screenshots

N/A

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.