### PR TITLE
feat(theme): validate config with JSON Schema

### DIFF
--- a/lib/plugins/filter/before_generate/index.ts
+++ b/lib/plugins/filter/before_generate/index.ts
@@ -3,5 +3,6 @@ import type Hexo from '../../../hexo';
 export = (ctx: Hexo) => {
   const { filter } = ctx.extend;
 
+  filter.register('before_generate', require('./validate_theme_config'), -100);
   filter.register('before_generate', require('./render_post'));
 };

--- a/lib/plugins/filter/before_generate/validate_theme_config.ts
+++ b/lib/plugins/filter/before_generate/validate_theme_config.ts
@@ -1,0 +1,100 @@
+import { join } from 'path';
+import Ajv2020, { type ErrorObject, type ValidateFunction } from 'ajv/dist/2020';
+import addFormats from 'ajv-formats';
+import { exists, readFile } from 'hexo-fs';
+import type Hexo from '../../../hexo';
+
+interface CachedValidator {
+  source: string;
+  validate: ValidateFunction;
+}
+
+const validatorCache = new Map<string, CachedValidator>();
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function loadValidator(schemaPath: string): Promise<ValidateFunction> {
+  let source: string,
+    schema: any;
+
+  try {
+    source = await readFile(schemaPath);
+  } catch (error) {
+    throw new TypeError(`Failed to read theme config schema "${schemaPath}": ${errorMessage(error)}`);
+  }
+
+  const cached = validatorCache.get(schemaPath);
+  if (cached?.source === source) return cached.validate;
+
+  try {
+    schema = JSON.parse(source);
+  } catch (error) {
+    throw new TypeError(`Failed to read theme config schema "${schemaPath}": ${errorMessage(error)}`);
+  }
+
+  const validate = compileSchema(schema, schemaPath);
+  validatorCache.set(schemaPath, { source, validate });
+  return validate;
+}
+
+function compileSchema(schema: any, schemaPath: string): ValidateFunction {
+  if (schema && typeof schema === 'object' && schema.$async === true) {
+    throw new TypeError(`Invalid theme config schema "${schemaPath}": asynchronous schemas are not supported`);
+  }
+
+  const ajv = new Ajv2020({
+    allErrors: true,
+    coerceTypes: false,
+    removeAdditional: false,
+    strict: true,
+    useDefaults: false
+  });
+
+  addFormats(ajv);
+
+  try {
+    return ajv.compile(schema);
+  } catch (error) {
+    throw new TypeError(`Invalid theme config schema "${schemaPath}": ${errorMessage(error)}`);
+  }
+}
+
+function escapeJsonPointer(value: string): string {
+  return value.replace(/~/g, '~0').replace(/\//g, '~1');
+}
+
+function errorPath(error: ErrorObject): string {
+  let property: unknown;
+  let path = error.instancePath;
+
+  if (error.keyword === 'additionalProperties' || error.keyword === 'unevaluatedProperties') {
+    property = error.params.additionalProperty || error.params.unevaluatedProperty;
+  } else if (error.keyword === 'required') {
+    property = error.params.missingProperty;
+  }
+
+  if (typeof property === 'string') path += `/${escapeJsonPointer(property)}`;
+  return path || '/';
+}
+
+function formatErrors(errors: ErrorObject[] = []): string {
+  return errors.map(error => {
+    const path = errorPath(error);
+    return `  - ${path} ${error.message || 'is invalid'}`;
+  }).join('\n');
+}
+
+async function validateThemeConfig(this: Hexo): Promise<void> {
+  const schemaPath = join(this.theme_dir, 'config.schema.json');
+
+  if (!await exists(schemaPath)) return;
+  const validate = await loadValidator(schemaPath);
+
+  if (!validate(this.theme.config)) {
+    throw new TypeError(`Theme config validation failed using "${schemaPath}":\n${formatErrors(validate.errors)}`);
+  }
+}
+
+export = validateThemeConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -3530,9 +3530,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.6.tgz",
+      "integrity": "sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "abbrev": "^5.0.0",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "bluebird": "^3.7.2",
         "fast-archy": "^1.0.0",
         "fast-text-table": "^1.0.1",
@@ -1004,10 +1006,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
-      "dev": true,
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1018,6 +1019,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
       }
     },
     "node_modules/ansi-colors": {
@@ -3476,7 +3494,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-equals": {
@@ -3516,7 +3533,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5004,7 +5020,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -6852,7 +6867,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
   "license": "MIT",
   "dependencies": {
     "abbrev": "^5.0.0",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "bluebird": "^3.7.2",
     "fast-archy": "^1.0.0",
     "fast-text-table": "^1.0.1",

--- a/test/scripts/filters/validate_theme_config.ts
+++ b/test/scripts/filters/validate_theme_config.ts
@@ -1,0 +1,178 @@
+import { join, sep } from 'path';
+import BluebirdPromise from 'bluebird';
+import chai from 'chai';
+import { exists, mkdirs, rmdir, writeFile } from 'hexo-fs';
+import Hexo from '../../../lib/hexo';
+import validateThemeConfigFilter from '../../../lib/plugins/filter/before_generate/validate_theme_config';
+
+type ValidateThemeConfigFilterReturn = ReturnType<typeof validateThemeConfigFilter>;
+chai.should();
+
+describe('Validate theme config', () => {
+  const baseDir = join(__dirname, 'validate_theme_config_test');
+  const themeDir = join(baseDir, 'themes', 'test');
+  const schemaPath = join(themeDir, 'config.schema.json');
+  const hexo = new Hexo(baseDir, { silent: true });
+  const validateThemeConfig: () => BluebirdPromise<ValidateThemeConfigFilterReturn> = BluebirdPromise.method(validateThemeConfigFilter).bind(hexo);
+
+  hexo.theme_dir = themeDir + sep;
+
+  async function resetThemeDir() {
+    if (await exists(baseDir)) await rmdir(baseDir);
+    await mkdirs(themeDir);
+    hexo.theme.config = {};
+  }
+
+  function writeSchema(schema: any) {
+    return writeFile(schemaPath, JSON.stringify(schema));
+  }
+
+  async function getValidationError(): Promise<Error> {
+    try {
+      await validateThemeConfig();
+    } catch (error) {
+      return error as Error;
+    }
+
+    throw new Error('Expected theme config validation to fail');
+  }
+
+  beforeEach(resetThemeDir);
+
+  after(async () => {
+    if (await exists(baseDir)) await rmdir(baseDir);
+  });
+
+  it('does nothing when the theme has no config.schema.json', async () => {
+    await validateThemeConfig();
+  });
+
+  it('accepts a valid theme config', async () => {
+    hexo.theme.config = {
+      darkmode: true,
+      homepage: 'https://hexo.io/'
+    };
+
+    await writeSchema({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: {
+        darkmode: { type: 'boolean' },
+        homepage: { type: 'string', format: 'uri' }
+      },
+      required: ['darkmode', 'homepage']
+    });
+
+    await validateThemeConfig();
+  });
+
+  it('reports all validation errors without config values', async () => {
+    hexo.theme.config = {
+      darkmode: 'yes',
+      scheme: 'secret-value',
+      'unexpected/key': 'another-secret-value'
+    };
+
+    await writeSchema({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: {
+        darkmode: { type: 'boolean' },
+        scheme: { enum: ['Muse', 'Gemini'] },
+        requiredOption: { type: 'string' }
+      },
+      required: ['requiredOption'],
+      additionalProperties: false
+    });
+
+    const error = await getValidationError();
+
+    error.should.be.instanceOf(TypeError);
+    error.message.should.contain('/darkmode must be boolean');
+    error.message.should.contain('/scheme must be equal to one of the allowed values');
+    error.message.should.contain('/requiredOption must have required property');
+    error.message.should.contain('/unexpected~1key must NOT have additional properties');
+    error.message.should.not.contain('secret-value');
+    error.message.should.not.contain('another-secret-value');
+  });
+
+  it('validates the merged theme config during generation', async () => {
+    await Promise.all([
+      writeFile(join(baseDir, '_config.yml'), [
+        'url: https://hexo.io/',
+        'theme: test'
+      ].join('\n')),
+      writeFile(join(baseDir, '_config.test.yml'), 'darkmode: yes'),
+      writeFile(join(themeDir, '_config.yml'), 'darkmode: true'),
+      writeSchema({
+        $schema: 'https://json-schema.org/draft/2020-12/schema',
+        type: 'object',
+        properties: {
+          darkmode: { type: 'boolean' }
+        }
+      })
+    ]);
+
+    const siteHexo = new Hexo(baseDir, { silent: true });
+    siteHexo.env.init = true;
+    await siteHexo.init();
+
+    let error: Error | undefined;
+
+    try {
+      await siteHexo.load();
+    } catch (loadError) {
+      error = loadError as Error;
+    }
+
+    error.should.be.instanceOf(TypeError);
+    error.message.should.contain('/darkmode must be boolean');
+  });
+
+  it('reports malformed schema files', async () => {
+    await writeFile(schemaPath, '{');
+
+    const error = await getValidationError();
+
+    error.should.be.instanceOf(TypeError);
+    error.message.should.contain('Failed to read theme config schema');
+  });
+
+  it('reloads the validator when the schema changes', async () => {
+    hexo.theme.config = { darkmode: true };
+
+    await writeSchema({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: {
+        darkmode: { type: 'boolean' }
+      }
+    });
+
+    await validateThemeConfig();
+
+    await writeSchema({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      type: 'object',
+      properties: {
+        darkmode: { type: 'string' }
+      }
+    });
+
+    const error = await getValidationError();
+    error.message.should.contain('/darkmode must be string');
+  });
+
+  it('rejects asynchronous schemas', async () => {
+    await writeSchema({
+      $schema: 'https://json-schema.org/draft/2020-12/schema',
+      $async: true,
+      type: 'object'
+    });
+
+    const error = await getValidationError();
+
+    error.should.be.instanceOf(TypeError);
+    error.message.should.contain('asynchronous schemas are not supported');
+  });
+});


### PR DESCRIPTION
## What does it do?

Closes #4580.

This adds opt-in theme configuration validation to Hexo. A theme can provide a conventional `config.schema.json` file in its root; Hexo discovers it automatically without requiring a `package.json` declaration.

Before generators run, Hexo validates the fully merged theme configuration with JSON Schema 2020-12 and standard format support. Themes without the schema file keep the current behavior.

Validation is deliberately non-mutating: it does not coerce types, inject defaults, or remove unknown properties. It reports all detected paths in one error while avoiding configuration values in the message. Compiled validators are cached by schema path and content, so schema edits are picked up during watch mode.

Example failure:

```text
Theme config validation failed using "themes/next/config.schema.json":
  - /darkmode must be boolean
```

### Verification

- Added unit coverage for opt-in behavior, valid and invalid configurations, merged theme overrides, malformed and asynchronous schemas, and schema reloads.
- `npm run eslint`
- `npm run build`
- 49 focused filter and Hexo lifecycle tests
- End-to-end generation against NexT 8.29.0: 696 routes generated with the real configuration; an invalid `darkmode` override was rejected before public output was written.

## Screenshots

N/A — CLI-only behavior; representative output is included above.

## Pull request tasks

- [x] Add test cases for the changes.
- [x] Passed the CI test.
