### PR TITLE
feat(helper): support locale-aware category sorting

### DIFF
--- a/lib/plugins/helper/list_categories.ts
+++ b/lib/plugins/helper/list_categories.ts
@@ -9,6 +9,7 @@ interface Options {
   depth?: number | string;
   orderby?: string;
   order?: number;
+  locale?: string;
   show_count?: boolean;
   show_current?: boolean;
   transform?: (name: string) => string;
@@ -33,6 +34,7 @@ function listCategoriesHelper(this: LocalsType, categories?: Query<CategorySchem
   const depth = options.depth ? parseInt(String(options.depth), 10) : 0;
   const orderby = options.orderby || 'name';
   const order = options.order || 1;
+  const collator = orderby === 'name' && options.locale ? new Intl.Collator(options.locale) : undefined;
   const showCurrent = options.show_current || false;
   const childrenIndicator = Object.prototype.hasOwnProperty.call(options, 'children_indicator') ? options.children_indicator : false;
 
@@ -45,7 +47,14 @@ function listCategoriesHelper(this: LocalsType, categories?: Query<CategorySchem
       query.parent = {$exists: false};
     }
 
-    return (categories as Query<CategorySchema>).find(query).sort(orderby, order);
+    const result = (categories as Query<CategorySchema>).find(query);
+
+    if (collator) {
+      const direction = order === -1 || String(order) === 'desc' ? -1 : 1;
+      return result.toArray().sort((a, b) => collator.compare(a.name, b.name) * direction);
+    }
+
+    return result.sort(orderby, order);
   };
 
   const hierarchicalList = (level: number, parent?: any) => {

--- a/test/scripts/helpers/list_categories.ts
+++ b/test/scripts/helpers/list_categories.ts
@@ -316,4 +316,35 @@ describe('list_categories', () => {
       '</ul>'
     ].join(''));
   });
+
+  it('locale', async () => {
+    const names = ['生活', '技术', '编程', '随笔', '测试'];
+    await Category.insert(names.map(name => ({name})));
+
+    try {
+      const categories = Category.find({name: {$in: names}});
+      const renderedNames: string[] = [];
+      const options = {
+        style: false as const,
+        show_count: false,
+        transform(name: string) {
+          renderedNames.push(name);
+          return name;
+        }
+      };
+
+      listCategories(categories, options);
+      renderedNames.should.eql(['技术', '测试', '生活', '编程', '随笔']);
+
+      renderedNames.length = 0;
+      listCategories(categories, {...options, locale: 'zh-CN'});
+      renderedNames.should.eql(['编程', '测试', '技术', '生活', '随笔']);
+
+      renderedNames.length = 0;
+      listCategories(categories, {...options, locale: 'zh-CN', order: -1});
+      renderedNames.should.eql(['随笔', '生活', '技术', '测试', '编程']);
+    } finally {
+      await Category.remove({name: {$in: names}});
+    }
+  });
 });


### PR DESCRIPTION
<!--
Thank you for creating a pull request to contribute to Hexo code! Before you open the request please answer the following questions to help it be more easily integrated. Please check the boxes "[ ]" with "[x]" when done too.
-->

## What does it do?

Adds an optional `locale` option to `list_categories` so category names can be sorted with `Intl.Collator`.

Locale-aware sorting is only used when `orderby` is `name` and a locale is explicitly provided. Existing sites that do not set `locale` continue to use Warehouse's current sorting behavior.

For example:

```ejs
<%- list_categories({ locale: 'zh-CN' }) %>
```

The tests cover the existing Unicode order, Chinese locale-aware order, and descending order.

Closes #5631.

## Screenshots

N/A — this changes category ordering generated by a helper.

## Pull request tasks

- [x] Add test cases for the changes.
- [ ] Passed the CI test.
