### PR TITLE
perf: avoid copying partial locals on cache hits

### DIFF
--- a/lib/plugins/helper/partial.ts
+++ b/lib/plugins/helper/partial.ts
@@ -15,26 +15,32 @@ export = (ctx: Hexo) => function partial(this: LocalsType, name: string, locals?
   const currentView = this.filename.substring(viewDir.length);
   const path = join(dirname(currentView), name);
   const view = ctx.theme.getView(path) || ctx.theme.getView(name);
-  const viewLocals: Record<string, any> = {};
 
   if (!view) {
     throw new Error(`Partial ${name} does not exist. (in ${currentView})`);
   }
 
-  if (options.only) {
-    Object.assign(viewLocals, locals);
-  } else {
-    Object.assign(viewLocals, this, locals);
-  }
+  // Build locals lazily so a fragment cache hit does not copy the render context.
+  const render = () => {
+    const viewLocals: Record<string, any> = {};
 
-  // Partial don't need layout
-  viewLocals.layout = false;
+    if (options.only) {
+      Object.assign(viewLocals, locals);
+    } else {
+      Object.assign(viewLocals, this, locals);
+    }
+
+    // Partial don't need layout
+    viewLocals.layout = false;
+
+    return view.renderSync(viewLocals);
+  };
 
   if (cache) {
     const cacheId = typeof cache === 'string' ? cache : view.path;
 
-    return this.fragment_cache(cacheId, () => view.renderSync(viewLocals));
+    return this.fragment_cache(cacheId, render);
   }
 
-  return view.renderSync(viewLocals);
+  return render();
 };

--- a/test/scripts/helpers/partial.ts
+++ b/test/scripts/helpers/partial.ts
@@ -71,6 +71,23 @@ describe('partial', () => {
     partial('test', {}, {cache: 'ash'}).should.eql('baz');
   });
 
+  it('does not build locals when cache is hit', () => {
+    hexo.theme.setView('test.njk', '{{ foo }}');
+    partial('test', {foo: 'bar'}, {cache: 'skip-locals'}).should.eql('bar');
+
+    let reads = 0;
+    const locals = Object.defineProperty({}, 'foo', {
+      enumerable: true,
+      get() {
+        reads++;
+        return 'baz';
+      }
+    });
+
+    partial('test', locals, {cache: 'skip-locals'}).should.eql('bar');
+    reads.should.eql(0);
+  });
+
   it('only', () => {
     hexo.theme.setView('test.njk', '{{ foo }}{{ bar }}');
 


### PR DESCRIPTION
## What does it do?

`partial()` currently builds `viewLocals` and copies the render context before checking the fragment cache. This work is unnecessary when the cached fragment is returned without rendering the view.

This change moves construction of `viewLocals` into the render callback passed to `fragment_cache()`. As a result:

- Fragment cache hits no longer copy `this` and `locals`.
- Cache misses and uncached partials keep the existing rendering behavior.
- View lookup, missing-view errors, and cache ID selection remain unchanged.

A regression test uses an enumerable getter to verify that partial locals are not accessed on a cache hit.

### Performance

On a profiled real-world blog, `partial()` was called 5,475 times during a generation, including 2,885 fragment cache hits. Those hits unnecessarily copied approximately 532,000 properties.

Five warmed, paired `hexo generate` runs were performed against clean copies of the same site, alternating between `master` and this patch:

| Measurement | master | patched | Improvement |
| --- | ---: | ---: | ---: |
| Median | 4,473.3 ms | 4,327.5 ms | 145.8 ms (3.26%) |
| Mean | 4,515.0 ms | 4,355.7 ms | 159.3 ms (3.53%) |

Four of the five paired runs were faster with the patch. There is some normal run-to-run variation, so the conservative observed improvement is approximately 2–3% for this site.

### Validation

- Partial helper tests: 7 passing
- TypeScript build
- ESLint
- `git diff --check`

## Screenshots

N/A

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.