### PR TITLE
feat(open_graph): support fediverse creator metadata

### DIFF
--- a/lib/plugins/helper/open_graph.ts
+++ b/lib/plugins/helper/open_graph.ts
@@ -66,6 +66,7 @@ interface Options {
   updated?: Moment | Date | false;
   language?: string;
   author?: string;
+  fediverse_creator?: string | string[];
   twitter_image?: string;
   twitter_id?: string;
   twitter_site?: string;
@@ -164,6 +165,16 @@ function openGraphHelper(this: LocalsType, options: Options = {}) {
       return tag.name ? tag.name : tag;
     }).filter(Boolean).sort().forEach(keyword => {
       result += og('article:tag', keyword);
+    });
+  }
+
+  if (options.fediverse_creator) {
+    const fediverseCreators = Array.isArray(options.fediverse_creator)
+      ? options.fediverse_creator
+      : [options.fediverse_creator];
+
+    fediverseCreators.filter(Boolean).forEach(creator => {
+      result += meta('fediverse:creator', creator);
     });
   }
 

--- a/test/scripts/helpers/open_graph.ts
+++ b/test/scripts/helpers/open_graph.ts
@@ -453,9 +453,9 @@ describe('open_graph', () => {
       page: {},
       config: hexo.config,
       is_post: isPost
-    }, {fediverse_creator: '@hexo@fosstodon.org'});
+    }, {fediverse_creator: '@hexo@example.com'});
 
-    result.should.have.string(meta({name: 'fediverse:creator', content: '@hexo@fosstodon.org'}));
+    result.should.have.string(meta({name: 'fediverse:creator', content: '@hexo@example.com'}));
   });
 
   it('fediverse_creator - array', () => {
@@ -463,11 +463,11 @@ describe('open_graph', () => {
       page: {},
       config: hexo.config,
       is_post: isPost
-    }, {fediverse_creator: ['@hexo@fosstodon.org', '@hexo@mastodon.social']});
+    }, {fediverse_creator: ['@hexo@example.com', '@hexo@example.org']});
 
     result.should.have.string([
-      meta({name: 'fediverse:creator', content: '@hexo@fosstodon.org'}),
-      meta({name: 'fediverse:creator', content: '@hexo@mastodon.social'})
+      meta({name: 'fediverse:creator', content: '@hexo@example.com'}),
+      meta({name: 'fediverse:creator', content: '@hexo@example.org'})
     ].join('\n'));
   });
 

--- a/test/scripts/helpers/open_graph.ts
+++ b/test/scripts/helpers/open_graph.ts
@@ -448,6 +448,29 @@ describe('open_graph', () => {
     result.should.have.string(meta({property: 'og:description', content: escaped}));
   });
 
+  it('fediverse_creator - string', () => {
+    const result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    }, {fediverse_creator: '@hexo@fosstodon.org'});
+
+    result.should.have.string(meta({name: 'fediverse:creator', content: '@hexo@fosstodon.org'}));
+  });
+
+  it('fediverse_creator - array', () => {
+    const result = openGraph.call({
+      page: {},
+      config: hexo.config,
+      is_post: isPost
+    }, {fediverse_creator: ['@hexo@fosstodon.org', '@hexo@mastodon.social']});
+
+    result.should.have.string([
+      meta({name: 'fediverse:creator', content: '@hexo@fosstodon.org'}),
+      meta({name: 'fediverse:creator', content: '@hexo@mastodon.social'})
+    ].join('\n'));
+  });
+
   it('twitter_card - options', () => {
     const result = openGraph.call({
       page: {},


### PR DESCRIPTION
## What does it do?

Adds a `fediverse_creator` option to the `open_graph()` helper and emits the author-attribution metadata used by Mastodon and other Fediverse software:

```html
<meta name="fediverse:creator" content="@username@domain.name">
```

The option accepts either a single creator or an array of creators. Array values generate repeated tags in the configured order, allowing the first creator to remain the preferred attribution while preserving future support for multiple creators.

This makes the metadata available to themes that delegate social metadata generation to Hexo's helper.

Closes #5804.

### Validation

- `npm test -- --grep '^open_graph'` (63 passing)
- `npm run eslint`
- `npm run build`

## Screenshots

N/A — this change only affects generated metadata.

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.